### PR TITLE
Add Missing Constructor PHPDoc Summaries

### DIFF
--- a/src/Func/BiFuncOf.php
+++ b/src/Func/BiFuncOf.php
@@ -18,7 +18,11 @@ use Closure;
  */
 final readonly class BiFuncOf implements BiFunc
 {
-    /** @param Closure(X, Y): Z $origin */
+    /**
+     * Ctor.
+     *
+     * @param Closure(X, Y): Z $origin The closure to wrap.
+     */
     public function __construct(private Closure $origin)
     {
     }

--- a/src/Func/BiProcOf.php
+++ b/src/Func/BiProcOf.php
@@ -17,7 +17,11 @@ use Closure;
  */
 final readonly class BiProcOf implements BiProc
 {
-    /** @param Closure(X, Y): void $origin */
+    /**
+     * Ctor.
+     *
+     * @param Closure(X, Y): void $origin The closure to wrap.
+     */
     public function __construct(private Closure $origin)
     {
     }

--- a/src/Func/FuncEnvelope.php
+++ b/src/Func/FuncEnvelope.php
@@ -21,7 +21,9 @@ namespace Primus\Func;
 abstract readonly class FuncEnvelope implements Func
 {
     /**
-     * @param Func<I, O> $origin
+     * Ctor.
+     *
+     * @param Func<I, O> $origin The wrapped function.
      */
     public function __construct(private Func $origin)
     {

--- a/src/Func/FuncOf.php
+++ b/src/Func/FuncOf.php
@@ -18,7 +18,9 @@ use Closure;
 final readonly class FuncOf implements Func
 {
     /**
-     * @param Closure(I):O $origin
+     * Ctor.
+     *
+     * @param Closure(I):O $origin The closure to wrap.
      */
     public function __construct(private Closure $origin)
     {

--- a/src/Func/FuncWithFallback.php
+++ b/src/Func/FuncWithFallback.php
@@ -17,8 +17,10 @@ use Exception;
 final readonly class FuncWithFallback extends FuncEnvelope
 {
     /**
-     * @param Func<I, O> $origin
-     * @param Func<I, O> $fallback
+     * Ctor.
+     *
+     * @param Func<I, O> $origin The primary function.
+     * @param Func<I, O> $fallback The fallback function used on exception.
      */
     public function __construct(Func $origin, Func $fallback)
     {

--- a/src/Func/PredicateOf.php
+++ b/src/Func/PredicateOf.php
@@ -16,7 +16,11 @@ use Closure;
  */
 final readonly class PredicateOf implements Predicate
 {
-    /** @param Closure(X): bool $origin */
+    /**
+     * Ctor.
+     *
+     * @param Closure(X): bool $origin The closure to wrap.
+     */
     public function __construct(private Closure $origin)
     {
     }

--- a/src/Func/ProcOf.php
+++ b/src/Func/ProcOf.php
@@ -16,7 +16,11 @@ use Closure;
  */
 final readonly class ProcOf implements Proc
 {
-    /** @param Closure(X): void $origin */
+    /**
+     * Ctor.
+     *
+     * @param Closure(X): void $origin The closure to wrap.
+     */
     public function __construct(private Closure $origin)
     {
     }

--- a/src/Func/Repeated.php
+++ b/src/Func/Repeated.php
@@ -21,7 +21,10 @@ namespace Primus\Func;
 final readonly class Repeated implements Func
 {
     /**
-     * @param Func<T, T> $origin
+     * Ctor.
+     *
+     * @param Func<T, T> $origin The function to repeat.
+     * @param int $times Number of sequential applications.
      */
     public function __construct(
         private Func $origin,

--- a/src/Func/StickyFunc.php
+++ b/src/Func/StickyFunc.php
@@ -29,7 +29,9 @@ final class StickyFunc implements Func
     private array $cache = [];
 
     /**
-     * @param Func<X, Y> $origin
+     * Ctor.
+     *
+     * @param Func<X, Y> $origin The function whose results are cached.
      */
     public function __construct(private readonly Func $origin)
     {

--- a/src/Iterable/Filtered.php
+++ b/src/Iterable/Filtered.php
@@ -29,8 +29,10 @@ use Primus\Func\Predicate;
 final readonly class Filtered implements IteratorAggregate
 {
     /**
-     * @param IteratorAggregate<T> $origin
-     * @param Predicate<T> $predicate
+     * Ctor.
+     *
+     * @param IteratorAggregate<T> $origin The origin iterable.
+     * @param Predicate<T> $predicate The predicate used to filter values.
      */
     public function __construct(
         private IteratorAggregate $origin,

--- a/src/Iterable/IterableOf.php
+++ b/src/Iterable/IterableOf.php
@@ -26,7 +26,9 @@ use Primus\Iterator\IteratorOf;
 final readonly class IterableOf implements IteratorAggregate
 {
     /**
-     * @param array<mixed,T> $items Strict list of items
+     * Ctor.
+     *
+     * @param array<mixed,T> $items The items to iterate over.
      */
     public function __construct(private array $items)
     {

--- a/src/Iterable/Joined.php
+++ b/src/Iterable/Joined.php
@@ -8,6 +8,8 @@ use Iterator;
 use IteratorAggregate;
 
 /**
+ * Iterable that joins multiple iterators into a single sequence.
+ *
  * @template T
  * @implements IteratorAggregate<int, T>
  *
@@ -16,7 +18,9 @@ use IteratorAggregate;
 final readonly class Joined implements IteratorAggregate
 {
     /**
-     * @param array<Iterator<int,T>> $iterators
+     * Ctor.
+     *
+     * @param array<Iterator<int,T>> $iterators The iterators to join.
      */
     public function __construct(
         private array $iterators,

--- a/src/Iterable/Mapped.php
+++ b/src/Iterable/Mapped.php
@@ -31,8 +31,10 @@ use Primus\Func\Func;
 final readonly class Mapped implements IteratorAggregate
 {
     /**
-     * @param IteratorAggregate<X> $origin
-     * @param Func<X, Y> $func
+     * Ctor.
+     *
+     * @param IteratorAggregate<X> $origin The origin iterable.
+     * @param Func<X, Y> $func The function used to transform elements.
      */
     public function __construct(
         private IteratorAggregate $origin,

--- a/src/Iterable/NoNulls.php
+++ b/src/Iterable/NoNulls.php
@@ -20,7 +20,7 @@ final readonly class NoNulls implements IteratorAggregate
     /**
      * Ctor.
      *
-     * @param Iterator<int, T|null> $origin The iterator whose nulls are removed.
+     * @param Iterator<int, T|null> $origin The iterator validated for non-null values; nulls trigger RuntimeException on access.
      */
     public function __construct(
         private Iterator $origin

--- a/src/Iterable/NoNulls.php
+++ b/src/Iterable/NoNulls.php
@@ -18,7 +18,9 @@ use IteratorAggregate;
 final readonly class NoNulls implements IteratorAggregate
 {
     /**
-     * @param Iterator<int, T|null> $origin
+     * Ctor.
+     *
+     * @param Iterator<int, T|null> $origin The iterator whose nulls are removed.
      */
     public function __construct(
         private Iterator $origin

--- a/src/Iterator/Filtered.php
+++ b/src/Iterator/Filtered.php
@@ -22,8 +22,10 @@ final class Filtered implements Iterator
     private bool $isValid = false;
 
     /**
-     * @param Iterator<mixed, T> $origin
-     * @param Predicate<T>       $predicate
+     * Ctor.
+     *
+     * @param Iterator<mixed, T> $origin The origin iterator.
+     * @param Predicate<T>       $predicate The predicate used to filter values.
      */
     public function __construct(
         private readonly Iterator $origin,

--- a/src/Iterator/IteratorOf.php
+++ b/src/Iterator/IteratorOf.php
@@ -28,7 +28,9 @@ final class IteratorOf implements Iterator
     private int $position = 0;
 
     /**
-     * @param array<array-key, T> $items
+     * Ctor.
+     *
+     * @param array<array-key, T> $items The items to iterate over.
      */
     public function __construct(private readonly array $items)
     {

--- a/src/Iterator/Joined.php
+++ b/src/Iterator/Joined.php
@@ -35,7 +35,9 @@ final class Joined implements Iterator
     private Iterator $current;
 
     /**
-     * @param array<int,Iterator<int,T>> $iterators
+     * Ctor.
+     *
+     * @param array<int,Iterator<int,T>> $iterators The iterators to concatenate.
      */
     public function __construct(array $iterators)
     {

--- a/src/Iterator/Mapped.php
+++ b/src/Iterator/Mapped.php
@@ -8,6 +8,8 @@ use Iterator;
 use Primus\Func\Func;
 
 /**
+ * Iterator that lazily transforms each element of the origin iterator using the provided function.
+ *
  * @template X
  * @template Y
  * @implements Iterator<mixed, Y>
@@ -20,8 +22,10 @@ final class Mapped implements Iterator
     private int $position = 0;
 
     /**
-     * @param Iterator<mixed, X> $origin
-     * @param Func<X, Y> $func
+     * Ctor.
+     *
+     * @param Iterator<mixed, X> $origin The origin iterator.
+     * @param Func<X, Y> $func The function used to transform elements.
      */
     public function __construct(
         private readonly Iterator $origin,

--- a/src/Iterator/NoNulls.php
+++ b/src/Iterator/NoNulls.php
@@ -25,7 +25,7 @@ final class NoNulls implements Iterator
     /**
      * Ctor.
      *
-     * @param Iterator<mixed, T|null> $origin The iterator whose nulls are removed.
+     * @param Iterator<mixed, T|null> $origin The iterator validated for non-null values; nulls trigger RuntimeException on access.
      */
     public function __construct(
         private readonly Iterator $origin

--- a/src/Iterator/NoNulls.php
+++ b/src/Iterator/NoNulls.php
@@ -23,7 +23,9 @@ final class NoNulls implements Iterator
     private int $position = 0;
 
     /**
-     * @param Iterator<mixed, T|null> $origin
+     * Ctor.
+     *
+     * @param Iterator<mixed, T|null> $origin The iterator whose nulls are removed.
      */
     public function __construct(
         private readonly Iterator $origin

--- a/src/Scalar/AndOf.php
+++ b/src/Scalar/AndOf.php
@@ -21,7 +21,9 @@ use InvalidArgumentException;
 final readonly class AndOf extends ScalarEnvelope
 {
     /**
-     * @param Scalar<bool> ...$conditions
+     * Ctor.
+     *
+     * @param Scalar<bool> ...$conditions The scalars to AND together.
      */
     public function __construct(Scalar ...$conditions)
     {

--- a/src/Scalar/Between.php
+++ b/src/Scalar/Between.php
@@ -22,9 +22,11 @@ namespace Primus\Scalar;
 final readonly class Between extends ScalarEnvelope
 {
     /**
-     * @param Scalar<T> $value
-     * @param Scalar<T> $lower
-     * @param Scalar<T> $upper
+     * Ctor.
+     *
+     * @param Scalar<T> $value The scalar to test.
+     * @param Scalar<T> $lower The lower bound, exclusive.
+     * @param Scalar<T> $upper The upper bound, exclusive.
      */
     public function __construct(Scalar $value, Scalar $lower, Scalar $upper)
     {

--- a/src/Scalar/Constant.php
+++ b/src/Scalar/Constant.php
@@ -25,7 +25,9 @@ use Override;
 final readonly class Constant implements Scalar
 {
     /**
-     * @param T $value Value to return on each call.
+     * Ctor.
+     *
+     * @param T $value The value returned on each call.
      */
     public function __construct(private mixed $value)
     {

--- a/src/Scalar/EqualTo.php
+++ b/src/Scalar/EqualTo.php
@@ -21,8 +21,10 @@ namespace Primus\Scalar;
 final readonly class EqualTo extends ScalarEnvelope
 {
     /**
-     * @param Scalar<T> $left
-     * @param Scalar<T> $right
+     * Ctor.
+     *
+     * @param Scalar<T> $left The left operand.
+     * @param Scalar<T> $right The right operand.
      */
     public function __construct(Scalar $left, Scalar $right)
     {

--- a/src/Scalar/GreaterThan.php
+++ b/src/Scalar/GreaterThan.php
@@ -21,8 +21,10 @@ namespace Primus\Scalar;
 final readonly class GreaterThan extends ScalarEnvelope
 {
     /**
-     * @param Scalar<T> $left
-     * @param Scalar<T> $right
+     * Ctor.
+     *
+     * @param Scalar<T> $left The left operand.
+     * @param Scalar<T> $right The right operand.
      */
     public function __construct(Scalar $left, Scalar $right)
     {

--- a/src/Scalar/LessThan.php
+++ b/src/Scalar/LessThan.php
@@ -21,8 +21,10 @@ namespace Primus\Scalar;
 final readonly class LessThan extends ScalarEnvelope
 {
     /**
-     * @param Scalar<T> $left
-     * @param Scalar<T> $right
+     * Ctor.
+     *
+     * @param Scalar<T> $left The left operand.
+     * @param Scalar<T> $right The right operand.
      */
     public function __construct(Scalar $left, Scalar $right)
     {

--- a/src/Scalar/Not.php
+++ b/src/Scalar/Not.php
@@ -17,7 +17,9 @@ namespace Primus\Scalar;
 final readonly class Not extends ScalarEnvelope
 {
     /**
-     * @param Scalar<bool> $origin
+     * Ctor.
+     *
+     * @param Scalar<bool> $origin The scalar to negate.
      */
     public function __construct(Scalar $origin)
     {

--- a/src/Scalar/OrOf.php
+++ b/src/Scalar/OrOf.php
@@ -17,7 +17,9 @@ use InvalidArgumentException;
 final readonly class OrOf extends ScalarEnvelope
 {
     /**
-     * @param Scalar<bool> ...$conditions
+     * Ctor.
+     *
+     * @param Scalar<bool> ...$conditions The scalars to OR together.
      */
     public function __construct(Scalar ...$conditions)
     {

--- a/src/Scalar/ScalarEnvelope.php
+++ b/src/Scalar/ScalarEnvelope.php
@@ -17,7 +17,9 @@ namespace Primus\Scalar;
 abstract readonly class ScalarEnvelope implements Scalar
 {
     /**
-     * @param Scalar<T> $origin
+     * Ctor.
+     *
+     * @param Scalar<T> $origin The wrapped scalar.
      */
     public function __construct(protected Scalar $origin)
     {

--- a/src/Scalar/ScalarOf.php
+++ b/src/Scalar/ScalarOf.php
@@ -27,7 +27,9 @@ use Override;
 final readonly class ScalarOf implements Scalar
 {
     /**
-     * @param Closure(): T $closure
+     * Ctor.
+     *
+     * @param Closure(): T $closure The deferred computation.
      */
     public function __construct(private Closure $closure)
     {

--- a/src/Scalar/Sticky.php
+++ b/src/Scalar/Sticky.php
@@ -36,7 +36,9 @@ final class Sticky implements Scalar
     private $stored;
 
     /**
-     * @param Scalar<T> $origin
+     * Ctor.
+     *
+     * @param Scalar<T> $origin The scalar whose value is cached.
      */
     public function __construct(private readonly Scalar $origin)
     {

--- a/src/Scalar/Ternary.php
+++ b/src/Scalar/Ternary.php
@@ -25,9 +25,11 @@ namespace Primus\Scalar;
 final readonly class Ternary extends ScalarEnvelope
 {
     /**
-     * @param Scalar<bool> $condition
-     * @param Scalar<T> $yes
-     * @param Scalar<T> $no
+     * Ctor.
+     *
+     * @param Scalar<bool> $condition The branching condition.
+     * @param Scalar<T> $yes The value returned when condition is true.
+     * @param Scalar<T> $no The value returned when condition is false.
      */
     public function __construct(Scalar $condition, Scalar $yes, Scalar $no)
     {

--- a/src/Scalar/XorOf.php
+++ b/src/Scalar/XorOf.php
@@ -24,7 +24,9 @@ use InvalidArgumentException;
 final readonly class XorOf extends ScalarEnvelope
 {
     /**
-     * @param Scalar<bool> ...$conditions
+     * Ctor.
+     *
+     * @param Scalar<bool> ...$conditions The scalars to XOR together.
      */
     public function __construct(Scalar ...$conditions)
     {

--- a/src/Text/Joined.php
+++ b/src/Text/Joined.php
@@ -16,7 +16,10 @@ namespace Primus\Text;
 final readonly class Joined extends TextEnvelope
 {
     /**
-     * @param iterable<Text> $parts
+     * Ctor.
+     *
+     * @param string $separator The glue inserted between parts.
+     * @param iterable<Text> $parts The texts to join.
      */
     public function __construct(string $separator, iterable $parts)
     {

--- a/src/Text/Replaced.php
+++ b/src/Text/Replaced.php
@@ -22,8 +22,11 @@ namespace Primus\Text;
 final readonly class Replaced extends TextEnvelope
 {
     /**
-     * @param string|string[] $search
-     * @param string|string[] $replacement
+     * Ctor.
+     *
+     * @param Text $origin The origin text.
+     * @param string|string[] $search The substrings to search for.
+     * @param string|string[] $replacement The replacements.
      */
     public function __construct(
         Text $origin,

--- a/src/Text/Split.php
+++ b/src/Text/Split.php
@@ -23,7 +23,10 @@ use Primus\Scalar\Scalar;
 final readonly class Split implements Scalar
 {
     /**
-     * @param non-empty-string $delimiter
+     * Ctor.
+     *
+     * @param non-empty-string $delimiter The delimiter used to split the text.
+     * @param Text $origin The text to split.
      */
     public function __construct(
         private string $delimiter,

--- a/src/Text/TextOfScalar.php
+++ b/src/Text/TextOfScalar.php
@@ -11,7 +11,11 @@ use Primus\Scalar\Scalar;
  */
 final readonly class TextOfScalar implements Text
 {
-    /** @param Scalar<string> $origin */
+    /**
+     * Ctor.
+     *
+     * @param Scalar<string> $origin The scalar producing the string value.
+     */
     public function __construct(private Scalar $origin)
     {
     }


### PR DESCRIPTION
- Added "Ctor." summary lines and parameter descriptions to 36 constructor PHPDocs that previously had only @param tags
- Added class-level summaries to Iterable\Joined and Iterator\Mapped
- Closes 38 haspadar.phpdocEmpty errors from the piqule-provided phpstan ruleset

Part of #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Comprehensive updates to constructor documentation across all major library modules including Func, Iterable, Iterator, Scalar, and Text. Enhanced parameter descriptions, consistent formatting, and detailed explanations of constructor purposes and parameter roles now provide developers with significantly improved API comprehension, clearer understanding of component intentions, and overall better usage guidance and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->