### PR TITLE
Resolve Real PHPStan Findings Without Suppression

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "php": "~8.3.16 || ~8.4.3 || ~8.5.0"
     },
     "require-dev": {
+        "haspadar/phpstan-rules": "0.42.1",
         "haspadar/piqule": "dev-main",
         "slevomat/coding-standard": "^8.28",
         "kubawerlos/php-cs-fixer-custom-fixers": "^3.36"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd3b2920d6a714e71a26f761330afd15",
+    "content-hash": "a361bbad933e906ee672bdb7b0b23015",
     "packages": [],
     "packages-dev": [
         {
@@ -1815,16 +1815,16 @@
         },
         {
             "name": "haspadar/phpstan-rules",
-            "version": "v0.37.2",
+            "version": "v0.42.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/phpstan-rules.git",
-                "reference": "0bbb3b3285236c406e6d9196c9ad976f8f06c32d"
+                "reference": "bc3aa5840c0b52b6208ea399ab94987f79463050"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/0bbb3b3285236c406e6d9196c9ad976f8f06c32d",
-                "reference": "0bbb3b3285236c406e6d9196c9ad976f8f06c32d",
+                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/bc3aa5840c0b52b6208ea399ab94987f79463050",
+                "reference": "bc3aa5840c0b52b6208ea399ab94987f79463050",
                 "shasum": ""
             },
             "require": {
@@ -1862,9 +1862,9 @@
             "description": "PHPStan design rules for immutability and structure",
             "support": {
                 "issues": "https://github.com/haspadar/phpstan-rules/issues",
-                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.37.2"
+                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.42.1"
             },
-            "time": "2026-04-21T11:00:31+00:00"
+            "time": "2026-04-23T12:56:16+00:00"
         },
         {
             "name": "haspadar/piqule",
@@ -1872,12 +1872,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/piqule.git",
-                "reference": "c06d82b1fbf8ad7614ae98e0bd1146b75ca13cac"
+                "reference": "3b96447a796aedb70579c63b0d53a77239f1c69d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/piqule/zipball/c06d82b1fbf8ad7614ae98e0bd1146b75ca13cac",
-                "reference": "c06d82b1fbf8ad7614ae98e0bd1146b75ca13cac",
+                "url": "https://api.github.com/repos/haspadar/piqule/zipball/3b96447a796aedb70579c63b0d53a77239f1c69d",
+                "reference": "3b96447a796aedb70579c63b0d53a77239f1c69d",
                 "shasum": ""
             },
             "require": {
@@ -1925,7 +1925,7 @@
                 "issues": "https://github.com/haspadar/piqule/issues",
                 "source": "https://github.com/haspadar/piqule/tree/main"
             },
-            "time": "2026-04-22T12:20:12+00:00"
+            "time": "2026-04-23T14:38:10+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",
@@ -3539,11 +3539,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.50",
+            "version": "2.1.51",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d452086fb4cf648c6b2d8cf3b639351f79e4f3e2",
-                "reference": "d452086fb4cf648c6b2d8cf3b639351f79e4f3e2",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dc3b523c45e714c70de2ac5113b958223b55dc59",
+                "reference": "dc3b523c45e714c70de2ac5113b958223b55dc59",
                 "shasum": ""
             },
             "require": {
@@ -3588,7 +3588,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-17T13:10:32+00:00"
+            "time": "2026-04-21T18:22:01+00:00"
         },
         {
             "name": "phpstan/phpstan-strict-rules",

--- a/src/Func/StickyFunc.php
+++ b/src/Func/StickyFunc.php
@@ -40,6 +40,8 @@ final class StickyFunc implements Func
     public function apply(mixed $input): mixed
     {
         $key = serialize($input);
-        return $this->cache[$key] ??= $this->origin->apply($input);
+        $this->cache[$key] ??= $this->origin->apply($input);
+
+        return $this->cache[$key];
     }
 }

--- a/src/Iterable/Filtered.php
+++ b/src/Iterable/Filtered.php
@@ -43,9 +43,9 @@ final readonly class Filtered implements IteratorAggregate
     #[\Override]
     public function getIterator(): Iterator
     {
-        /** @var Iterator<mixed,T> $it */
-        $it = $this->origin->getIterator();
+        /** @var Iterator<mixed,T> $iterator */
+        $iterator = $this->origin->getIterator();
 
-        return new \Primus\Iterator\Filtered($it, $this->predicate);
+        return new \Primus\Iterator\Filtered($iterator, $this->predicate);
     }
 }

--- a/src/Iterable/Mapped.php
+++ b/src/Iterable/Mapped.php
@@ -45,11 +45,11 @@ final readonly class Mapped implements IteratorAggregate
     #[\Override]
     public function getIterator(): Iterator
     {
-        /** @var Iterator<mixed,X> $it */
-        $it = $this->origin->getIterator();
+        /** @var Iterator<mixed,X> $iterator */
+        $iterator = $this->origin->getIterator();
 
         return new \Primus\Iterator\Mapped(
-            $it,
+            $iterator,
             $this->func,
         );
     }

--- a/src/Scalar/Ternary.php
+++ b/src/Scalar/Ternary.php
@@ -7,8 +7,8 @@ namespace Primus\Scalar;
 /**
  * Conditional scalar.
  *
- * Returns {@see $yes} if {@see $condition} evaluates to true,
- * otherwise {@see $no}.
+ * Returns {@see $truthy} if {@see $condition} evaluates to true,
+ * otherwise {@see $falsy}.
  *
  * Example:
  *     $scalar = new Ternary(
@@ -28,14 +28,14 @@ final readonly class Ternary extends ScalarEnvelope
      * Ctor.
      *
      * @param Scalar<bool> $condition The branching condition.
-     * @param Scalar<T> $yes The value returned when condition is true.
-     * @param Scalar<T> $no The value returned when condition is false.
+     * @param Scalar<T> $truthy The value returned when condition is true.
+     * @param Scalar<T> $falsy The value returned when condition is false.
      */
-    public function __construct(Scalar $condition, Scalar $yes, Scalar $no)
+    public function __construct(Scalar $condition, Scalar $truthy, Scalar $falsy)
     {
         parent::__construct(
             new ScalarOf(
-                fn () => $condition->value() ? $yes->value() : $no->value()
+                fn () => $condition->value() ? $truthy->value() : $falsy->value()
             )
         );
     }

--- a/src/Text/Abbreviated.php
+++ b/src/Text/Abbreviated.php
@@ -37,7 +37,7 @@ final readonly class Abbreviated extends TextEnvelope
             return;
         }
 
-        $truncated = (new Sub($origin, 0, $limit - 1))->value() . '…';
+        $truncated = sprintf('%s…', (new Sub($origin, 0, $limit - 1))->value());
         parent::__construct(new TextOf($truncated));
     }
 }

--- a/src/Text/Capitalized.php
+++ b/src/Text/Capitalized.php
@@ -30,8 +30,11 @@ final readonly class Capitalized extends TextEnvelope
             new TextOf(
                 $value === ''
                     ? ''
-                    : mb_strtoupper(mb_substr($value, 0, 1, 'UTF-8'), 'UTF-8')
-                    . mb_substr($value, 1, null, 'UTF-8')
+                    : sprintf(
+                        '%s%s',
+                        mb_strtoupper(mb_substr($value, 0, 1, 'UTF-8'), 'UTF-8'),
+                        mb_substr($value, 1, null, 'UTF-8')
+                    )
             )
         );
     }

--- a/src/Text/LeftPadded.php
+++ b/src/Text/LeftPadded.php
@@ -23,19 +23,19 @@ final readonly class LeftPadded extends TextEnvelope
      *
      * @param Text $origin The text to pad.
      * @param int $length The desired total length after padding.
-     * @param string $padChar The character to use for padding.
+     * @param string $padding The character to use for padding.
      */
     public function __construct(
         Text $origin,
         int $length,
-        string $padChar
+        string $padding
     ) {
         parent::__construct(
             new TextOf(
                 str_pad(
                     $origin->value(),
                     $length,
-                    $padChar,
+                    $padding,
                     STR_PAD_LEFT
                 )
             )

--- a/src/Text/RandomText.php
+++ b/src/Text/RandomText.php
@@ -30,15 +30,15 @@ final readonly class RandomText extends TextEnvelope
     {
         $scalar = new ScalarOf(
             function () use ($length, $alphabet): string {
-                $alphabet = $alphabet !== '' ? $alphabet : 'a';
-                $size = mb_strlen($alphabet, 'UTF-8');
-                $result = '';
+                $source = $alphabet !== '' ? $alphabet : 'a';
+                $size = mb_strlen($source, 'UTF-8');
+                $chars = [];
 
                 for ($i = 0; $i < max(0, $length); $i++) {
-                    $result .= mb_substr($alphabet, random_int(0, $size - 1), 1, 'UTF-8');
+                    $chars[] = mb_substr($source, random_int(0, $size - 1), 1, 'UTF-8');
                 }
 
-                return $result;
+                return implode('', $chars);
             }
         );
 

--- a/src/Text/RightPadded.php
+++ b/src/Text/RightPadded.php
@@ -22,19 +22,19 @@ final readonly class RightPadded extends TextEnvelope
      *
      * @param Text $origin The text to pad.
      * @param int $length The desired total length after padding.
-     * @param string $padChar The character to use for padding.
+     * @param string $padding The character to use for padding.
      */
     public function __construct(
         Text $origin,
         int $length,
-        string $padChar
+        string $padding
     ) {
         parent::__construct(
             new TextOf(
                 str_pad(
                     $origin->value(),
                     $length,
-                    $padChar
+                    $padding
                 )
             )
         );


### PR DESCRIPTION
- Fixed 11 real phpstan findings across 10 files without suppressions
- Renamed private $it to $iterator in Filtered/Mapped
- Renamed public Ternary $yes/$no to $truthy/$falsy and $padChar to $padding
- Refactored string concatenations via sprintf and array buffer
- Split combined assign-and-return in StickyFunc
- Updated phpstan-rules to 0.42.1 for the for-loop innerAssignment fix

Part of #31

**Breaking changes:**
- Ternary constructor: $yes/$no renamed to $truthy/$falsy
- LeftPadded/RightPadded constructor: $padChar renamed to $padding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved caching mechanism and optimized string construction across text and iterable components
  * Standardized variable and parameter naming conventions for better code consistency

* **Chores**
  * Added development dependency for enhanced static analysis tooling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->