### PR TITLE
Drop PHPDoc Blocks from Overridden Methods

### DIFF
--- a/src/Func/FuncEnvelope.php
+++ b/src/Func/FuncEnvelope.php
@@ -31,10 +31,6 @@ abstract readonly class FuncEnvelope implements Func
     {
     }
 
-    /**
-     * @param I $input
-     * @return O
-     */
     #[\Override]
     public function apply(mixed $input): mixed
     {

--- a/src/Func/FuncOf.php
+++ b/src/Func/FuncOf.php
@@ -28,10 +28,6 @@ final readonly class FuncOf implements Func
     {
     }
 
-    /**
-     * @param I $input
-     * @return O
-     */
     #[\Override]
     public function apply($input): mixed
     {

--- a/src/Iterable/Filtered.php
+++ b/src/Iterable/Filtered.php
@@ -43,10 +43,6 @@ final readonly class Filtered implements IteratorAggregate
     ) {
     }
 
-    /**
-     * @throws \Exception
-     * @return Iterator<mixed, T>
-     */
     #[\Override]
     public function getIterator(): Iterator
     {

--- a/src/Iterable/IterableOf.php
+++ b/src/Iterable/IterableOf.php
@@ -36,10 +36,6 @@ final readonly class IterableOf implements IteratorAggregate
     {
     }
 
-    /**
-     * @psalm-return Iterator<mixed, T>
-     * @phpstan-return Iterator<mixed, T>
-     */
     #[\Override]
     public function getIterator(): Iterator
     {

--- a/src/Iterable/Joined.php
+++ b/src/Iterable/Joined.php
@@ -23,9 +23,6 @@ final readonly class Joined implements IteratorAggregate
     ) {
     }
 
-    /**
-     * @return Iterator<int,T>
-     */
     #[\Override]
     public function getIterator(): Iterator
     {

--- a/src/Iterable/Mapped.php
+++ b/src/Iterable/Mapped.php
@@ -45,9 +45,6 @@ final readonly class Mapped implements IteratorAggregate
     ) {
     }
 
-    /**
-     * @return Iterator<int, Y>
-     */
     #[\Override]
     public function getIterator(): Iterator
     {

--- a/src/Iterable/NoNulls.php
+++ b/src/Iterable/NoNulls.php
@@ -29,9 +29,6 @@ final readonly class NoNulls implements IteratorAggregate
     ) {
     }
 
-    /**
-     * @return Iterator<int, T>
-     */
     #[\Override]
     public function getIterator(): Iterator
     {

--- a/src/Iterator/Mapped.php
+++ b/src/Iterator/Mapped.php
@@ -36,9 +36,6 @@ final class Mapped implements Iterator
         $this->origin->rewind();
     }
 
-    /**
-     * @return Y
-     */
     #[\Override]
     public function current(): mixed
     {

--- a/src/Iterator/NoNulls.php
+++ b/src/Iterator/NoNulls.php
@@ -41,9 +41,6 @@ final class NoNulls implements Iterator
         $this->origin->rewind();
     }
 
-    /**
-     * @return T
-     */
     #[\Override]
     public function current(): mixed
     {

--- a/src/Logic/Logic.php
+++ b/src/Logic/Logic.php
@@ -20,9 +20,6 @@ use Primus\Scalar\Scalar;
  */
 interface Logic extends Scalar
 {
-    /**
-     * Whether the condition is logically true.
-     */
     #[\Override]
     public function value(): bool;
 

--- a/src/Scalar/Constant.php
+++ b/src/Scalar/Constant.php
@@ -35,9 +35,6 @@ final readonly class Constant implements Scalar
     {
     }
 
-    /**
-     * @return T
-     */
     #[Override]
     public function value()
     {

--- a/src/Scalar/ScalarEnvelope.php
+++ b/src/Scalar/ScalarEnvelope.php
@@ -8,8 +8,6 @@ declare(strict_types=1);
 
 namespace Primus\Scalar;
 
-use Throwable;
-
 /**
  * Base class for scalar decorators.
  *
@@ -29,10 +27,6 @@ abstract readonly class ScalarEnvelope implements Scalar
     {
     }
 
-    /**
-     * @throws Throwable
-     * @return T
-     */
     #[\Override]
     final public function value()
     {

--- a/src/Scalar/ScalarOf.php
+++ b/src/Scalar/ScalarOf.php
@@ -37,9 +37,6 @@ final readonly class ScalarOf implements Scalar
     {
     }
 
-    /**
-     * @return T
-     */
     #[Override]
     public function value()
     {

--- a/src/Scalar/Sticky.php
+++ b/src/Scalar/Sticky.php
@@ -8,8 +8,6 @@ declare(strict_types=1);
 
 namespace Primus\Scalar;
 
-use Throwable;
-
 /**
  * Cached version of a {@see Scalar}.
  *
@@ -48,10 +46,6 @@ final class Sticky implements Scalar
     {
     }
 
-    /**
-     * @throws Throwable
-     * @return T
-     */
     #[\Override]
     public function value()
     {

--- a/src/Text/Split.php
+++ b/src/Text/Split.php
@@ -35,9 +35,6 @@ final readonly class Split implements Scalar
     ) {
     }
 
-    /**
-     * @return iterable<Text>
-     */
     #[\Override]
     public function value(): iterable
     {

--- a/src/Text/Text.php
+++ b/src/Text/Text.php
@@ -20,9 +20,6 @@ use Primus\Scalar\Scalar;
  */
 interface Text extends Scalar
 {
-    /**
-     * Returns the string value represented by this object.
-     */
     #[Override]
     public function value(): string;
 }

--- a/src/Text/TextOfScalar.php
+++ b/src/Text/TextOfScalar.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace Primus\Text;
 
 use Primus\Scalar\Scalar;
-use Throwable;
 
 /**
  * Text based on a scalar producing a string.
@@ -21,9 +20,6 @@ final readonly class TextOfScalar implements Text
     {
     }
 
-    /**
-     * @throws Throwable
-     */
     #[\Override]
     public function value(): string
     {


### PR DESCRIPTION
- Removed PHPDoc blocks from methods marked with #[\Override] to avoid doc duplication with parent declarations
- Removed now-unused Throwable imports from Scalar and Text classes

Part of #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal documentation and code cleanup. No changes to functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->