### PR TITLE
Remove SPDX Headers From Source Files

### DIFF
--- a/src/Func/BiFunc.php
+++ b/src/Func/BiFunc.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Func;

--- a/src/Func/BiFuncOf.php
+++ b/src/Func/BiFuncOf.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Func;

--- a/src/Func/BiProc.php
+++ b/src/Func/BiProc.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Func;

--- a/src/Func/BiProcOf.php
+++ b/src/Func/BiProcOf.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Func;

--- a/src/Func/Func.php
+++ b/src/Func/Func.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Func;

--- a/src/Func/FuncEnvelope.php
+++ b/src/Func/FuncEnvelope.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Func;

--- a/src/Func/FuncOf.php
+++ b/src/Func/FuncOf.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Func;

--- a/src/Func/Predicate.php
+++ b/src/Func/Predicate.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Func;

--- a/src/Func/PredicateOf.php
+++ b/src/Func/PredicateOf.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Func;

--- a/src/Func/Proc.php
+++ b/src/Func/Proc.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Func;

--- a/src/Func/ProcOf.php
+++ b/src/Func/ProcOf.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Func;

--- a/src/Iterable/Filtered.php
+++ b/src/Iterable/Filtered.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Iterable;

--- a/src/Iterable/IterableOf.php
+++ b/src/Iterable/IterableOf.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Iterable;

--- a/src/Iterable/Mapped.php
+++ b/src/Iterable/Mapped.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Iterable;

--- a/src/Iterable/NoNulls.php
+++ b/src/Iterable/NoNulls.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Iterable;

--- a/src/Iterator/IteratorOf.php
+++ b/src/Iterator/IteratorOf.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Iterator;

--- a/src/Iterator/NoNulls.php
+++ b/src/Iterator/NoNulls.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Iterator;

--- a/src/Logic/IsAlphanumeric.php
+++ b/src/Logic/IsAlphanumeric.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Logic;

--- a/src/Logic/IsEmail.php
+++ b/src/Logic/IsEmail.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Logic;

--- a/src/Logic/IsEmpty.php
+++ b/src/Logic/IsEmpty.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Logic;

--- a/src/Logic/IsNumeric.php
+++ b/src/Logic/IsNumeric.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Logic;

--- a/src/Logic/IsUrl.php
+++ b/src/Logic/IsUrl.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Logic;

--- a/src/Logic/IsUuid.php
+++ b/src/Logic/IsUuid.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Logic;

--- a/src/Logic/Logic.php
+++ b/src/Logic/Logic.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Logic;

--- a/src/Logic/LogicEnvelope.php
+++ b/src/Logic/LogicEnvelope.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Logic;

--- a/src/Logic/No.php
+++ b/src/Logic/No.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Logic;

--- a/src/Logic/Yes.php
+++ b/src/Logic/Yes.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Logic;

--- a/src/Numeric/Number.php
+++ b/src/Numeric/Number.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Numeric;

--- a/src/Scalar/AndOf.php
+++ b/src/Scalar/AndOf.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Scalar;

--- a/src/Scalar/Between.php
+++ b/src/Scalar/Between.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Scalar;

--- a/src/Scalar/Constant.php
+++ b/src/Scalar/Constant.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Scalar;

--- a/src/Scalar/EqualTo.php
+++ b/src/Scalar/EqualTo.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Scalar;

--- a/src/Scalar/GreaterThan.php
+++ b/src/Scalar/GreaterThan.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Scalar;

--- a/src/Scalar/LessThan.php
+++ b/src/Scalar/LessThan.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Scalar;

--- a/src/Scalar/Not.php
+++ b/src/Scalar/Not.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Scalar;

--- a/src/Scalar/OrOf.php
+++ b/src/Scalar/OrOf.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Scalar;

--- a/src/Scalar/Scalar.php
+++ b/src/Scalar/Scalar.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Scalar;

--- a/src/Scalar/ScalarEnvelope.php
+++ b/src/Scalar/ScalarEnvelope.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Scalar;

--- a/src/Scalar/ScalarOf.php
+++ b/src/Scalar/ScalarOf.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Scalar;

--- a/src/Scalar/Sticky.php
+++ b/src/Scalar/Sticky.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Scalar;

--- a/src/Scalar/Ternary.php
+++ b/src/Scalar/Ternary.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Scalar;

--- a/src/Scalar/XorOf.php
+++ b/src/Scalar/XorOf.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Scalar;

--- a/src/Text/Abbreviated.php
+++ b/src/Text/Abbreviated.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/Capitalized.php
+++ b/src/Text/Capitalized.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/HtmlEscaped.php
+++ b/src/Text/HtmlEscaped.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/Joined.php
+++ b/src/Text/Joined.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/LeftPadded.php
+++ b/src/Text/LeftPadded.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/LengthOfText.php
+++ b/src/Text/LengthOfText.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/Lowered.php
+++ b/src/Text/Lowered.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/Normalized.php
+++ b/src/Text/Normalized.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/RandomText.php
+++ b/src/Text/RandomText.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/Repeated.php
+++ b/src/Text/Repeated.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/Replaced.php
+++ b/src/Text/Replaced.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/RightPadded.php
+++ b/src/Text/RightPadded.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/Split.php
+++ b/src/Text/Split.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/Sub.php
+++ b/src/Text/Sub.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/Text.php
+++ b/src/Text/Text.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/TextEnvelope.php
+++ b/src/Text/TextEnvelope.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/TextOf.php
+++ b/src/Text/TextOf.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/TextOfScalar.php
+++ b/src/Text/TextOfScalar.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/Trimmed.php
+++ b/src/Text/Trimmed.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/TrimmedLeft.php
+++ b/src/Text/TrimmedLeft.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/TrimmedRight.php
+++ b/src/Text/TrimmedRight.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/Uppered.php
+++ b/src/Text/Uppered.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/src/Text/WithoutTags.php
+++ b/src/Text/WithoutTags.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Text;

--- a/tests/Constraint/AppliesBiFuncTo.php
+++ b/tests/Constraint/AppliesBiFuncTo.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Constraint;

--- a/tests/Constraint/AppliesFuncTo.php
+++ b/tests/Constraint/AppliesFuncTo.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Constraint;

--- a/tests/Constraint/EqualsValue.php
+++ b/tests/Constraint/EqualsValue.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Constraint;

--- a/tests/Constraint/ExecBiProcTo.php
+++ b/tests/Constraint/ExecBiProcTo.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Constraint;

--- a/tests/Constraint/HasCallCount.php
+++ b/tests/Constraint/HasCallCount.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Constraint;

--- a/tests/Constraint/HasIteratorValues.php
+++ b/tests/Constraint/HasIteratorValues.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Constraint;

--- a/tests/Constraint/HasKey.php
+++ b/tests/Constraint/HasKey.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Constraint;

--- a/tests/Constraint/HasKeyValuePairs.php
+++ b/tests/Constraint/HasKeyValuePairs.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Constraint;

--- a/tests/Constraint/HasScalarBoolValue.php
+++ b/tests/Constraint/HasScalarBoolValue.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Constraint;

--- a/tests/Constraint/HasScalarValue.php
+++ b/tests/Constraint/HasScalarValue.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Constraint;

--- a/tests/Constraint/HasScalarValues.php
+++ b/tests/Constraint/HasScalarValues.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Constraint;

--- a/tests/Constraint/HasSize.php
+++ b/tests/Constraint/HasSize.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Constraint;

--- a/tests/Constraint/HasTextValue.php
+++ b/tests/Constraint/HasTextValue.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Constraint;

--- a/tests/Constraint/HasTextValues.php
+++ b/tests/Constraint/HasTextValues.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Constraint;

--- a/tests/Constraint/MatchesPattern.php
+++ b/tests/Constraint/MatchesPattern.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Constraint;

--- a/tests/Constraint/ThrowsClosure.php
+++ b/tests/Constraint/ThrowsClosure.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Constraint;

--- a/tests/Constraint/ThrowsValue.php
+++ b/tests/Constraint/ThrowsValue.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Constraint;

--- a/tests/CountCalls.php
+++ b/tests/CountCalls.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests;

--- a/tests/Func/BiFuncOfTest.php
+++ b/tests/Func/BiFuncOfTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Func;

--- a/tests/Func/BiProcOfTest.php
+++ b/tests/Func/BiProcOfTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Func;

--- a/tests/Func/FuncOfTest.php
+++ b/tests/Func/FuncOfTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Func;

--- a/tests/Func/FuncWithFallbackTest.php
+++ b/tests/Func/FuncWithFallbackTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Func;

--- a/tests/Func/PredicateOfTest.php
+++ b/tests/Func/PredicateOfTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Func;

--- a/tests/Func/ProcOfTest.php
+++ b/tests/Func/ProcOfTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Func;

--- a/tests/Func/RepeatedTest.php
+++ b/tests/Func/RepeatedTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Func;

--- a/tests/Func/StickyFuncTest.php
+++ b/tests/Func/StickyFuncTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Func;

--- a/tests/Iterable/FilteredTest.php
+++ b/tests/Iterable/FilteredTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Iterable;

--- a/tests/Iterable/IterableOfTest.php
+++ b/tests/Iterable/IterableOfTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Iterable;

--- a/tests/Iterable/JoinedTest.php
+++ b/tests/Iterable/JoinedTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Iterable;

--- a/tests/Iterable/MappedTest.php
+++ b/tests/Iterable/MappedTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Iterable;

--- a/tests/Iterable/NoNullsTest.php
+++ b/tests/Iterable/NoNullsTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Iterable;

--- a/tests/Iterator/FilteredTest.php
+++ b/tests/Iterator/FilteredTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Iterator;

--- a/tests/Iterator/IteratorOfTest.php
+++ b/tests/Iterator/IteratorOfTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Iterator;

--- a/tests/Iterator/JoinedTest.php
+++ b/tests/Iterator/JoinedTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Iterator;

--- a/tests/Iterator/MappedTest.php
+++ b/tests/Iterator/MappedTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Iterator;

--- a/tests/Iterator/NoNullsTest.php
+++ b/tests/Iterator/NoNullsTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Iterator;

--- a/tests/Logic/IsNumericTest.php
+++ b/tests/Logic/IsNumericTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Logic;

--- a/tests/Logic/IsUrlTest.php
+++ b/tests/Logic/IsUrlTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Logic;

--- a/tests/Logic/NoTest.php
+++ b/tests/Logic/NoTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Logic;

--- a/tests/Logic/YesTest.php
+++ b/tests/Logic/YesTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Logic;

--- a/tests/Scalar/AndOfTest.php
+++ b/tests/Scalar/AndOfTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Scalar;

--- a/tests/Scalar/BetweenTest.php
+++ b/tests/Scalar/BetweenTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Scalar;

--- a/tests/Scalar/ConstantTest.php
+++ b/tests/Scalar/ConstantTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Scalar;

--- a/tests/Scalar/EqualToTest.php
+++ b/tests/Scalar/EqualToTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Scalar;

--- a/tests/Scalar/GreaterThanTest.php
+++ b/tests/Scalar/GreaterThanTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Scalar;

--- a/tests/Scalar/LessThanTest.php
+++ b/tests/Scalar/LessThanTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Scalar;

--- a/tests/Scalar/NotTest.php
+++ b/tests/Scalar/NotTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Scalar;

--- a/tests/Scalar/OrOfTest.php
+++ b/tests/Scalar/OrOfTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Scalar;

--- a/tests/Scalar/ScalarOfTest.php
+++ b/tests/Scalar/ScalarOfTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Scalar;

--- a/tests/Scalar/StickyTest.php
+++ b/tests/Scalar/StickyTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Scalar;

--- a/tests/Scalar/TernaryTest.php
+++ b/tests/Scalar/TernaryTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Scalar;

--- a/tests/Scalar/XorOfTest.php
+++ b/tests/Scalar/XorOfTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Scalar;

--- a/tests/Text/AbbreviatedTest.php
+++ b/tests/Text/AbbreviatedTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Text;

--- a/tests/Text/CapitalizedTest.php
+++ b/tests/Text/CapitalizedTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Text;

--- a/tests/Text/HtmlEscapedTest.php
+++ b/tests/Text/HtmlEscapedTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Text;

--- a/tests/Text/JoinedTest.php
+++ b/tests/Text/JoinedTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Text;

--- a/tests/Text/LeftPaddedTest.php
+++ b/tests/Text/LeftPaddedTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Text;

--- a/tests/Text/LengthOfTextTest.php
+++ b/tests/Text/LengthOfTextTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Text;

--- a/tests/Text/LoweredTest.php
+++ b/tests/Text/LoweredTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Text;

--- a/tests/Text/NormalizedTest.php
+++ b/tests/Text/NormalizedTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Text;

--- a/tests/Text/RandomTextTest.php
+++ b/tests/Text/RandomTextTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Text;

--- a/tests/Text/RepeatedTest.php
+++ b/tests/Text/RepeatedTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Text;

--- a/tests/Text/ReplacedTest.php
+++ b/tests/Text/ReplacedTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Text;

--- a/tests/Text/RightPaddedTest.php
+++ b/tests/Text/RightPaddedTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Text;

--- a/tests/Text/SplitTest.php
+++ b/tests/Text/SplitTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Text;

--- a/tests/Text/SubTest.php
+++ b/tests/Text/SubTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Text;

--- a/tests/Text/TextOfScalarTest.php
+++ b/tests/Text/TextOfScalarTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Text;

--- a/tests/Text/TextOfTest.php
+++ b/tests/Text/TextOfTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Text;

--- a/tests/Text/TrimmedLeftTest.php
+++ b/tests/Text/TrimmedLeftTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Text;

--- a/tests/Text/TrimmedRightTest.php
+++ b/tests/Text/TrimmedRightTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Text;

--- a/tests/Text/TrimmedTest.php
+++ b/tests/Text/TrimmedTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Text;

--- a/tests/Text/UpperedTest.php
+++ b/tests/Text/UpperedTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Text;

--- a/tests/Text/WithoutTagsTest.php
+++ b/tests/Text/WithoutTagsTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/*
- * SPDX-FileCopyrightText: Copyright (c) 2025 Kanstantsin Mesnik
- * SPDX-License-Identifier: MIT
- */
 declare(strict_types=1);
 
 namespace Primus\Tests\Text;


### PR DESCRIPTION
- Removed SPDX-FileCopyrightText and SPDX-License-Identifier blocks from 138 PHP files in src/ and tests/
- Attribution now lives solely in the root LICENSE and composer.json MIT metadata

Part of #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed SPDX copyright and license comment headers from multiple files across the source and test directories. No functional code changes, method signatures, or runtime behavior were affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->