### PR TITLE
Document Constructors With Ctor. Summary

### DIFF
--- a/src/Logic/LogicEnvelope.php
+++ b/src/Logic/LogicEnvelope.php
@@ -16,6 +16,9 @@ use Primus\Text\Text;
  */
 abstract readonly class LogicEnvelope implements Logic
 {
+    /**
+     * Ctor.
+     */
     public function __construct(protected Text $text)
     {
     }

--- a/src/Logic/LogicEnvelope.php
+++ b/src/Logic/LogicEnvelope.php
@@ -18,6 +18,8 @@ abstract readonly class LogicEnvelope implements Logic
 {
     /**
      * Ctor.
+     *
+     * @param Text $text The text to evaluate.
      */
     public function __construct(protected Text $text)
     {

--- a/src/Text/Abbreviated.php
+++ b/src/Text/Abbreviated.php
@@ -24,6 +24,9 @@ final readonly class Abbreviated extends TextEnvelope
 {
     /**
      * Ctor.
+     *
+     * @param Text $origin The text to abbreviate.
+     * @param int $limit The maximum length of the result.
      */
     public function __construct(Text $origin, int $limit = 50)
     {

--- a/src/Text/Abbreviated.php
+++ b/src/Text/Abbreviated.php
@@ -22,6 +22,9 @@ namespace Primus\Text;
  */
 final readonly class Abbreviated extends TextEnvelope
 {
+    /**
+     * Ctor.
+     */
     public function __construct(Text $origin, int $limit = 50)
     {
         if ($limit <= 0) {

--- a/src/Text/Capitalized.php
+++ b/src/Text/Capitalized.php
@@ -22,6 +22,9 @@ namespace Primus\Text;
  */
 final readonly class Capitalized extends TextEnvelope
 {
+    /**
+     * Ctor.
+     */
     public function __construct(Text $origin)
     {
         $value = $origin->value();

--- a/src/Text/Capitalized.php
+++ b/src/Text/Capitalized.php
@@ -24,6 +24,8 @@ final readonly class Capitalized extends TextEnvelope
 {
     /**
      * Ctor.
+     *
+     * @param Text $origin The text to capitalize.
      */
     public function __construct(Text $origin)
     {

--- a/src/Text/HtmlEscaped.php
+++ b/src/Text/HtmlEscaped.php
@@ -19,6 +19,9 @@ namespace Primus\Text;
  */
 final readonly class HtmlEscaped extends TextEnvelope
 {
+    /**
+     * Ctor.
+     */
     public function __construct(Text $origin)
     {
         parent::__construct(

--- a/src/Text/HtmlEscaped.php
+++ b/src/Text/HtmlEscaped.php
@@ -21,6 +21,8 @@ final readonly class HtmlEscaped extends TextEnvelope
 {
     /**
      * Ctor.
+     *
+     * @param Text $origin The text to escape.
      */
     public function __construct(Text $origin)
     {

--- a/src/Text/LeftPadded.php
+++ b/src/Text/LeftPadded.php
@@ -24,6 +24,10 @@ final readonly class LeftPadded extends TextEnvelope
 {
     /**
      * Ctor.
+     *
+     * @param Text $origin The text to pad.
+     * @param int $length The desired total length after padding.
+     * @param string $padChar The character to use for padding.
      */
     public function __construct(
         Text $origin,

--- a/src/Text/LeftPadded.php
+++ b/src/Text/LeftPadded.php
@@ -22,6 +22,9 @@ namespace Primus\Text;
  */
 final readonly class LeftPadded extends TextEnvelope
 {
+    /**
+     * Ctor.
+     */
     public function __construct(
         Text $origin,
         int $length,

--- a/src/Text/LengthOfText.php
+++ b/src/Text/LengthOfText.php
@@ -25,6 +25,8 @@ final readonly class LengthOfText extends ScalarEnvelope
 {
     /**
      * Ctor.
+     *
+     * @param Text $origin The text to measure.
      */
     public function __construct(Text $origin)
     {

--- a/src/Text/LengthOfText.php
+++ b/src/Text/LengthOfText.php
@@ -23,6 +23,9 @@ use Primus\Scalar\ScalarOf;
  */
 final readonly class LengthOfText extends ScalarEnvelope
 {
+    /**
+     * Ctor.
+     */
     public function __construct(Text $origin)
     {
         /** @var ScalarOf<int> $scalar */

--- a/src/Text/Lowered.php
+++ b/src/Text/Lowered.php
@@ -23,6 +23,8 @@ final readonly class Lowered extends TextEnvelope
 {
     /**
      * Ctor.
+     *
+     * @param Text $origin The text to lowercase.
      */
     public function __construct(Text $origin)
     {

--- a/src/Text/Lowered.php
+++ b/src/Text/Lowered.php
@@ -21,6 +21,9 @@ namespace Primus\Text;
  */
 final readonly class Lowered extends TextEnvelope
 {
+    /**
+     * Ctor.
+     */
     public function __construct(Text $origin)
     {
         parent::__construct(

--- a/src/Text/Normalized.php
+++ b/src/Text/Normalized.php
@@ -27,6 +27,8 @@ final readonly class Normalized extends TextEnvelope
 {
     /**
      * Ctor.
+     *
+     * @param Text $origin The text to normalize.
      */
     public function __construct(Text $origin)
     {

--- a/src/Text/Normalized.php
+++ b/src/Text/Normalized.php
@@ -25,6 +25,9 @@ use Primus\Scalar\ScalarOf;
  */
 final readonly class Normalized extends TextEnvelope
 {
+    /**
+     * Ctor.
+     */
     public function __construct(Text $origin)
     {
         parent::__construct(

--- a/src/Text/RandomText.php
+++ b/src/Text/RandomText.php
@@ -24,6 +24,9 @@ use Primus\Scalar\ScalarOf;
  */
 final readonly class RandomText extends TextEnvelope
 {
+    /**
+     * Ctor.
+     */
     public function __construct(int $length, string $alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789')
     {
         $scalar = new ScalarOf(

--- a/src/Text/RandomText.php
+++ b/src/Text/RandomText.php
@@ -26,6 +26,9 @@ final readonly class RandomText extends TextEnvelope
 {
     /**
      * Ctor.
+     *
+     * @param int $length The length of the generated text.
+     * @param string $alphabet The characters to pick from.
      */
     public function __construct(int $length, string $alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789')
     {

--- a/src/Text/Repeated.php
+++ b/src/Text/Repeated.php
@@ -19,6 +19,9 @@ namespace Primus\Text;
  */
 final readonly class Repeated extends TextEnvelope
 {
+    /**
+     * Ctor.
+     */
     public function __construct(Text $origin, int $count)
     {
         parent::__construct(

--- a/src/Text/Repeated.php
+++ b/src/Text/Repeated.php
@@ -21,6 +21,9 @@ final readonly class Repeated extends TextEnvelope
 {
     /**
      * Ctor.
+     *
+     * @param Text $origin The text to repeat.
+     * @param int $count The number of repetitions.
      */
     public function __construct(Text $origin, int $count)
     {

--- a/src/Text/RightPadded.php
+++ b/src/Text/RightPadded.php
@@ -21,6 +21,9 @@ namespace Primus\Text;
  */
 final readonly class RightPadded extends TextEnvelope
 {
+    /**
+     * Ctor.
+     */
     public function __construct(
         Text $origin,
         int $length,

--- a/src/Text/RightPadded.php
+++ b/src/Text/RightPadded.php
@@ -23,6 +23,10 @@ final readonly class RightPadded extends TextEnvelope
 {
     /**
      * Ctor.
+     *
+     * @param Text $origin The text to pad.
+     * @param int $length The desired total length after padding.
+     * @param string $padChar The character to use for padding.
      */
     public function __construct(
         Text $origin,

--- a/src/Text/Sub.php
+++ b/src/Text/Sub.php
@@ -24,6 +24,10 @@ final readonly class Sub extends TextEnvelope
 {
     /**
      * Ctor.
+     *
+     * @param Text $text The text to extract from.
+     * @param int $start The start position in characters.
+     * @param int $length The maximum number of characters to extract.
      */
     public function __construct(Text $text, int $start, int $length = PHP_INT_MAX)
     {

--- a/src/Text/Sub.php
+++ b/src/Text/Sub.php
@@ -22,6 +22,9 @@ namespace Primus\Text;
  */
 final readonly class Sub extends TextEnvelope
 {
+    /**
+     * Ctor.
+     */
     public function __construct(Text $text, int $start, int $length = PHP_INT_MAX)
     {
         parent::__construct(

--- a/src/Text/TextEnvelope.php
+++ b/src/Text/TextEnvelope.php
@@ -18,6 +18,8 @@ abstract readonly class TextEnvelope implements Text
 {
     /**
      * Ctor.
+     *
+     * @param Text $origin The text to delegate to.
      */
     public function __construct(protected Text $origin)
     {

--- a/src/Text/TextEnvelope.php
+++ b/src/Text/TextEnvelope.php
@@ -16,6 +16,9 @@ use Override;
  */
 abstract readonly class TextEnvelope implements Text
 {
+    /**
+     * Ctor.
+     */
     public function __construct(protected Text $origin)
     {
     }

--- a/src/Text/TextOf.php
+++ b/src/Text/TextOf.php
@@ -17,6 +17,8 @@ final readonly class TextOf implements Text
 {
     /**
      * Ctor.
+     *
+     * @param string $value The string to wrap.
      */
     public function __construct(private string $value)
     {

--- a/src/Text/TextOf.php
+++ b/src/Text/TextOf.php
@@ -15,6 +15,9 @@ use Override;
  */
 final readonly class TextOf implements Text
 {
+    /**
+     * Ctor.
+     */
     public function __construct(private string $value)
     {
     }

--- a/src/Text/Trimmed.php
+++ b/src/Text/Trimmed.php
@@ -21,6 +21,9 @@ namespace Primus\Text;
  */
 final readonly class Trimmed extends TextEnvelope
 {
+    /**
+     * Ctor.
+     */
     public function __construct(Text $origin)
     {
         parent::__construct(

--- a/src/Text/Trimmed.php
+++ b/src/Text/Trimmed.php
@@ -23,6 +23,8 @@ final readonly class Trimmed extends TextEnvelope
 {
     /**
      * Ctor.
+     *
+     * @param Text $origin The text to trim.
      */
     public function __construct(Text $origin)
     {

--- a/src/Text/TrimmedLeft.php
+++ b/src/Text/TrimmedLeft.php
@@ -21,6 +21,8 @@ final readonly class TrimmedLeft extends TextEnvelope
 {
     /**
      * Ctor.
+     *
+     * @param Text $origin The text to trim on the left.
      */
     public function __construct(Text $origin)
     {

--- a/src/Text/TrimmedLeft.php
+++ b/src/Text/TrimmedLeft.php
@@ -19,6 +19,9 @@ namespace Primus\Text;
  */
 final readonly class TrimmedLeft extends TextEnvelope
 {
+    /**
+     * Ctor.
+     */
     public function __construct(Text $origin)
     {
         parent::__construct(

--- a/src/Text/TrimmedRight.php
+++ b/src/Text/TrimmedRight.php
@@ -22,6 +22,9 @@ use Primus\Scalar\ScalarOf;
  */
 final readonly class TrimmedRight extends TextEnvelope
 {
+    /**
+     * Ctor.
+     */
     public function __construct(Text $origin)
     {
         parent::__construct(

--- a/src/Text/TrimmedRight.php
+++ b/src/Text/TrimmedRight.php
@@ -24,6 +24,8 @@ final readonly class TrimmedRight extends TextEnvelope
 {
     /**
      * Ctor.
+     *
+     * @param Text $origin The text to trim on the right.
      */
     public function __construct(Text $origin)
     {

--- a/src/Text/Uppered.php
+++ b/src/Text/Uppered.php
@@ -22,6 +22,8 @@ final readonly class Uppered extends TextEnvelope
 {
     /**
      * Ctor.
+     *
+     * @param Text $origin The text to uppercase.
      */
     public function __construct(Text $origin)
     {

--- a/src/Text/Uppered.php
+++ b/src/Text/Uppered.php
@@ -20,6 +20,9 @@ namespace Primus\Text;
  */
 final readonly class Uppered extends TextEnvelope
 {
+    /**
+     * Ctor.
+     */
     public function __construct(Text $origin)
     {
         parent::__construct(

--- a/src/Text/WithoutTags.php
+++ b/src/Text/WithoutTags.php
@@ -20,6 +20,9 @@ namespace Primus\Text;
  */
 final readonly class WithoutTags extends TextEnvelope
 {
+    /**
+     * Ctor.
+     */
     public function __construct(Text $origin)
     {
         parent::__construct(

--- a/src/Text/WithoutTags.php
+++ b/src/Text/WithoutTags.php
@@ -22,6 +22,8 @@ final readonly class WithoutTags extends TextEnvelope
 {
     /**
      * Ctor.
+     *
+     * @param Text $origin The text to strip HTML tags from.
      */
     public function __construct(Text $origin)
     {


### PR DESCRIPTION
- Added minimal Ctor. PHPDoc summary to 19 constructors to satisfy haspadar.phpdocMissingMethod rule

Part of #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added constructor documentation across numerous text-related components and logic envelope to improve code clarity and developer experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->