### PR TITLE
Start PHPDoc Summaries With Plain Class Name

### DIFF
--- a/src/Func/FuncWithFallback.php
+++ b/src/Func/FuncWithFallback.php
@@ -7,7 +7,7 @@ namespace Primus\Func;
 use Exception;
 
 /**
- * {@see Func} with fallback.
+ * Func with fallback.
  *
  * @template I
  * @template O

--- a/src/Func/Repeated.php
+++ b/src/Func/Repeated.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Primus\Func;
 
 /**
- * {@see Func} applied multiple times sequentially.
+ * Func applied multiple times sequentially.
  *
  * Example:
  *     $func = new Repeated(

--- a/src/Iterable/Filtered.php
+++ b/src/Iterable/Filtered.php
@@ -13,8 +13,7 @@ use IteratorAggregate;
 use Primus\Func\Predicate;
 
 /**
- * Iterable that lazily filters values from another iterable
- * using the provided predicate.
+ * Iterable that lazily filters values from another iterable using the provided predicate.
  *
  * Example:
  *     $it = new Filtered(

--- a/src/Iterable/Mapped.php
+++ b/src/Iterable/Mapped.php
@@ -13,8 +13,7 @@ use IteratorAggregate;
 use Primus\Func\Func;
 
 /**
- * Iterable that lazily transforms each element
- * of the origin iterable using the provided function.
+ * Iterable that lazily transforms each element of the origin iterable using the provided function.
  *
  * Example:
  *     $it = new Mapped(

--- a/src/Logic/IsAlphanumeric.php
+++ b/src/Logic/IsAlphanumeric.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Primus\Logic;
 
 /**
- * {@see Logic} that returns true if text contains only alphanumeric characters (A–Z, a–z, 0–9).
+ * Logic that returns true if text contains only alphanumeric characters (A–Z, a–z, 0–9).
  *
  * Example:
  *     new IsAlphanumeric(new TextOf("abc123")) → true

--- a/src/Logic/IsEmail.php
+++ b/src/Logic/IsEmail.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Primus\Logic;
 
 /**
- * {@see Logic} that returns true if the text is a valid email.
+ * Logic that returns true if the text is a valid email.
  *
  */
 final readonly class IsEmail extends LogicEnvelope

--- a/src/Logic/IsEmpty.php
+++ b/src/Logic/IsEmpty.php
@@ -11,7 +11,7 @@ namespace Primus\Logic;
 use Primus\Text\Trimmed;
 
 /**
- * {@see Logic} that returns true if the text is empty or whitespace-only.
+ * Logic that returns true if the text is empty or whitespace-only.
  *
  */
 final readonly class IsEmpty extends LogicEnvelope

--- a/src/Logic/IsNumeric.php
+++ b/src/Logic/IsNumeric.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Primus\Logic;
 
 /**
- * {@see Logic} that returns true if text represents a valid numeric value.
+ * Logic that returns true if text represents a valid numeric value.
  *
  * Uses PHP's {@see is_numeric()} to determine if the string is a number.
  *

--- a/src/Logic/IsUrl.php
+++ b/src/Logic/IsUrl.php
@@ -11,7 +11,7 @@ namespace Primus\Logic;
 use Primus\Text\Text;
 
 /**
- * {@see Logic} that returns true if a {@see Text} is a valid URL.
+ * Logic that returns true if a {@see Text} is a valid URL.
  *
  * Example:
  *     new IsUrl(new TextOf("https://example.com")) → true

--- a/src/Logic/IsUuid.php
+++ b/src/Logic/IsUuid.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Primus\Logic;
 
 /**
- * {@see Logic} that returns true if the text is a valid UUID v1–v5.
+ * Logic that returns true if the text is a valid UUID v1–v5.
  *
  * Matches 8-4-4-4-12 pattern with correct version and variant bits.
  *

--- a/src/Logic/No.php
+++ b/src/Logic/No.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Primus\Logic;
 
 /**
- * {@see Logic} that always returns false.
+ * Logic that always returns false.
  *
  * Useful in testing or as a default negative condition.
  *

--- a/src/Logic/Yes.php
+++ b/src/Logic/Yes.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Primus\Logic;
 
 /**
- * {@see Logic} that always returns true.
+ * Logic that always returns true.
  *
  * Useful in testing or as a default condition.
  *

--- a/src/Text/Capitalized.php
+++ b/src/Text/Capitalized.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Primus\Text;
 
 /**
- * {@see Text} with the first character capitalized.
+ * Text with the first character capitalized.
  *
  * Converts only the first character to uppercase
  * and leaves the rest of the text unchanged.

--- a/src/Text/Joined.php
+++ b/src/Text/Joined.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Primus\Text;
 
 /**
- * Text joined from multiple {@see Text} parts with a separator.
+ * Text joined from multiple Text parts with a separator.
  *
  * Example:
  *     $text = new Joined(', ', [new TextOf('a'), new TextOf('b'), new TextOf('c')]);

--- a/src/Text/Joined.php
+++ b/src/Text/Joined.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Primus\Text;
 
 /**
- * {@see Text} joined from multiple {@see Text} parts with a separator.
+ * Text joined from multiple {@see Text} parts with a separator.
  *
  * Example:
  *     $text = new Joined(', ', [new TextOf('a'), new TextOf('b'), new TextOf('c')]);

--- a/src/Text/LeftPadded.php
+++ b/src/Text/LeftPadded.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Primus\Text;
 
 /**
- * {@see Text} with left padding.
+ * Text with left padding.
  *
  * Pads the text on the left to the specified length
  * with the given character using {@see str_pad()}.

--- a/src/Text/Lowered.php
+++ b/src/Text/Lowered.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Primus\Text;
 
 /**
- * {@see Text} in lowercase.
+ * Text in lowercase.
  *
  * Converts the given text to lowercase using multibyte support.
  *

--- a/src/Text/Normalized.php
+++ b/src/Text/Normalized.php
@@ -12,7 +12,7 @@ use InvalidArgumentException;
 use Primus\Scalar\ScalarOf;
 
 /**
- * {@see Text} with normalized whitespace.
+ * Text with normalized whitespace.
  *
  * Replaces multiple spaces, tabs, and newlines
  * with a single space and trims leading/trailing whitespace.

--- a/src/Text/Repeated.php
+++ b/src/Text/Repeated.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Primus\Text;
 
 /**
- * {@see Text} repeated multiple times.
+ * Text repeated multiple times.
  *
  * Example:
  *     $text = new Repeated(new TextOf('xo'), 3);

--- a/src/Text/Replaced.php
+++ b/src/Text/Replaced.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Primus\Text;
 
 /**
- * {@see Text} with replaced substrings.
+ * Text with replaced substrings.
  *
  * Replaces one or multiple search strings with replacements.
  *

--- a/src/Text/RightPadded.php
+++ b/src/Text/RightPadded.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Primus\Text;
 
 /**
- * {@see Text} with right padding.
+ * Text with right padding.
  *
  * Pads the text to the specified length with the given character using {@see str_pad()}.
  *

--- a/src/Text/Split.php
+++ b/src/Text/Split.php
@@ -11,7 +11,7 @@ namespace Primus\Text;
 use Primus\Scalar\Scalar;
 
 /**
- * {@see Text} split by a delimiter into parts.
+ * Text split by a delimiter into parts.
  *
  * Produces an iterable of {@see Text} segments separated by the given delimiter.
  *

--- a/src/Text/Trimmed.php
+++ b/src/Text/Trimmed.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Primus\Text;
 
 /**
- * {@see Text} without leading or trailing whitespace.
+ * Text without leading or trailing whitespace.
  *
  * Applies {@see trim()} to the original text.
  *

--- a/src/Text/TrimmedLeft.php
+++ b/src/Text/TrimmedLeft.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Primus\Text;
 
 /**
- * {@see Text} with whitespace removed from the left side.
+ * Text with whitespace removed from the left side.
  *
  * Example:
  *     $text = new TrimmedLeft(new TextOf("   hello "));

--- a/src/Text/TrimmedRight.php
+++ b/src/Text/TrimmedRight.php
@@ -12,7 +12,7 @@ use InvalidArgumentException;
 use Primus\Scalar\ScalarOf;
 
 /**
- * {@see Text} with whitespace removed from the right side.
+ * Text with whitespace removed from the right side.
  *
  * Example:
  *     $text = new TrimmedRight(new TextOf(" hello   "));

--- a/src/Text/Uppered.php
+++ b/src/Text/Uppered.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Primus\Text;
 
 /**
- * {@see Text} in uppercase.
+ * Text in uppercase.
  *
  * Converts the given text to uppercase using multibyte support.
  *

--- a/src/Text/WithoutTags.php
+++ b/src/Text/WithoutTags.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Primus\Text;
 
 /**
- * {@see Text} without HTML tags.
+ * Text without HTML tags.
  *
  * Strips all HTML tags from the origin text using {@see strip_tags()}.
  *


### PR DESCRIPTION
- Removed leading {@see ClassName} inline tag from class-level PHPDoc summaries so they start with a capital letter
- Collapsed two-line summaries in Iterable/Filtered and Iterable/Mapped into a single line so the ending period sits in the summary

Part of #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized and simplified class/docblock descriptions across many modules by converting reference-style tags to plain text and collapsing/clarifying multi-line descriptions for improved readability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->