### PR TITLE
Enable Piqule CI Orchestrator And Close Migration

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 2%
+
+    patch:
+      default:
+        target: 80%
+        threshold: 5%
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: false

--- a/.github/workflows/piqule.yml
+++ b/.github/workflows/piqule.yml
@@ -1,0 +1,152 @@
+name: Piqule
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+
+  # ============================================================
+  # PR SIZE CHECK
+  # ============================================================
+  pr_size:
+    name: PR Size
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          fetch-depth: 0
+
+      - uses: maidsafe/pr_size_checker@948bfb3e96d93fbeeef4e207375163e8dae5665e
+        with:
+          max_lines_changed: 250
+
+
+  # ============================================================
+  # INFRA CHECKS
+  # ============================================================
+  infra:
+    name: ${{ matrix.check }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        check:
+          - actionlint
+          - hadolint
+          - markdownlint
+          - yamllint
+          - typos
+          - shellcheck
+          - jsonlint
+
+    steps:
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+
+      - uses: shivammathur/setup-php@690cb7c9d81dbfe51eba732cfca0a00ca42db777
+        with:
+          php-version: 8.3
+
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Run check
+        run: vendor/bin/piqule check ${{ matrix.check }}
+
+
+  # ============================================================
+  # PHP STATIC ANALYSIS
+  # ============================================================
+  php-static:
+    name: ${{ matrix.check }} (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ["8.3"]
+        check:
+          - phpcs
+          - phpstan
+          - psalm
+          - phpmd
+          - phpmetrics
+
+    steps:
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+
+      - uses: shivammathur/setup-php@690cb7c9d81dbfe51eba732cfca0a00ca42db777
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, dom, json
+
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Run static check
+        run: vendor/bin/piqule check ${{ matrix.check }}
+
+
+  # ============================================================
+  # PHP TESTS + COVERAGE + MUTATION
+  # ============================================================
+  php-tests:
+    name: Tests / Coverage / Mutation (PHP 8.3)
+    runs-on: ubuntu-latest
+    needs: php-static
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+
+      - uses: shivammathur/setup-php@690cb7c9d81dbfe51eba732cfca0a00ca42db777
+        with:
+          php-version: 8.3
+          coverage: xdebug
+          extensions: mbstring, dom, json
+
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      # ------------------------------------------------------------
+      # PHPUnit (if config exists)
+      # ------------------------------------------------------------
+      - name: PHPUnit (coverage)
+        if: hashFiles('.piqule/phpunit/phpunit.xml') != ''
+        run: bash .piqule/phpunit/command.sh
+
+      # ------------------------------------------------------------
+      # Upload coverage to Codecov (if coverage exists)
+      # ------------------------------------------------------------
+      - name: Upload coverage to Codecov
+        if: true == true && hashFiles('.piqule/codecov/coverage.xml') != ''
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: .piqule/codecov/coverage.xml
+          fail_ci_if_error: true
+
+      # ------------------------------------------------------------
+      # Infection (if config exists)
+      # ------------------------------------------------------------
+      - name: Infection
+        if: hashFiles('.piqule/infection/infection.json5') != ''
+        env:
+          INFECTION_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+        run: bash .piqule/infection/command.sh

--- a/.piqule.yaml
+++ b/.piqule.yaml
@@ -1,0 +1,15 @@
+# Piqule configuration. All available keys and their defaults are in .piqule/config.yaml.
+#
+# override:
+#     phpstan.level: 8
+#     php.versions: ["8.3", "8.4", "8.5"]
+#
+# append:
+#     php.src:
+#         - lib
+#     exclude:
+#         - legacy
+override:
+    phpunit.testsuites.unit: ["../../tests"]
+    phpunit.testsuites.integration: []
+    phpmetrics.coupling.max_afferent: 20

--- a/.piqule/.gitignore
+++ b/.piqule/.gitignore
@@ -1,0 +1,9 @@
+php-cs-fixer/.php-cs-fixer.cache
+codecov/coverage-report/
+codecov/coverage.xml
+infection/*.log
+ast-metrics/reports/
+phpmetrics/phpmetrics.json
+phpmetrics/html/
+phpunit/.phpunit.result.cache
+templates.md5

--- a/.piqule/_composer.sh
+++ b/.piqule/_composer.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BIN="${1:-}"
+if [ -z "$BIN" ]; then
+  echo "Usage: .piqule/_composer.sh <bin>"
+  exit 1
+fi
+
+BIN_PATH="vendor/bin/$BIN"
+
+if [ ! -f "vendor/autoload.php" ]; then
+  echo "vendor not found"
+  echo "Run: composer install"
+  exit 1
+fi
+
+if [ ! -f "$BIN_PATH" ]; then
+  echo "$BIN_PATH not found"
+  echo "Run: composer install"
+  exit 1
+fi
+
+echo "$BIN_PATH"

--- a/.piqule/_docker.sh
+++ b/.piqule/_docker.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Error: docker is not installed or not in PATH" >&2
+  exit 1
+fi
+
+PROJECT_ROOT="$(pwd)"
+
+IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:5dc15e7dba7dbb8ec6060d01e40858947dcaa902e5af8b64921beef3fe63611f}"
+
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  -v "$PROJECT_ROOT:/project" \
+  -w /project \
+  "$IMAGE" \
+  "$@"

--- a/.piqule/_skip_if_empty.sh
+++ b/.piqule/_skip_if_empty.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="${1:-}"
+GLOB="${2:-}"
+TOOL="${3:-}"
+
+if [ -z "$DIR" ] || [ -z "$GLOB" ] || [ -z "$TOOL" ]; then
+  echo "Usage: .piqule/_skip_if_empty.sh <dir> <glob> <tool-name> [<kind>] -- <cmd> [args...]" >&2
+  exit 2
+fi
+
+shift 3
+
+KIND="PHP source files"
+if [ $# -gt 0 ] && [ "$1" != "--" ]; then
+  KIND="$1"
+  shift
+fi
+
+if [ $# -eq 0 ] || [ "$1" != "--" ]; then
+  echo "Usage: .piqule/_skip_if_empty.sh <dir> <glob> <tool-name> [<kind>] -- <cmd> [args...]" >&2
+  exit 2
+fi
+shift
+
+if [ $# -eq 0 ]; then
+  echo "Usage: .piqule/_skip_if_empty.sh <dir> <glob> <tool-name> [<kind>] -- <cmd> [args...]" >&2
+  exit 2
+fi
+
+if [ ! -d "$DIR" ] || [ -z "$(find "$DIR" -name "$GLOB" -print -quit)" ]; then
+  echo "No $KIND found, skipping $TOOL"
+  exit 0
+fi
+
+exec "$@"

--- a/.piqule/actionlint/command.sh
+++ b/.piqule/actionlint/command.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! -d ".github/workflows" ]; then
+  echo "No GitHub workflows found"
+  exit 0
+fi
+
+.piqule/_docker.sh actionlint

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -1,0 +1,149 @@
+# Built-in defaults for all configuration keys.
+# Copy any key into .piqule.yaml under "override" or "append" to customize.
+#
+# Example .piqule.yaml:
+#
+#     override:
+#         phpstan.level: 8
+#     append:
+#         infra.exclude:
+#             - dist
+
+defaults:
+  php.src: ["src"]
+  infra.exclude: ["vendor", "tests", ".git"]
+  php.versions: ["8.3"]
+
+  check.full: false
+  check.parallel: true
+  check.slow: ["infection", "sonar"]
+
+  ci.piqule_bin: "vendor/bin/piqule"
+  ci.pr.max_lines_changed: 250
+
+  coverage.patch.target: 80
+  coverage.patch.threshold: 5
+  coverage.project.target: 80
+  coverage.project.threshold: 2
+
+  codecov.cloud: true
+  codecov.cli: false
+
+  coderabbit.cloud: true
+  coderabbit.cli: false
+
+  docker.image: "ghcr.io/haspadar/piqule-infra@sha256:5dc15e7dba7dbb8ec6060d01e40858947dcaa902e5af8b64921beef3fe63611f"
+
+  actionlint.cli: true
+
+  hadolint.cli: true
+  hadolint.failure_threshold: "error"
+  hadolint.ignore: ["vendor", "tests", ".git"]
+  hadolint.ignored_yaml: "[]"
+  hadolint.override.error_yaml: "[]"
+  hadolint.override.warning_yaml: "[]"
+  hadolint.patterns: ["Dockerfile*"]
+
+  jsonlint.cli: true
+  jsonlint.compact: true
+  jsonlint.continue: true
+  jsonlint.duplicate_keys: false
+  jsonlint.mode: ["json5"]
+  jsonlint.patterns: ["**/*.json", "**/*.json5", "**/*.jsonc", "!vendor/**", "!tests/**", "!.git/**"]
+
+  markdownlint.cli: true
+  markdownlint.ignores: ["vendor/**", "tests/**", ".git/**"]
+
+  php-cs-fixer.cli: true
+  php_cs_fixer.allow_unsupported: ["true"]
+  php_cs_fixer.exclude: ["vendor", "tests", ".git"]
+  php_cs_fixer.paths: ["../.."]
+
+  phpcs.cli: true
+  phpcs.excludes: ["vendor/*", "tests/*", ".git/*"]
+  phpcs.files: ["../../src"]
+  phpcs.root_namespace: ""
+
+  phpmd.cli: true
+  phpmd.paths: ["src"]
+  phpmd.class_complexity: 50
+  phpmd.class_length: 200
+  phpmd.cyclomatic: 10
+  phpmd.max_fields: 10
+  phpmd.max_methods: 10
+  phpmd.max_parameters: 5
+  phpmd.method_length: 50
+  phpmd.npath: 200
+
+  phpmetrics.cli: true
+  phpmetrics.includes: ["../../src"]
+  phpmetrics.excludes: ["vendor", "tests", ".git"]
+  phpmetrics.extensions: ["php"]
+  phpmetrics.complexity.max_cyclomatic_per_method: 10
+  phpmetrics.complexity.max_weighted_methods_per_class: 20
+  phpmetrics.coupling.max_afferent: 14
+  phpmetrics.coupling.max_efferent: 10
+  phpmetrics.halstead.max_bugs_per_method: 0.5
+  phpmetrics.halstead.max_difficulty_per_method: 15
+  phpmetrics.halstead.max_effort_per_method: 15000
+  phpmetrics.halstead.max_volume_per_method: 1000
+  phpmetrics.inheritance.max_depth: 3
+  phpmetrics.report.html: ["html"]
+  phpmetrics.report.json: ["phpmetrics.json"]
+  phpmetrics.size.max_loc_per_class: 1000
+  phpmetrics.size.max_logical_loc_per_class: 600
+  phpmetrics.size.max_logical_loc_per_method: 20
+  phpmetrics.structure.max_methods_per_class: 10
+
+  phpstan.cli: true
+  phpstan.level: 9
+  phpstan.memory: "1G"
+  phpstan.paths: ["../../src"]
+  phpstan.checked_exceptions: ['\Throwable']
+  phpstan.neon_includes: ["../../vendor/phpstan/phpstan-strict-rules/rules.neon", "../../vendor/haspadar/phpstan-rules/rules.neon"]
+  phpstan.afferent_coupling.ignore_interfaces: true
+  phpstan.afferent_coupling.excluded_classes: []
+
+  phpunit.cli: true
+  phpunit.php_options: "-d memory_limit=1G"
+  phpunit.source.include: ["../../src"]
+  phpunit.testsuites.unit: ["../../tests/Unit"]
+  phpunit.testsuites.integration: ["../../tests/Integration"]
+
+  psalm.cli: true
+  psalm.error_level: 1
+  psalm.project.directories: ["../../src"]
+  psalm.project.files: []
+  psalm.project.ignore: []
+  psalm.suppress.possibly_unused: []
+
+  infection.cli: true
+  infection.min_msi: 50
+  infection.min_covered_msi: 80
+  infection.php_options: "-d memory_limit=1G"
+  infection.source.directories: ["../../src"]
+  infection.timeout: 30
+
+  shellcheck.cli: true
+  shellcheck.exclude: []
+  shellcheck.external_sources: true
+  shellcheck.ignore_dirs: ["vendor", "tests", ".git"]
+  shellcheck.severity: "warning"
+  shellcheck.shell: "bash"
+  shellcheck.source_path: "."
+
+  sonar.cloud: true
+  sonar.cli: false
+  sonar.organization: []
+  sonar.projectKey: []
+  sonar.sources: ["src"]
+  sonar.tests: ["tests"]
+  sonar.exclusions: []
+  sonar.php.coverage.reportPaths: [".piqule/codecov/coverage.xml"]
+
+  typos.cli: true
+  typos.exclude: ["vendor/", "tests/", ".git/"]
+
+  yamllint.cli: true
+  yamllint.ignore: ["vendor/**", "tests/**", ".git/**", ".piqule/**/html/**", ".piqule/**/coverage-report/**"]
+  yamllint.line_length.max: 120

--- a/.piqule/hadolint/.hadolint.yml
+++ b/.piqule/hadolint/.hadolint.yml
@@ -1,0 +1,9 @@
+# Hadolint configuration (Piqule managed)
+
+failure-threshold: error
+
+ignored: []
+
+override:
+  error: []
+  warning: []

--- a/.piqule/hadolint/command.sh
+++ b/.piqule/hadolint/command.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG=".piqule/hadolint/.hadolint.yml"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "No hadolint config found, skipping hadolint"
+  exit 0
+fi
+
+# ============================================================
+# File selection (portable, correct precedence, NUL-safe)
+# ============================================================
+
+FILES=()
+while IFS= read -r -d '' file; do
+  FILES+=("$file")
+done < <(
+  find . \
+    -type f \
+    \( \
+      -name "Dockerfile*" -o \
+      -false \
+    \) \
+    ! -path "./vendor/*" \
+    ! -path "./tests/*" \
+    ! -path "./.git/*" \
+    -print0
+)
+
+if [ ${#FILES[@]} -eq 0 ]; then
+  echo "No Dockerfiles found"
+  exit 0
+fi
+
+.piqule/_docker.sh hadolint \
+  --config "$CONFIG" \
+  "${FILES[@]}"

--- a/.piqule/infection/command.sh
+++ b/.piqule/infection/command.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG=".piqule/infection/infection.json5"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "Infection config not found: $CONFIG"
+  exit 1
+fi
+
+INFECTION_BIN="$(.piqule/_composer.sh infection)"
+
+PHP_OPTIONS_STR="-d memory_limit=1G"
+PHP_OPTIONS=()
+if [ -n "$PHP_OPTIONS_STR" ]; then
+  read -ra PHP_OPTIONS <<< "$PHP_OPTIONS_STR"
+fi
+
+PHP_OPTIONS_RC=0
+PHP_OPTIONS_DIAG=$(php "${PHP_OPTIONS[@]+"${PHP_OPTIONS[@]}"}" -r 'exit(0);' 2>&1 >/dev/null) || PHP_OPTIONS_RC=$?
+if [ "$PHP_OPTIONS_RC" -ne 0 ] || [ -n "$PHP_OPTIONS_DIAG" ]; then
+  echo "Invalid infection.php_options: $PHP_OPTIONS_STR" >&2
+  [ -n "$PHP_OPTIONS_DIAG" ] && printf '%s\n' "$PHP_OPTIONS_DIAG" >&2
+  exit 1
+fi
+
+exec .piqule/_skip_if_empty.sh src '*.php' Infection -- \
+  env XDEBUG_MODE=coverage \
+  php "${PHP_OPTIONS[@]+"${PHP_OPTIONS[@]}"}" \
+  "$INFECTION_BIN" \
+  --configuration="$CONFIG" \
+  --threads=max

--- a/.piqule/infection/infection.json5
+++ b/.piqule/infection/infection.json5
@@ -1,0 +1,31 @@
+{
+  "$schema": "../../vendor/infection/infection/resources/schema.json",
+
+  "source": {
+    "directories": [
+        "../../src"
+    ]
+  },
+
+  "testFramework": "phpunit",
+
+  "phpUnit": {
+    "configDir": "../phpunit"
+  },
+
+  "initialTestsPhpOptions": "-d memory_limit=1G",
+  "timeout": 30,
+  "minMsi": 50,
+  "minCoveredMsi": 80,
+  "logs": {
+    "text": "infection.log",
+    "summary": "infection-summary.log",
+    "stryker": {
+      "badge": "/^(main|develop)$/"
+    }
+  },
+
+  "mutators": {
+    "@default": true
+  }
+}

--- a/.piqule/jsonlint/command.sh
+++ b/.piqule/jsonlint/command.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG=".piqule/jsonlint/config.json"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "JSONLint config not found: $CONFIG"
+  exit 1
+fi
+
+.piqule/_docker.sh jsonlint \
+  -f "$CONFIG" \
+  --quiet

--- a/.piqule/jsonlint/config.json
+++ b/.piqule/jsonlint/config.json
@@ -1,0 +1,14 @@
+{
+  "mode": "json5",
+  "compact": true,
+  "continue": true,
+  "duplicate-keys": false,
+  "patterns": [
+    "**/*.json",
+    "**/*.json5",
+    "**/*.jsonc",
+    "!vendor/**",
+    "!tests/**",
+    "!.git/**"
+  ]
+}

--- a/.piqule/markdownlint/.markdownlint-cli2.jsonc
+++ b/.piqule/markdownlint/.markdownlint-cli2.jsonc
@@ -1,0 +1,18 @@
+{
+  // MD013 (line length) disabled because many projects contain long URLs,
+  // code examples, or tables that should not be arbitrarily wrapped.
+  // MD033 (inline HTML) disabled because README files often require <details>,
+  // <br>, and other HTML elements that Markdown lacks equivalents for.
+  "config": {
+    "default": true,
+    "MD013": false,
+    "MD033": false
+  },
+
+  // Ignore dependency/vendor directories to avoid linting third-party content.
+  "ignores": [
+    "vendor/**",
+    "tests/**",
+    ".git/**"
+  ]
+}

--- a/.piqule/markdownlint/command.sh
+++ b/.piqule/markdownlint/command.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG=".piqule/markdownlint/.markdownlint-cli2.jsonc"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "Markdownlint config not found: $CONFIG"
+  exit 1
+fi
+
+.piqule/_docker.sh markdownlint-cli2 \
+  --config "$CONFIG"

--- a/.piqule/php-cs-fixer/command.sh
+++ b/.piqule/php-cs-fixer/command.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG=".piqule/php-cs-fixer/php-cs-fixer.project.php"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "PHP CS Fixer config not found: $CONFIG"
+  exit 1
+fi
+
+BIN="$(.piqule/_composer.sh php-cs-fixer)"
+
+exec .piqule/_skip_if_empty.sh src '*.php' "PHP CS Fixer" -- \
+  "$BIN" fix \
+  --config="$CONFIG" \
+  --dry-run \
+  --diff

--- a/.piqule/php-cs-fixer/kubawerlos-code.php
+++ b/.piqule/php-cs-fixer/kubawerlos-code.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+// kubawerlos/php-cs-fixer-custom-fixers: code quality rules
+return [
+    PhpCsFixerCustomFixers\Fixer\ClassConstantUsageFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\CommentSurroundedBySpacesFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\ForeachUseValueFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\FunctionParameterSeparationFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\IssetToArrayKeyExistsFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\MultilineCommentOpeningClosingAloneFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\NoPhpStormGeneratedCommentFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\NoReferenceInFunctionDefinitionFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\NoSuperfluousConcatenationFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\NoUselessCommentFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\NoUselessDirnameCallFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\NoUselessParenthesisFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\NoUselessStrlenFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\SingleSpaceAfterStatementFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\SingleSpaceBeforeStatementFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\TrimKeyFixer::name() => true,
+];

--- a/.piqule/php-cs-fixer/kubawerlos-phpdoc.php
+++ b/.piqule/php-cs-fixer/kubawerlos-phpdoc.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+// kubawerlos/php-cs-fixer-custom-fixers: PHPDoc rules
+return [
+    PhpCsFixerCustomFixers\Fixer\PhpdocNoIncorrectVarAnnotationFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\PhpdocParamTypeFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\PhpdocPropertySortedFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\PhpdocSelfAccessorFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\PhpdocTypeListFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\PhpdocTypesCommaSpacesFixer::name() => true,
+    PhpCsFixerCustomFixers\Fixer\PhpdocTypesTrimFixer::name() => true,
+];

--- a/.piqule/php-cs-fixer/php-cs-fixer.php
+++ b/.piqule/php-cs-fixer/php-cs-fixer.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This ruleset is meant to be reused across projects in two ways:
+ *
+ * 1) Directly, by running `php-cs-fixer fix --config=configs/php-cs-fixer.php`
+ *    and passing the target paths via CLI arguments.
+ *
+ * 2) Imported from a project's root `.php-cs-fixer.php`, where the project
+ *    defines its own Finder / path configuration.
+ *
+ * Only the rule definitions are shared across projects; path and Finder
+ * configuration belong to the consuming project.
+ */
+
+$customFixers = new PhpCsFixerCustomFixers\Fixers();
+
+return (new PhpCsFixer\Config())
+    ->registerCustomFixers($customFixers)
+    ->setRiskyAllowed(true)
+    ->setRules(array_merge(
+        require __DIR__ . '/kubawerlos-code.php',
+        require __DIR__ . '/kubawerlos-phpdoc.php',
+    [
+
+        '@PER-CS2.0' => true,
+        '@PHP8x3Migration' => true,
+
+        // Arrays
+        'array_syntax' => ['syntax' => 'short'],
+        'trailing_comma_in_multiline' => [
+            'elements' => ['arrays', 'arguments', 'parameters'],
+        ],
+
+        // Imports
+        'ordered_imports' => [
+            'sort_algorithm' => 'alpha',
+            'imports_order' => ['class', 'function', 'const'],
+        ],
+        'no_unused_imports' => true,
+        'no_leading_import_slash' => true,
+        'global_namespace_import' => [
+            'import_classes' => true,
+            'import_constants' => true,
+            'import_functions' => true,
+        ],
+
+        // Strict types
+        'declare_strict_types' => true,
+        'declare_equal_normalize' => ['space' => 'none'],
+
+        // Final & visibility
+        'final_class' => true,
+        'final_internal_class' => true,
+
+        // Types
+        'native_type_declaration_casing' => true,
+
+        // Formatting
+        'blank_line_before_statement' => ['statements' => ['return', 'throw', 'try']],
+        'class_attributes_separation' => [
+            'elements' => ['method' => 'one', 'property' => 'one'],
+        ],
+        'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
+        'no_blank_lines_after_class_opening' => true,
+        'no_extra_blank_lines' => ['tokens' => ['extra', 'throw', 'use']],
+        'no_trailing_comma_in_singleline' => true,
+        'no_whitespace_in_blank_line' => true,
+
+        // PHPDoc
+        'phpdoc_align' => ['align' => 'left'],
+        'phpdoc_indent' => true,
+        'phpdoc_no_empty_return' => true,
+        'phpdoc_order' => true,
+        'phpdoc_scalar' => true,
+        'phpdoc_trim' => true,
+        'phpdoc_types' => true,
+        'phpdoc_var_without_name' => true,
+
+        // Clean code
+        'strict_comparison' => true,
+        'strict_param' => true,
+
+        // Casting
+        'cast_spaces' => ['space' => 'single'],
+        'lowercase_cast' => true,
+
+        // Control structures
+        'control_structure_braces' => true,
+        'control_structure_continuation_position' => true,
+
+        // Operators
+        'binary_operator_spaces' => ['default' => 'single_space'],
+        'concat_space' => ['spacing' => 'one'],
+        'unary_operator_spaces' => true,
+        'not_operator_with_successor_space' => false,
+
+        // Misc
+        'encoding' => true,
+        'full_opening_tag' => true,
+        'single_quote' => true,
+        'ternary_operator_spaces' => true,
+
+        // PHP 8.4 compatibility: keep parentheses around `new` expressions
+        // so tools based on pdepend (phpmd) can still parse the code
+        'new_expression_parentheses' => ['use_parentheses' => true],
+    ]))
+    ->setUnsupportedPhpVersionAllowed(true);

--- a/.piqule/php-cs-fixer/php-cs-fixer.php
+++ b/.piqule/php-cs-fixer/php-cs-fixer.php
@@ -76,7 +76,7 @@ return (new PhpCsFixer\Config())
         'phpdoc_order' => true,
         'phpdoc_scalar' => true,
         'phpdoc_trim' => true,
-        'phpdoc_types' => true,
+        'phpdoc_types' => false,
         'phpdoc_var_without_name' => true,
 
         // Clean code

--- a/.piqule/php-cs-fixer/php-cs-fixer.project.php
+++ b/.piqule/php-cs-fixer/php-cs-fixer.project.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Finder;
+
+/** @var PhpCsFixer\Config $rules */
+$rules = require __DIR__ . '/php-cs-fixer.php';
+
+$rules->setFinder(
+    Finder::create()
+        ->in([__DIR__ . '/../..'])
+        ->exclude(['vendor','tests','.git']),
+)->setCacheFile(__DIR__ . '/.php-cs-fixer.cache');
+
+return $rules;

--- a/.piqule/phpcs/command.sh
+++ b/.piqule/phpcs/command.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG=".piqule/phpcs/phpcs.xml"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "PHPCS config not found: $CONFIG"
+  exit 1
+fi
+
+BIN="$(.piqule/_composer.sh phpcs)"
+
+exec .piqule/_skip_if_empty.sh src '*.php' PHPCS -- \
+  "$BIN" --standard="$CONFIG"

--- a/.piqule/phpcs/phpcs.xml
+++ b/.piqule/phpcs/phpcs.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<ruleset name="Piqule PHPCS Rules">
+    <description>Structural and semantic PHP rules</description>
+
+    <file>../../src</file>
+
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>tests/*</exclude-pattern>
+    <exclude-pattern>.git/*</exclude-pattern>
+
+    <arg name="extensions" value="php"/>
+    <arg name="colors"/>
+
+    <rule ref="Generic.PHP.Syntax"/>
+
+    <rule ref=".piqule/phpcs/slevomat-types.xml"/>
+    <rule ref=".piqule/phpcs/slevomat-classes.xml"/>
+    <rule ref=".piqule/phpcs/slevomat-functions.xml"/>
+    <rule ref=".piqule/phpcs/slevomat-namespaces.xml"/>
+    <rule ref=".piqule/phpcs/slevomat-flow.xml"/>
+    <rule ref=".piqule/phpcs/slevomat-style.xml"/>
+
+</ruleset>

--- a/.piqule/phpcs/slevomat-classes.xml
+++ b/.piqule/phpcs/slevomat-classes.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<ruleset name="Slevomat: classes">
+
+    <rule ref="SlevomatCodingStandard.Classes.BackedEnumTypeSpacing"/>
+    <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
+    <rule ref="SlevomatCodingStandard.Classes.ClassKeywordOrder"/>
+    <rule ref="SlevomatCodingStandard.Classes.ClassMemberSpacing"/>
+    <rule ref="SlevomatCodingStandard.Classes.ClassStructure">
+        <properties>
+            <property name="groups" type="array">
+                <element value="uses"/>
+                <element value="enum cases"/>
+                <element value="constants"/>
+                <element value="properties"/>
+                <element value="constructor"/>
+                <element value="static constructors"/>
+                <element value="destructor"/>
+                <element value="magic methods"/>
+                <element value="invoke method"/>
+                <element value="methods"/>
+            </property>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Classes.ConstantSpacing"/>
+    <rule ref="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants"/>
+    <rule ref="SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition"/>
+    <rule ref="SlevomatCodingStandard.Classes.DisallowMultiPropertyDefinition"/>
+    <rule ref="SlevomatCodingStandard.Classes.DisallowStringExpressionPropertyFetch"/>
+    <rule ref="SlevomatCodingStandard.Classes.EnumCaseSpacing"/>
+    <rule ref="SlevomatCodingStandard.Classes.ForbiddenPublicProperty"/>
+    <rule ref="SlevomatCodingStandard.Classes.MethodSpacing"/>
+    <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
+    <rule ref="SlevomatCodingStandard.Classes.ParentCallSpacing"/>
+    <rule ref="SlevomatCodingStandard.Classes.PropertyDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Classes.PropertySpacing"/>
+    <rule ref="SlevomatCodingStandard.Classes.RequireAbstractOrFinal"/>
+    <rule ref="SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion"/>
+    <rule ref="SlevomatCodingStandard.Classes.RequireMultiLineMethodSignature">
+        <properties>
+            <property name="minLineLength" value="101"/>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Classes.RequireSelfReference"/>
+    <rule ref="SlevomatCodingStandard.Classes.RequireSingleLineMethodSignature">
+        <properties>
+            <property name="maxLineLength" value="100"/>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
+    <rule ref="SlevomatCodingStandard.Classes.SuperfluousErrorNaming"/>
+    <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>
+    <rule ref="SlevomatCodingStandard.Classes.SuperfluousTraitNaming"/>
+    <rule ref="SlevomatCodingStandard.Classes.TraitUseDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Classes.TraitUseOrder"/>
+    <rule ref="SlevomatCodingStandard.Classes.TraitUseSpacing"/>
+    <rule ref="SlevomatCodingStandard.Classes.UselessLateStaticBinding"/>
+
+    <rule ref="SlevomatCodingStandard.Attributes.AttributeAndTargetSpacing"/>
+    <rule ref="SlevomatCodingStandard.Attributes.AttributesOrder">
+        <properties>
+            <property name="orderAlphabetically" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Attributes.DisallowAttributesJoining"/>
+    <rule ref="SlevomatCodingStandard.Attributes.DisallowMultipleAttributesPerLine"/>
+    <rule ref="SlevomatCodingStandard.Attributes.RequireAttributeAfterDocComment"/>
+
+</ruleset>

--- a/.piqule/phpcs/slevomat-flow.xml
+++ b/.piqule/phpcs/slevomat-flow.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<ruleset name="Slevomat: control flow">
+
+    <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.BlockControlStructureSpacing"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEmpty"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowShortTernaryOperator"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowTrailingMultiLineTernaryOperator"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.NewWithParentheses"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireMultiLineTernaryOperator"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireTernaryOperator"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.UselessTernaryOperator"/>
+
+    <rule ref="SlevomatCodingStandard.Exceptions.CatchExceptionsOrder"/>
+    <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
+    <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly"/>
+    <rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch"/>
+
+    <rule ref="SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable"/>
+    <rule ref="SlevomatCodingStandard.Variables.DisallowVariableVariable"/>
+    <rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable"/>
+    <rule ref="SlevomatCodingStandard.Variables.UnusedVariable"/>
+    <rule ref="SlevomatCodingStandard.Variables.UselessVariable"/>
+
+</ruleset>

--- a/.piqule/phpcs/slevomat-flow.xml
+++ b/.piqule/phpcs/slevomat-flow.xml
@@ -20,7 +20,6 @@
 
     <rule ref="SlevomatCodingStandard.Exceptions.CatchExceptionsOrder"/>
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
-    <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly"/>
     <rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch"/>
 
     <rule ref="SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable"/>

--- a/.piqule/phpcs/slevomat-functions.xml
+++ b/.piqule/phpcs/slevomat-functions.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<ruleset name="Slevomat: functions">
+
+    <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration">
+        <properties>
+            <property name="spacesCountAfterKeyword" value="0"/>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Functions.DisallowEmptyFunction"/>
+    <rule ref="SlevomatCodingStandard.Functions.DisallowNamedArguments"/>
+    <rule ref="SlevomatCodingStandard.Functions.NamedArgumentSpacing"/>
+    <rule ref="SlevomatCodingStandard.Functions.RequireArrowFunction"/>
+    <rule ref="SlevomatCodingStandard.Functions.RequireMultiLineCall"/>
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall"/>
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse"/>
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Functions.StaticClosure"/>
+    <rule ref="SlevomatCodingStandard.Functions.StrictCall"/>
+    <rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure"/>
+    <rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue"/>
+
+    <rule ref="SlevomatCodingStandard.Arrays.ArrayAccess"/>
+    <rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation"/>
+    <rule ref="SlevomatCodingStandard.Arrays.DisallowPartiallyKeyed"/>
+    <rule ref="SlevomatCodingStandard.Arrays.MultiLineArrayEndBracketPlacement"/>
+    <rule ref="SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace"/>
+    <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
+
+    <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
+    <rule ref="SlevomatCodingStandard.Operators.NegationOperatorSpacing"/>
+    <rule ref="SlevomatCodingStandard.Operators.RequireCombinedAssignmentOperator"/>
+    <rule ref="SlevomatCodingStandard.Operators.RequireOnlyStandaloneIncrementAndDecrementOperators"/>
+    <rule ref="SlevomatCodingStandard.Operators.SpreadOperatorSpacing"/>
+
+    <rule ref="SlevomatCodingStandard.Numbers.RequireNumericLiteralSeparator">
+        <properties>
+            <property name="minDigitsBeforeDecimalPoint" value="5"/>
+        </properties>
+    </rule>
+
+</ruleset>

--- a/.piqule/phpcs/slevomat-namespaces.xml
+++ b/.piqule/phpcs/slevomat-namespaces.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<ruleset name="Slevomat: namespaces">
+
+    <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.NamespaceDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.NamespaceSpacing"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
+        <properties>
+            <property name="searchAnnotations" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Namespaces.RequireOneNamespaceInFile"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
+        <properties>
+            <property name="searchAnnotations" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UseSpacing">
+        <properties>
+            <property name="linesCountBetweenUseTypes" value="1"/>
+        </properties>
+    </rule>
+
+</ruleset>

--- a/.piqule/phpcs/slevomat-style.xml
+++ b/.piqule/phpcs/slevomat-style.xml
@@ -18,7 +18,6 @@
     <rule ref="SlevomatCodingStandard.PHP.DisallowReference"/>
     <rule ref="SlevomatCodingStandard.PHP.OptimizedFunctionsWithoutUnpacking"/>
     <rule ref="SlevomatCodingStandard.PHP.ReferenceSpacing"/>
-    <rule ref="SlevomatCodingStandard.PHP.RequireExplicitAssertion"/>
     <rule ref="SlevomatCodingStandard.PHP.RequireNowdoc"/>
     <rule ref="SlevomatCodingStandard.PHP.ShortList"/>
     <rule ref="SlevomatCodingStandard.PHP.TypeCast"/>

--- a/.piqule/phpcs/slevomat-style.xml
+++ b/.piqule/phpcs/slevomat-style.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<ruleset name="Slevomat: style">
+
+    <rule ref="SlevomatCodingStandard.Commenting.AnnotationName"/>
+    <rule ref="SlevomatCodingStandard.Commenting.DeprecatedAnnotationDeclaration"/>
+    <rule ref="SlevomatCodingStandard.Commenting.DisallowCommentAfterCode"/>
+    <rule ref="SlevomatCodingStandard.Commenting.RequireOneLineDocComment"/>
+    <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing"/>
+    <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
+    <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations"/>
+    <rule ref="SlevomatCodingStandard.Commenting.ForbiddenComments"/>
+    <rule ref="SlevomatCodingStandard.Commenting.RequireOneDocComment"/>
+    <rule ref="SlevomatCodingStandard.Commenting.ThrowsAnnotationsOrder"/>
+    <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment"/>
+    <rule ref="SlevomatCodingStandard.Commenting.UselessInheritDocComment"/>
+
+    <rule ref="SlevomatCodingStandard.PHP.DisallowDirectMagicInvokeCall"/>
+    <rule ref="SlevomatCodingStandard.PHP.DisallowReference"/>
+    <rule ref="SlevomatCodingStandard.PHP.OptimizedFunctionsWithoutUnpacking"/>
+    <rule ref="SlevomatCodingStandard.PHP.ReferenceSpacing"/>
+    <rule ref="SlevomatCodingStandard.PHP.RequireExplicitAssertion"/>
+    <rule ref="SlevomatCodingStandard.PHP.RequireNowdoc"/>
+    <rule ref="SlevomatCodingStandard.PHP.ShortList"/>
+    <rule ref="SlevomatCodingStandard.PHP.TypeCast"/>
+    <rule ref="SlevomatCodingStandard.PHP.UselessParentheses"/>
+    <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
+
+    <rule ref="SlevomatCodingStandard.Whitespaces.DuplicateSpaces"/>
+    <rule ref="SlevomatCodingStandard.Strings.DisallowVariableParsing"/>
+
+    <rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
+        <properties>
+            <property name="rootNamespaces" type="array">
+                <element key="src" value="Primus"/>
+            </property>
+        </properties>
+    </rule>
+
+</ruleset>

--- a/.piqule/phpcs/slevomat-types.xml
+++ b/.piqule/phpcs/slevomat-types.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<ruleset name="Slevomat: types">
+
+    <rule ref="SlevomatCodingStandard.TypeHints.ClassConstantTypeHint"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.DNFTypeHintFormat"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint"/>
+
+</ruleset>

--- a/.piqule/phpmd/command.sh
+++ b/.piqule/phpmd/command.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG=".piqule/phpmd/phpmd.xml"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "PHPMD config not found: $CONFIG"
+  exit 1
+fi
+
+BIN="$(.piqule/_composer.sh phpmd)"
+
+exec .piqule/_skip_if_empty.sh src '*.php' PHPMD -- \
+  "$BIN" \
+src \
+  text \
+  "$CONFIG"

--- a/.piqule/phpmd/phpmd.xml
+++ b/.piqule/phpmd/phpmd.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         name="Piqule PHPMD Ruleset"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0
+                             https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
+    <description>
+        Numeric-only PHPMD ruleset with intentionally strict thresholds
+    </description>
+
+    <!-- Cyclomatic complexity -->
+    <rule ref="rulesets/codesize.xml/CyclomaticComplexity">
+        <properties>
+            <property name="reportLevel" value="10"/>
+        </properties>
+    </rule>
+
+    <!-- NPath complexity -->
+    <rule ref="rulesets/codesize.xml/NPathComplexity">
+        <properties>
+            <property name="reportLevel" value="200"/>
+        </properties>
+    </rule>
+
+    <!-- Method length -->
+    <rule ref="rulesets/codesize.xml/ExcessiveMethodLength">
+        <properties>
+            <property name="minimum" value="50"/>
+        </properties>
+    </rule>
+
+    <!-- Class length -->
+    <rule ref="rulesets/codesize.xml/ExcessiveClassLength">
+        <properties>
+            <property name="minimum" value="200"/>
+        </properties>
+    </rule>
+
+    <!-- Number of methods -->
+    <rule ref="rulesets/codesize.xml/TooManyMethods">
+        <properties>
+            <property name="maxmethods" value="10"/>
+        </properties>
+    </rule>
+
+    <!-- Too many fields -->
+    <rule ref="rulesets/codesize.xml/TooManyFields">
+        <properties>
+            <property name="maxfields" value="10"/>
+        </properties>
+    </rule>
+
+    <!-- Excessive parameter list -->
+    <rule ref="rulesets/codesize.xml/ExcessiveParameterList">
+        <properties>
+            <property name="minimum" value="5"/>
+        </properties>
+    </rule>
+
+    <!-- Boolean argument flag -->
+    <rule ref="rulesets/cleancode.xml/BooleanArgumentFlag"/>
+
+    <!-- Excessive class complexity (WMC) -->
+    <rule ref="rulesets/codesize.xml/ExcessiveClassComplexity">
+        <properties>
+            <property name="maximum" value="50"/>
+        </properties>
+    </rule>
+
+</ruleset>

--- a/.piqule/phpmetrics/command.sh
+++ b/.piqule/phpmetrics/command.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG=".piqule/phpmetrics/config.json"
+VERIFY=".piqule/phpmetrics/verify.php"
+REPORT=".piqule/phpmetrics/phpmetrics.json"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "PHPMetrics config not found: $CONFIG"
+  exit 1
+fi
+
+rm -f "$REPORT"
+
+BIN="$(.piqule/_composer.sh phpmetrics)"
+
+.piqule/_skip_if_empty.sh src '*.php' PHPMetrics -- \
+  php -d error_reporting='E_ALL & ~E_DEPRECATED' \
+  "$BIN" \
+  --config="$CONFIG"
+
+if [ -f "$VERIFY" ] && [ -f "$REPORT" ]; then
+  php "$VERIFY"
+fi

--- a/.piqule/phpmetrics/config.json
+++ b/.piqule/phpmetrics/config.json
@@ -1,0 +1,18 @@
+{
+  "composer": false,
+  "includes": [
+    "../../src"
+  ],
+  "excludes": [
+    "vendor",
+    "tests",
+    ".git"
+  ],
+  "extensions": [
+    "php"
+  ],
+  "report": {
+    "html": "html",
+    "json": "phpmetrics.json"
+  }
+}

--- a/.piqule/phpmetrics/rules.php
+++ b/.piqule/phpmetrics/rules.php
@@ -1,0 +1,29 @@
+<?php
+
+return [
+    'complexity' => [
+        'max_cyclomatic_per_method' => 10,
+        'max_weighted_methods_per_class' => 20,
+    ],
+    'size' => [
+        'max_loc_per_class' => 1000,
+        'max_logical_loc_per_class' => 600,
+        'max_logical_loc_per_method' => 20,
+    ],
+    'halstead' => [
+        'max_volume_per_method' => 1000,
+        'max_difficulty_per_method' => 15,
+        'max_effort_per_method' => 15000,
+        'max_bugs_per_method' => 0.5,
+    ],
+    'inheritance' => [
+        'max_depth' => 3,
+    ],
+    'structure' => [
+        'max_methods_per_class' => 10,
+    ],
+    'coupling' => [
+        'max_afferent' => 20,
+        'max_efferent' => 10,
+    ],
+];

--- a/.piqule/phpmetrics/verify.php
+++ b/.piqule/phpmetrics/verify.php
@@ -1,0 +1,223 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+$config = require __DIR__ . '/rules.php';
+$report = json_decode(
+    file_get_contents(__DIR__ . '/phpmetrics.json'),
+    true,
+    flags: JSON_THROW_ON_ERROR,
+);
+
+$violations = analyzeReport($report, $config);
+
+if ($violations !== []) {
+    renderViolationsGrouped($violations);
+    exit(1);
+}
+
+echo "✔ phpmetrics passed all thresholds\n";
+
+function analyzeReport(array $report, array $config): array
+{
+    $violations = [];
+
+    foreach ($report as $node) {
+        if (($node['_type'] ?? null) === 'Hal\\Metric\\ClassMetric') {
+            foreach (analyzeClass($node, $config) as $v) {
+                $violations[] = $v;
+            }
+        }
+
+        if (($node['_type'] ?? null) === 'Hal\\Metric\\ProjectMetric') {
+            foreach (analyzeProject($node, $config) as $v) {
+                $violations[] = $v;
+            }
+        }
+    }
+
+    return $violations;
+}
+
+function analyzeClass(array $node, array $config): array
+{
+    $violations = [];
+    $class = $node['name'];
+
+    foreach (classRules() as $r) {
+        $limit = rule($config, $r['rule']);
+        if ($limit === null) {
+            continue;
+        }
+
+        $actual = $node[$r['metric']] ?? null;
+        if ($actual === null) {
+            continue;
+        }
+
+        $items = $r['type'] === 'min'
+            ? checkMin($class, $r['label'], $actual, $limit, path($r['rule']))
+            : checkMax($class, $r['label'], $actual, $limit, path($r['rule']));
+
+        foreach ($items as $v) {
+            $violations[] = $v;
+        }
+    }
+
+    foreach ($node['methods'] ?? [] as $method) {
+        foreach (analyzeMethod($class, $method, $config) as $v) {
+            $violations[] = $v;
+        }
+    }
+
+    return $violations;
+}
+
+function analyzeMethod(string $class, array $method, array $config): array
+{
+    $violations = [];
+    $name = $method['name'];
+
+    foreach (methodRules() as $r) {
+        $limit = rule($config, $r['rule']);
+        if ($limit === null) {
+            continue;
+        }
+
+        foreach (
+            checkMax(
+                $class,
+                "Method {$name} {$r['label']}",
+                $method[$r['metric']] ?? 0,
+                $limit,
+                path($r['rule']),
+            ) as $v
+        ) {
+            $violations[] = $v;
+        }
+    }
+
+    return $violations;
+}
+
+function analyzeProject(array $node, array $config): array
+{
+    if ($node['name'] !== 'tree') {
+        return [];
+    }
+
+    $maxDepth = rule($config, ['inheritance', 'max_depth']);
+    if ($maxDepth === null) {
+        return [];
+    }
+
+    if ($node['depthOfInheritanceTree'] > $maxDepth) {
+        return [[
+            'class'   => 'Project',
+            'message' => "Inheritance depth too high: got {$node['depthOfInheritanceTree']} (max: $maxDepth)",
+            'rule'    => 'inheritance.max_depth',
+        ]];
+    }
+
+    return [];
+}
+
+function classRules(): array
+{
+    return [
+        ['label' => 'Maintainability', 'metric' => 'mi', 'rule' => ['maintainability', 'min_index'], 'type' => 'min'],
+        ['label' => 'WMC', 'metric' => 'wmc', 'rule' => ['complexity', 'max_weighted_methods_per_class'], 'type' => 'max'],
+        ['label' => 'Cyclomatic complexity', 'metric' => 'ccnMethodMax', 'rule' => ['complexity', 'max_cyclomatic_per_method'], 'type' => 'max'],
+        ['label' => 'LOC', 'metric' => 'loc', 'rule' => ['size', 'max_loc_per_class'], 'type' => 'max'],
+        ['label' => 'LLOC', 'metric' => 'lloc', 'rule' => ['size', 'max_logical_loc_per_class'], 'type' => 'max'],
+        ['label' => 'Methods count', 'metric' => 'nbMethods', 'rule' => ['structure', 'max_methods_per_class'], 'type' => 'max'],
+        ['label' => 'Afferent coupling', 'metric' => 'afferentCoupling', 'rule' => ['coupling', 'max_afferent'], 'type' => 'max'],
+        ['label' => 'Efferent coupling', 'metric' => 'efferentCoupling', 'rule' => ['coupling', 'max_efferent'], 'type' => 'max'],
+        ['label' => 'Instability', 'metric' => 'instability', 'rule' => ['coupling', 'max_instability'], 'type' => 'max'],
+    ];
+}
+
+function methodRules(): array
+{
+    return [
+        ['label' => 'LLOC', 'metric' => 'lloc', 'rule' => ['size', 'max_logical_loc_per_method']],
+        ['label' => 'volume', 'metric' => 'volume', 'rule' => ['halstead', 'max_volume_per_method']],
+        ['label' => 'difficulty', 'metric' => 'difficulty', 'rule' => ['halstead', 'max_difficulty_per_method']],
+        ['label' => 'effort', 'metric' => 'effort', 'rule' => ['halstead', 'max_effort_per_method']],
+        ['label' => 'bugs', 'metric' => 'bugs', 'rule' => ['halstead', 'max_bugs_per_method']],
+    ];
+}
+
+function rule(array $config, array $path): mixed
+{
+    foreach ($path as $key) {
+        if (!array_key_exists($key, $config)) {
+            return null;
+        }
+        $config = $config[$key];
+    }
+
+    return $config;
+}
+
+function path(array $rule): string
+{
+    return implode('.', $rule);
+}
+
+function checkMax(
+    string $class,
+    string $label,
+    int|float $actual,
+    int|float|null $max,
+    string $rule,
+): array {
+    if ($max === null || $actual <= $max) {
+        return [];
+    }
+
+    return [[
+        'class'   => $class,
+        'message' => "$label too high: got $actual (max: $max)",
+        'rule'    => $rule,
+    ]];
+}
+
+function checkMin(
+    string $class,
+    string $label,
+    int|float|null $actual,
+    int|float|null $min,
+    string $rule,
+): array {
+    if ($actual === null || $min === null || $actual >= $min) {
+        return [];
+    }
+
+    return [[
+        'class'   => $class,
+        'message' => "$label too low: got $actual (min: $min)",
+        'rule'    => $rule,
+    ]];
+}
+
+function renderViolationsGrouped(array $violations): void
+{
+    $byClass = [];
+
+    foreach ($violations as $v) {
+        $byClass[$v['class']][] = $v;
+    }
+
+    ksort($byClass);
+
+    foreach ($byClass as $class => $items) {
+        fwrite(STDERR, "\nClass: $class\n");
+        foreach ($items as $v) {
+            fwrite(STDERR, " • {$v['message']} #{$v['rule']}\n");
+        }
+    }
+
+    fwrite(STDERR, "\n");
+}

--- a/.piqule/phpstan/command.sh
+++ b/.piqule/phpstan/command.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG=".piqule/phpstan/phpstan.neon"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "PHPStan config not found: $CONFIG"
+  exit 1
+fi
+
+BIN="$(.piqule/_composer.sh phpstan)"
+
+exec .piqule/_skip_if_empty.sh src '*.php' PHPStan -- \
+  "$BIN" analyse \
+  -c "$CONFIG" \
+  --memory-limit=1G

--- a/.piqule/phpstan/phpstan.neon
+++ b/.piqule/phpstan/phpstan.neon
@@ -1,0 +1,27 @@
+includes:
+    - ../../vendor/phpstan/phpstan-strict-rules/rules.neon
+    - ../../vendor/haspadar/phpstan-rules/rules.neon
+
+parameters:
+    level: 9
+
+    paths:
+        - ../../src
+
+    errorFormat: table
+    reportUnmatchedIgnoredErrors: true
+
+    checkUninitializedProperties: true
+    checkClassCaseSensitivity: true
+    checkDynamicProperties: true
+
+    exceptions:
+        check:
+            missingCheckedExceptionInThrows: true
+        checkedExceptionClasses:
+            - \Throwable
+
+    haspadar:
+        afferentCoupling:
+            ignoreInterfaces: true
+

--- a/.piqule/phpunit/command.sh
+++ b/.piqule/phpunit/command.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG=".piqule/phpunit/phpunit.xml"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "PHPUnit config not found: $CONFIG" >&2
+  exit 1
+fi
+
+SEED="${PHPUNIT_SEED:-}"
+
+BIN="$(.piqule/_composer.sh phpunit)"
+
+ARGS=(-c "$CONFIG" --order-by=random)
+
+if [ -n "$SEED" ]; then
+  case "$SEED" in
+    (''|*[!0-9]*)
+      echo "PHPUNIT_SEED must be a positive integer, got: $SEED" >&2
+      exit 1
+      ;;
+  esac
+
+  if [ "$SEED" -eq 0 ]; then
+    echo "PHPUNIT_SEED must be greater than zero" >&2
+    exit 1
+  fi
+
+  ARGS+=(--random-order-seed="$SEED")
+fi
+
+PHP_OPTIONS_STR="-d memory_limit=1G"
+PHP_OPTIONS=()
+if [ -n "$PHP_OPTIONS_STR" ]; then
+  read -ra PHP_OPTIONS <<< "$PHP_OPTIONS_STR"
+fi
+
+PHP_OPTIONS_RC=0
+PHP_OPTIONS_DIAG=$(php "${PHP_OPTIONS[@]+"${PHP_OPTIONS[@]}"}" -r 'exit(0);' 2>&1 >/dev/null) || PHP_OPTIONS_RC=$?
+if [ "$PHP_OPTIONS_RC" -ne 0 ] || [ -n "$PHP_OPTIONS_DIAG" ]; then
+  echo "Invalid phpunit.php_options: $PHP_OPTIONS_STR" >&2
+  [ -n "$PHP_OPTIONS_DIAG" ] && printf '%s\n' "$PHP_OPTIONS_DIAG" >&2
+  exit 1
+fi
+
+COVERAGE_FILE=".piqule/codecov/coverage.xml"
+
+if php "${PHP_OPTIONS[@]+"${PHP_OPTIONS[@]}"}" -r 'exit(extension_loaded("xdebug") ? 0 : 1);' 2>/dev/null; then
+  mkdir -p "$(dirname "$COVERAGE_FILE")"
+  ARGS+=(--coverage-clover="$COVERAGE_FILE")
+  XDEBUG_MODE=coverage
+else
+  XDEBUG_MODE=off
+fi
+
+export XDEBUG_MODE
+
+exec .piqule/_skip_if_empty.sh tests '*Test.php' PHPUnit "PHP tests" -- \
+  php "${PHP_OPTIONS[@]+"${PHP_OPTIONS[@]}"}" "$BIN" "${ARGS[@]}"

--- a/.piqule/phpunit/phpunit.xml
+++ b/.piqule/phpunit/phpunit.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+        bootstrap="../../vendor/autoload.php"
+        colors="true"
+        executionOrder="random"
+        failOnWarning="true"
+        failOnRisky="true"
+        displayDetailsOnPhpunitDeprecations="true"
+        requireCoverageMetadata="false"
+        beStrictAboutCoverageMetadata="false"
+>
+    <testsuites>
+        <testsuite name="unit">
+            <directory suffix="Test.php">../../tests</directory>
+        </testsuite>
+
+        <testsuite name="integration">
+
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory suffix=".php">../../src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/.piqule/psalm/command.sh
+++ b/.piqule/psalm/command.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG=".piqule/psalm/psalm.xml"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "Psalm config not found: $CONFIG"
+  exit 1
+fi
+
+BIN="$(.piqule/_composer.sh psalm)"
+
+exec .piqule/_skip_if_empty.sh src '*.php' Psalm -- \
+  "$BIN" \
+  --root=. \
+  --config="$CONFIG" \
+  --no-cache

--- a/.piqule/psalm/psalm.xml
+++ b/.piqule/psalm/psalm.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<psalm
+        errorLevel="1"
+        xmlns="https://getpsalm.org/schema/config"
+        findUnusedCode="true"
+        findUnusedBaselineEntry="true"
+        ensureArrayStringOffsetsExist="true"
+        reportMixedIssues="true"
+>
+    <projectFiles>
+        <directory name="../../src" />
+
+        <ignoreFiles>
+
+        </ignoreFiles>
+    </projectFiles>
+    <issueHandlers>
+        <InvalidAttribute errorLevel="suppress" />
+        <UnusedClass errorLevel="suppress">
+            <errorLevel type="suppress">
+                <directory name="../../src" />
+            </errorLevel>
+        </UnusedClass>
+
+    </issueHandlers>
+</psalm>

--- a/.piqule/psalm/psalm.xml
+++ b/.piqule/psalm/psalm.xml
@@ -21,6 +21,5 @@
                 <directory name="../../src" />
             </errorLevel>
         </UnusedClass>
-
     </issueHandlers>
 </psalm>

--- a/.piqule/shellcheck/.shellcheckrc
+++ b/.piqule/shellcheck/.shellcheckrc
@@ -1,0 +1,18 @@
+# ============================================================
+# ShellCheck configuration (Piqule managed)
+# ============================================================
+
+# Target shell (bash, sh, dash, ksh)
+shell=bash
+
+# Minimum severity: error, warning, info, style
+severity=warning
+
+# Allow sourcing external files
+external-sources=true
+
+# Additional include path for sourced files (optional)
+# source-path=.
+
+# Excluded rules (one per line)
+

--- a/.piqule/shellcheck/command.sh
+++ b/.piqule/shellcheck/command.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG=".piqule/shellcheck/.shellcheckrc"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "ShellCheck config not found: $CONFIG"
+  exit 1
+fi
+
+# ============================================================
+# Collect shell scripts (portable, NUL-safe, no git)
+# ============================================================
+
+FILES=()
+while IFS= read -r -d '' file; do
+  # Include .sh files and files with bash/sh shebang
+  if [[ "$file" == *.sh ]] || \
+     head -n1 "$file" | grep -qE '^#!.*[[:space:]/](bash|sh)([[:space:]]|$)'; then
+    FILES+=("$file")
+  fi
+done < <(
+  find . \
+    -type f \
+    ! -path "./vendor/*" \
+    ! -path "./tests/*" \
+    ! -path "./.git/*" \
+    -print0
+)
+
+if [ ${#FILES[@]} -eq 0 ]; then
+  echo "No shell scripts found"
+  exit 0
+fi
+
+# ============================================================
+# Run ShellCheck (docker)
+# ============================================================
+
+.piqule/_docker.sh shellcheck \
+  --rcfile "$CONFIG" \
+  "${FILES[@]}"

--- a/.piqule/sonar/command.sh
+++ b/.piqule/sonar/command.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLOUD="true"
+if [ "$CLOUD" = "1" ] || [ "$CLOUD" = "true" ] || [ "$CLOUD" = "yes" ] || [ "$CLOUD" = "on" ]; then
+  printf '\033[33m[SKIP] SonarCloud automatic analysis — no local scanner needed\033[0m\n'
+  exit 0
+fi
+
+PROPS=".piqule/sonar/sonar-project.properties"
+
+if [ ! -f "$PROPS" ]; then
+  echo "SonarCloud config not found: $PROPS" >&2
+  exit 1
+fi
+
+if [ -z "${SONAR_TOKEN:-}" ]; then
+  printf '\033[33m[TIP] Set SONAR_TOKEN to enable SonarCloud analysis\033[0m\n'
+  printf '\033[33m      Get token at: https://sonarcloud.io/account/security\033[0m\n'
+  printf '\033[33m      ● export SONAR_TOKEN=<your-token>     (bash/zsh)\033[0m\n'
+  printf '\033[33m      ● set -Ux SONAR_TOKEN <your-token>    (fish)\033[0m\n'
+  exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Error: docker is not installed or not in PATH" >&2
+  exit 1
+fi
+
+COVERAGE_FILE=".piqule/codecov/coverage.xml"
+if [ -f "$COVERAGE_FILE" ]; then
+  ESCAPED_PWD=$(printf '%s' "$(pwd)" | sed 's/[&/\]/\\&/g')
+  sed "s|${ESCAPED_PWD}/||g" "$COVERAGE_FILE" > "${COVERAGE_FILE}.tmp" \
+    && mv "${COVERAGE_FILE}.tmp" "$COVERAGE_FILE"
+else
+  printf '\033[33m[TIP] Run piqule check phpunit first to include coverage in SonarCloud analysis\033[0m\n'
+fi
+
+PROJECT_ROOT="$(pwd)"
+IMAGE="${PIQULE_INFRA_IMAGE:-ghcr.io/haspadar/piqule-infra@sha256:5dc15e7dba7dbb8ec6060d01e40858947dcaa902e5af8b64921beef3fe63611f}"
+
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  -e SONAR_TOKEN="$SONAR_TOKEN" \
+  -e HOME=/tmp \
+  -v "$PROJECT_ROOT:/project" \
+  -w /project \
+  "$IMAGE" \
+  sonar-scanner -Dproject.settings="$PROPS" -Dsonar.qualitygate.wait=true

--- a/.piqule/sonar/sonar-project.properties
+++ b/.piqule/sonar/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.organization=
+sonar.projectKey=
+sonar.sources=src
+sonar.tests=tests
+sonar.exclusions=
+sonar.php.coverage.reportPaths=.piqule/codecov/coverage.xml

--- a/.piqule/typos/_typos.toml
+++ b/.piqule/typos/_typos.toml
@@ -1,0 +1,12 @@
+# Typos configuration
+# Docs: https://github.com/crate-ci/typos
+
+[default]
+binary = false
+
+[files]
+extend-exclude = [
+    "vendor/",
+    "tests/",
+    ".git/",
+]

--- a/.piqule/typos/command.sh
+++ b/.piqule/typos/command.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG=".piqule/typos/_typos.toml"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "Typos config not found: $CONFIG"
+  exit 1
+fi
+
+.piqule/_docker.sh typos \
+  --config "$CONFIG"

--- a/.piqule/yamllint/.yamllint.yml
+++ b/.piqule/yamllint/.yamllint.yml
@@ -1,0 +1,21 @@
+extends: default
+
+ignore: |
+  vendor/**
+  tests/**
+  .git/**
+  .piqule/**/html/**
+  .piqule/**/coverage-report/**
+
+rules:
+  document-start: disable
+
+  # truthy is disabled intentionally to avoid false-positives
+  # in GitHub Actions and CI-related YAML files
+  truthy: disable
+
+  # line-length max is configurable via yamllint.line_length.max; longer limits are common
+  # in CI workflows where commands cannot be easily split across lines
+  line-length:
+    max: 120
+    level: warning

--- a/.piqule/yamllint/command.sh
+++ b/.piqule/yamllint/command.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG=".piqule/yamllint/.yamllint.yml"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "Yamllint config not found: $CONFIG"
+  exit 1
+fi
+
+.piqule/_docker.sh yamllint \
+  -c "$CONFIG" \
+  .

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Kanstantsin Mesnik
+Copyright (c) 2025–2026 Konstantinas Mesnikas
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.lock
+++ b/composer.lock
@@ -1872,12 +1872,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/piqule.git",
-                "reference": "3b96447a796aedb70579c63b0d53a77239f1c69d"
+                "reference": "01dc7fda0396d56583014a4c4ee229c58b0705ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/piqule/zipball/3b96447a796aedb70579c63b0d53a77239f1c69d",
-                "reference": "3b96447a796aedb70579c63b0d53a77239f1c69d",
+                "url": "https://api.github.com/repos/haspadar/piqule/zipball/01dc7fda0396d56583014a4c4ee229c58b0705ad",
+                "reference": "01dc7fda0396d56583014a4c4ee229c58b0705ad",
                 "shasum": ""
             },
             "require": {
@@ -1925,7 +1925,7 @@
                 "issues": "https://github.com/haspadar/piqule/issues",
                 "source": "https://github.com/haspadar/piqule/tree/main"
             },
-            "time": "2026-04-23T14:38:10+00:00"
+            "time": "2026-04-23T21:23:37+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",

--- a/src/Func/BiFunc.php
+++ b/src/Func/BiFunc.php
@@ -10,7 +10,6 @@ namespace Primus\Func;
  * @template X
  * @template Y
  * @template Z
- *
  * @since 0.3
  */
 interface BiFunc

--- a/src/Func/BiFunc.php
+++ b/src/Func/BiFunc.php
@@ -20,6 +20,7 @@ interface BiFunc
      * @param X $first
      * @param Y $second
      * @return Z
+     * @psalm-suppress PossiblyUnusedMethod Public API of the library
      */
     public function apply(mixed $first, mixed $second): mixed;
 }

--- a/src/Func/BiFuncOf.php
+++ b/src/Func/BiFuncOf.php
@@ -14,7 +14,6 @@ use Override;
  * @template Y
  * @template Z
  * @implements BiFunc<X, Y, Z>
- *
  * @since 0.3
  */
 final readonly class BiFuncOf implements BiFunc

--- a/src/Func/BiFuncOf.php
+++ b/src/Func/BiFuncOf.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Primus\Func;
 
 use Closure;
+use Override;
 
 /**
  * Wraps a {@see Closure} as a {@see BiFunc}.
@@ -23,11 +24,9 @@ final readonly class BiFuncOf implements BiFunc
      *
      * @param Closure(X, Y): Z $origin The closure to wrap.
      */
-    public function __construct(private Closure $origin)
-    {
-    }
+    public function __construct(private Closure $origin) {}
 
-    #[\Override]
+    #[Override]
     public function apply(mixed $first, mixed $second): mixed
     {
         return ($this->origin)($first, $second);

--- a/src/Func/BiProc.php
+++ b/src/Func/BiProc.php
@@ -9,7 +9,6 @@ namespace Primus\Func;
  *
  * @template X
  * @template Y
- *
  * @since 0.3
  */
 interface BiProc

--- a/src/Func/BiProc.php
+++ b/src/Func/BiProc.php
@@ -18,6 +18,7 @@ interface BiProc
      *
      * @param X $first
      * @param Y $second
+     * @psalm-suppress PossiblyUnusedMethod Public API of the library
      */
     public function exec(mixed $first, mixed $second): void;
 }

--- a/src/Func/BiProcOf.php
+++ b/src/Func/BiProcOf.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Primus\Func;
 
 use Closure;
+use Override;
 
 /**
  * Wraps a {@see Closure} as a {@see BiProc}.
@@ -22,11 +23,9 @@ final readonly class BiProcOf implements BiProc
      *
      * @param Closure(X, Y): void $origin The closure to wrap.
      */
-    public function __construct(private Closure $origin)
-    {
-    }
+    public function __construct(private Closure $origin) {}
 
-    #[\Override]
+    #[Override]
     public function exec(mixed $first, mixed $second): void
     {
         ($this->origin)($first, $second);

--- a/src/Func/BiProcOf.php
+++ b/src/Func/BiProcOf.php
@@ -13,7 +13,6 @@ use Override;
  * @template X
  * @template Y
  * @implements BiProc<X, Y>
- *
  * @since 0.3
  */
 final readonly class BiProcOf implements BiProc

--- a/src/Func/Func.php
+++ b/src/Func/Func.php
@@ -9,7 +9,6 @@ namespace Primus\Func;
  *
  * @template I
  * @template O
- *
  * @since 0.3
  */
 interface Func

--- a/src/Func/FuncEnvelope.php
+++ b/src/Func/FuncEnvelope.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Primus\Func;
 
+use Override;
+
 /**
  * Envelope for {@see Func}.
  *
@@ -25,11 +27,9 @@ abstract readonly class FuncEnvelope implements Func
      *
      * @param Func<I, O> $origin The wrapped function.
      */
-    public function __construct(private Func $origin)
-    {
-    }
+    public function __construct(private Func $origin) {}
 
-    #[\Override]
+    #[Override]
     public function apply(mixed $input): mixed
     {
         return $this->origin->apply($input);

--- a/src/Func/FuncOf.php
+++ b/src/Func/FuncOf.php
@@ -13,7 +13,6 @@ use Override;
  * @template I
  * @template O
  * @implements Func<I, O>
- *
  * @since 0.3
  */
 final readonly class FuncOf implements Func

--- a/src/Func/FuncOf.php
+++ b/src/Func/FuncOf.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Primus\Func;
 
 use Closure;
+use Override;
 
 /**
  * Wraps a {@see Closure} as a {@see Func}.
@@ -22,11 +23,9 @@ final readonly class FuncOf implements Func
      *
      * @param Closure(I):O $origin The closure to wrap.
      */
-    public function __construct(private Closure $origin)
-    {
-    }
+    public function __construct(private Closure $origin) {}
 
-    #[\Override]
+    #[Override]
     public function apply($input): mixed
     {
         return ($this->origin)($input);

--- a/src/Func/FuncWithFallback.php
+++ b/src/Func/FuncWithFallback.php
@@ -36,8 +36,8 @@ final readonly class FuncWithFallback extends FuncEnvelope
                     } catch (Exception) { // @phpstan-ignore haspadar.illegalCatch
                         return $fallback->apply($input);
                     }
-                }
-            )
+                },
+            ),
         );
     }
 }

--- a/src/Func/FuncWithFallback.php
+++ b/src/Func/FuncWithFallback.php
@@ -30,10 +30,11 @@ final readonly class FuncWithFallback extends FuncEnvelope
                  * @param I $input
                  * @return O
                  */
-                function ($input) use ($origin, $fallback) {
+                static function ($input) use ($origin, $fallback) {
                     try {
                         return $origin->apply($input);
-                    } catch (Exception) { // @phpstan-ignore haspadar.illegalCatch
+                        // @phpstan-ignore-next-line haspadar.illegalCatch
+                    } catch (Exception) {
                         return $fallback->apply($input);
                     }
                 },

--- a/src/Func/Predicate.php
+++ b/src/Func/Predicate.php
@@ -9,7 +9,6 @@ namespace Primus\Func;
  *
  * @template X
  * @extends Func<X, bool>
- *
  * @since 0.3
  */
 interface Predicate extends Func {}

--- a/src/Func/Predicate.php
+++ b/src/Func/Predicate.php
@@ -12,6 +12,4 @@ namespace Primus\Func;
  *
  * @since 0.3
  */
-interface Predicate extends Func
-{
-}
+interface Predicate extends Func {}

--- a/src/Func/PredicateOf.php
+++ b/src/Func/PredicateOf.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Primus\Func;
 
 use Closure;
+use Override;
 
 /**
  * Wraps a {@see Closure} as a {@see Predicate}.
@@ -21,11 +22,9 @@ final readonly class PredicateOf implements Predicate
      *
      * @param Closure(X): bool $origin The closure to wrap.
      */
-    public function __construct(private Closure $origin)
-    {
-    }
+    public function __construct(private Closure $origin) {}
 
-    #[\Override]
+    #[Override]
     public function apply(mixed $input): bool
     {
         return ($this->origin)($input);

--- a/src/Func/PredicateOf.php
+++ b/src/Func/PredicateOf.php
@@ -12,7 +12,6 @@ use Override;
  *
  * @template X
  * @implements Predicate<X>
- *
  * @since 0.3
  */
 final readonly class PredicateOf implements Predicate

--- a/src/Func/Proc.php
+++ b/src/Func/Proc.php
@@ -16,6 +16,7 @@ interface Proc
      * Execute the procedure.
      *
      * @param X $input
+     * @psalm-suppress PossiblyUnusedMethod Public API of the library
      */
     public function exec(mixed $input): void;
 }

--- a/src/Func/Proc.php
+++ b/src/Func/Proc.php
@@ -8,7 +8,6 @@ namespace Primus\Func;
  * Procedure from X with no result.
  *
  * @template X
- *
  * @since 0.3
  */
 interface Proc

--- a/src/Func/ProcOf.php
+++ b/src/Func/ProcOf.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Primus\Func;
 
 use Closure;
+use Override;
 
 /**
  * Wraps a {@see Closure} as a {@see Proc}.
@@ -21,11 +22,9 @@ final readonly class ProcOf implements Proc
      *
      * @param Closure(X): void $origin The closure to wrap.
      */
-    public function __construct(private Closure $origin)
-    {
-    }
+    public function __construct(private Closure $origin) {}
 
-    #[\Override]
+    #[Override]
     public function exec(mixed $input): void
     {
         ($this->origin)($input);

--- a/src/Func/ProcOf.php
+++ b/src/Func/ProcOf.php
@@ -12,7 +12,6 @@ use Override;
  *
  * @template X
  * @implements Proc<X>
- *
  * @since 0.3
  */
 final readonly class ProcOf implements Proc

--- a/src/Func/Repeated.php
+++ b/src/Func/Repeated.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Primus\Func;
 
+use Override;
+use RuntimeException;
+
 /**
  * Func applied multiple times sequentially.
  *
@@ -28,16 +31,15 @@ final readonly class Repeated implements Func
      */
     public function __construct(
         private Func $origin,
-        private int $times
-    ) {
-    }
+        private int $times,
+    ) {}
 
-    #[\Override]
+    #[Override]
     public function apply(mixed $input): mixed
     {
         if ($this->times <= 0) {
             /** @phpstan-ignore missingType.checkedException */
-            throw new \RuntimeException('Repeated time must be >= 1');
+            throw new RuntimeException('Repeated time must be >= 1');
         }
 
         $result = $input;

--- a/src/Func/Repeated.php
+++ b/src/Func/Repeated.php
@@ -29,10 +29,7 @@ final readonly class Repeated implements Func
      * @param Func<T, T> $origin The function to repeat.
      * @param int $times Number of sequential applications.
      */
-    public function __construct(
-        private Func $origin,
-        private int $times,
-    ) {}
+    public function __construct(private Func $origin, private int $times) {}
 
     #[Override]
     public function apply(mixed $input): mixed
@@ -43,6 +40,7 @@ final readonly class Repeated implements Func
         }
 
         $result = $input;
+
         for ($i = 0; $i < $this->times; $i++) {
             $result = $this->origin->apply($result);
         }

--- a/src/Func/StickyFunc.php
+++ b/src/Func/StickyFunc.php
@@ -43,6 +43,7 @@ final class StickyFunc implements Func
         $key = serialize($input);
         $this->cache[$key] ??= $this->origin->apply($input);
 
+        /** @psalm-suppress MixedReturnStatement Cache stores Y per contract, see @var */
         return $this->cache[$key];
     }
 }

--- a/src/Func/StickyFunc.php
+++ b/src/Func/StickyFunc.php
@@ -14,8 +14,8 @@ use Override;
  *
  * Example:
  *     $doubled = new StickyFunc(new FuncOf(fn(int $x): int => $x * 2));
- *     echo $doubled->apply(5);  // 10
- *     echo $doubled->apply(5);  // cached
+ *     echo $doubled->apply(5); // 10
+ *     echo $doubled->apply(5); // cached
  *
  * @template X
  * @template Y

--- a/src/Func/StickyFunc.php
+++ b/src/Func/StickyFunc.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Primus\Func;
 
+use Override;
+
 /**
  * Cached (sticky) {@see Func}.
  *
@@ -33,11 +35,9 @@ final class StickyFunc implements Func
      *
      * @param Func<X, Y> $origin The function whose results are cached.
      */
-    public function __construct(private readonly Func $origin)
-    {
-    }
+    public function __construct(private readonly Func $origin) {}
 
-    #[\Override]
+    #[Override]
     public function apply(mixed $input): mixed
     {
         $key = serialize($input);

--- a/src/Iterable/Filtered.php
+++ b/src/Iterable/Filtered.php
@@ -8,6 +8,7 @@ use Iterator;
 use IteratorAggregate;
 use Override;
 use Primus\Func\Predicate;
+use Primus\Iterator\Filtered as FilteredIterator;
 
 /**
  * Iterable that lazily filters values from another iterable using the provided predicate.
@@ -19,12 +20,11 @@ use Primus\Func\Predicate;
  *     );
  *
  *     foreach ($it as $v) {
- *         echo $v . ' ';   // 40
+ *         echo $v . ' '; // 40
  *     }
  *
  * @template T
  * @implements IteratorAggregate<T>
- *
  * @since 0.5
  */
 final readonly class Filtered implements IteratorAggregate
@@ -35,10 +35,7 @@ final readonly class Filtered implements IteratorAggregate
      * @param IteratorAggregate<T> $origin The origin iterable.
      * @param Predicate<T> $predicate The predicate used to filter values.
      */
-    public function __construct(
-        private IteratorAggregate $origin,
-        private Predicate $predicate,
-    ) {}
+    public function __construct(private IteratorAggregate $origin, private Predicate $predicate) {}
 
     #[Override]
     public function getIterator(): Iterator
@@ -46,6 +43,6 @@ final readonly class Filtered implements IteratorAggregate
         /** @var Iterator<mixed, T> $iterator */
         $iterator = $this->origin->getIterator();
 
-        return new \Primus\Iterator\Filtered($iterator, $this->predicate);
+        return new FilteredIterator($iterator, $this->predicate);
     }
 }

--- a/src/Iterable/Filtered.php
+++ b/src/Iterable/Filtered.php
@@ -6,6 +6,7 @@ namespace Primus\Iterable;
 
 use Iterator;
 use IteratorAggregate;
+use Override;
 use Primus\Func\Predicate;
 
 /**
@@ -37,13 +38,12 @@ final readonly class Filtered implements IteratorAggregate
     public function __construct(
         private IteratorAggregate $origin,
         private Predicate $predicate,
-    ) {
-    }
+    ) {}
 
-    #[\Override]
+    #[Override]
     public function getIterator(): Iterator
     {
-        /** @var Iterator<mixed,T> $iterator */
+        /** @var Iterator<mixed, T> $iterator */
         $iterator = $this->origin->getIterator();
 
         return new \Primus\Iterator\Filtered($iterator, $this->predicate);

--- a/src/Iterable/IterableOf.php
+++ b/src/Iterable/IterableOf.php
@@ -6,6 +6,7 @@ namespace Primus\Iterable;
 
 use Iterator;
 use IteratorAggregate;
+use Override;
 use Primus\Iterator\IteratorOf;
 
 /**
@@ -28,13 +29,11 @@ final readonly class IterableOf implements IteratorAggregate
     /**
      * Ctor.
      *
-     * @param array<mixed,T> $items The items to iterate over.
+     * @param array<mixed, T> $items The items to iterate over.
      */
-    public function __construct(private array $items)
-    {
-    }
+    public function __construct(private array $items) {}
 
-    #[\Override]
+    #[Override]
     public function getIterator(): Iterator
     {
         return new IteratorOf($this->items);

--- a/src/Iterable/IterableOf.php
+++ b/src/Iterable/IterableOf.php
@@ -21,7 +21,6 @@ use Primus\Iterator\IteratorOf;
  *
  * @template T
  * @implements IteratorAggregate<T>
- *
  * @since 0.5
  */
 final readonly class IterableOf implements IteratorAggregate

--- a/src/Iterable/Joined.php
+++ b/src/Iterable/Joined.php
@@ -6,6 +6,7 @@ namespace Primus\Iterable;
 
 use Iterator;
 use IteratorAggregate;
+use Override;
 
 /**
  * Iterable that joins multiple iterators into a single sequence.
@@ -20,14 +21,13 @@ final readonly class Joined implements IteratorAggregate
     /**
      * Ctor.
      *
-     * @param array<Iterator<int,T>> $iterators The iterators to join.
+     * @param list<Iterator<int, T>> $iterators The iterators to join.
      */
     public function __construct(
         private array $iterators,
-    ) {
-    }
+    ) {}
 
-    #[\Override]
+    #[Override]
     public function getIterator(): Iterator
     {
         return new \Primus\Iterator\Joined($this->iterators);

--- a/src/Iterable/Joined.php
+++ b/src/Iterable/Joined.php
@@ -7,13 +7,13 @@ namespace Primus\Iterable;
 use Iterator;
 use IteratorAggregate;
 use Override;
+use Primus\Iterator\Joined as JoinedIterator;
 
 /**
  * Iterable that joins multiple iterators into a single sequence.
  *
  * @template T
  * @implements IteratorAggregate<int, T>
- *
  * @since 0.5
  */
 final readonly class Joined implements IteratorAggregate
@@ -23,13 +23,11 @@ final readonly class Joined implements IteratorAggregate
      *
      * @param list<Iterator<int, T>> $iterators The iterators to join.
      */
-    public function __construct(
-        private array $iterators,
-    ) {}
+    public function __construct(private array $iterators) {}
 
     #[Override]
     public function getIterator(): Iterator
     {
-        return new \Primus\Iterator\Joined($this->iterators);
+        return new JoinedIterator($this->iterators);
     }
 }

--- a/src/Iterable/Mapped.php
+++ b/src/Iterable/Mapped.php
@@ -8,6 +8,7 @@ use Iterator;
 use IteratorAggregate;
 use Override;
 use Primus\Func\Func;
+use Primus\Iterator\Mapped as MappedIterator;
 
 /**
  * Iterable that lazily transforms each element of the origin iterable using the provided function.
@@ -26,7 +27,6 @@ use Primus\Func\Func;
  * @template X
  * @template Y
  * @implements IteratorAggregate<Y>
- *
  * @since 0.5
  */
 final readonly class Mapped implements IteratorAggregate
@@ -37,10 +37,7 @@ final readonly class Mapped implements IteratorAggregate
      * @param IteratorAggregate<X> $origin The origin iterable.
      * @param Func<X, Y> $func The function used to transform elements.
      */
-    public function __construct(
-        private IteratorAggregate $origin,
-        private Func $func,
-    ) {}
+    public function __construct(private IteratorAggregate $origin, private Func $func) {}
 
     #[Override]
     public function getIterator(): Iterator
@@ -48,7 +45,7 @@ final readonly class Mapped implements IteratorAggregate
         /** @var Iterator<mixed, X> $iterator */
         $iterator = $this->origin->getIterator();
 
-        return new \Primus\Iterator\Mapped(
+        return new MappedIterator(
             $iterator,
             $this->func,
         );

--- a/src/Iterable/Mapped.php
+++ b/src/Iterable/Mapped.php
@@ -6,6 +6,7 @@ namespace Primus\Iterable;
 
 use Iterator;
 use IteratorAggregate;
+use Override;
 use Primus\Func\Func;
 
 /**
@@ -39,13 +40,12 @@ final readonly class Mapped implements IteratorAggregate
     public function __construct(
         private IteratorAggregate $origin,
         private Func $func,
-    ) {
-    }
+    ) {}
 
-    #[\Override]
+    #[Override]
     public function getIterator(): Iterator
     {
-        /** @var Iterator<mixed,X> $iterator */
+        /** @var Iterator<mixed, X> $iterator */
         $iterator = $this->origin->getIterator();
 
         return new \Primus\Iterator\Mapped(

--- a/src/Iterable/NoNulls.php
+++ b/src/Iterable/NoNulls.php
@@ -7,13 +7,13 @@ namespace Primus\Iterable;
 use Iterator;
 use IteratorAggregate;
 use Override;
+use Primus\Iterator\NoNulls as NoNullsIterator;
 
 /**
  * Iterable that forbids NULL values.
  *
  * @template T
  * @implements IteratorAggregate<T>
- *
  * @since 0.5
  */
 final readonly class NoNulls implements IteratorAggregate
@@ -23,13 +23,11 @@ final readonly class NoNulls implements IteratorAggregate
      *
      * @param Iterator<int, T|null> $origin The iterator validated for non-null values; nulls trigger RuntimeException on access.
      */
-    public function __construct(
-        private Iterator $origin,
-    ) {}
+    public function __construct(private Iterator $origin) {}
 
     #[Override]
     public function getIterator(): Iterator
     {
-        return new \Primus\Iterator\NoNulls($this->origin);
+        return new NoNullsIterator($this->origin);
     }
 }

--- a/src/Iterable/NoNulls.php
+++ b/src/Iterable/NoNulls.php
@@ -6,6 +6,7 @@ namespace Primus\Iterable;
 
 use Iterator;
 use IteratorAggregate;
+use Override;
 
 /**
  * Iterable that forbids NULL values.
@@ -23,11 +24,10 @@ final readonly class NoNulls implements IteratorAggregate
      * @param Iterator<int, T|null> $origin The iterator validated for non-null values; nulls trigger RuntimeException on access.
      */
     public function __construct(
-        private Iterator $origin
-    ) {
-    }
+        private Iterator $origin,
+    ) {}
 
-    #[\Override]
+    #[Override]
     public function getIterator(): Iterator
     {
         return new \Primus\Iterator\NoNulls($this->origin);

--- a/src/Iterator/Filtered.php
+++ b/src/Iterator/Filtered.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Primus\Iterator;
 
 use Iterator;
+use Override;
 use Primus\Func\Predicate;
 use RuntimeException;
 
@@ -23,22 +24,21 @@ final class Filtered implements Iterator
      * Ctor.
      *
      * @param Iterator<mixed, T> $origin The origin iterator.
-     * @param Predicate<T>       $predicate The predicate used to filter values.
+     * @param Predicate<T> $predicate The predicate used to filter values.
      */
     public function __construct(
         private readonly Iterator $origin,
-        private readonly Predicate $predicate
-    ) {
-    }
+        private readonly Predicate $predicate,
+    ) {}
 
-    #[\Override]
+    #[Override]
     public function rewind(): void
     {
         $this->origin->rewind();
         $this->advance();
     }
 
-    #[\Override]
+    #[Override]
     public function next(): void
     {
         if (!$this->isValid) {
@@ -50,27 +50,29 @@ final class Filtered implements Iterator
         $this->advance();
     }
 
-    #[\Override]
+    #[Override]
     public function current(): mixed
     {
         if (!$this->isValid) {
             /** @phpstan-ignore missingType.checkedException */
             throw new RuntimeException('Iterator is past the end');
         }
+
         return $this->origin->current();
     }
 
-    #[\Override]
+    #[Override]
     public function key(): mixed
     {
         if (!$this->isValid) {
             /** @phpstan-ignore missingType.checkedException */
             throw new RuntimeException('Iterator is past the end');
         }
+
         return $this->origin->key();
     }
 
-    #[\Override]
+    #[Override]
     public function valid(): bool
     {
         return $this->isValid;
@@ -86,6 +88,7 @@ final class Filtered implements Iterator
 
             if ($this->predicate->apply($value)) {
                 $this->isValid = true;
+
                 return;
             }
 

--- a/src/Iterator/IteratorOf.php
+++ b/src/Iterator/IteratorOf.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Primus\Iterator;
 
 use Iterator;
+use Override;
+use RuntimeException;
 
 /**
  * Simple iterator over a PHP array.
@@ -30,46 +32,44 @@ final class IteratorOf implements Iterator
      *
      * @param array<array-key, T> $items The items to iterate over.
      */
-    public function __construct(private readonly array $items)
-    {
-    }
+    public function __construct(private readonly array $items) {}
 
-    #[\Override]
+    #[Override]
     public function rewind(): void
     {
         $this->keys = array_keys($this->items);
         $this->position = 0;
     }
 
-    #[\Override]
+    #[Override]
     public function current(): mixed
     {
         if (!$this->valid()) {
             /** @phpstan-ignore missingType.checkedException */
-            throw new \RuntimeException('Iterator is past the end');
+            throw new RuntimeException('Iterator is past the end');
         }
 
         return $this->items[$this->keys[$this->position]];
     }
 
-    #[\Override]
+    #[Override]
     public function key(): int|string
     {
         if (!$this->valid()) {
             /** @phpstan-ignore missingType.checkedException */
-            throw new \RuntimeException('Iterator key is undefined because iterator is past the end');
+            throw new RuntimeException('Iterator key is undefined because iterator is past the end');
         }
 
         return $this->keys[$this->position];
     }
 
-    #[\Override]
+    #[Override]
     public function next(): void
     {
         $this->position++;
     }
 
-    #[\Override]
+    #[Override]
     public function valid(): bool
     {
         return $this->position < count($this->keys);

--- a/src/Iterator/IteratorOf.php
+++ b/src/Iterator/IteratorOf.php
@@ -13,7 +13,6 @@ use RuntimeException;
  *
  * @template T
  * @implements Iterator<array-key, T>
- *
  * @since 0.5
  */
 final class IteratorOf implements Iterator

--- a/src/Iterator/Joined.php
+++ b/src/Iterator/Joined.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Primus\Iterator;
 
 use Iterator;
+use Override;
 use RuntimeException;
 
 /**
@@ -21,12 +22,12 @@ final class Joined implements Iterator
     private int $position = 0;
 
     /**
-     * @var Iterator<int,Iterator<int,T>>
+     * @var Iterator<int, Iterator<int, T>>
      */
     private readonly Iterator $outer;
 
     /**
-     * @var Iterator<int,T>
+     * @var Iterator<int, T>
      * @phpstan-ignore haspadar.immutable
      */
     private Iterator $current;
@@ -34,7 +35,7 @@ final class Joined implements Iterator
     /**
      * Ctor.
      *
-     * @param array<int,Iterator<int,T>> $iterators The iterators to concatenate.
+     * @param array<int, Iterator<int, T>> $iterators The iterators to concatenate.
      */
     public function __construct(array $iterators)
     {
@@ -42,7 +43,7 @@ final class Joined implements Iterator
         $this->current = new IteratorOf([]);
     }
 
-    #[\Override]
+    #[Override]
     public function rewind(): void
     {
         $this->position = 0;
@@ -50,6 +51,7 @@ final class Joined implements Iterator
 
         if (!$this->outer->valid()) {
             $this->current = new IteratorOf([]);
+
             return;
         }
 
@@ -59,7 +61,7 @@ final class Joined implements Iterator
         $this->advance();
     }
 
-    #[\Override]
+    #[Override]
     public function current(): mixed
     {
         if (!$this->valid()) {
@@ -70,7 +72,7 @@ final class Joined implements Iterator
         return $this->current->current();
     }
 
-    #[\Override]
+    #[Override]
     public function key(): int
     {
         if (!$this->valid()) {
@@ -81,7 +83,7 @@ final class Joined implements Iterator
         return $this->position;
     }
 
-    #[\Override]
+    #[Override]
     public function next(): void
     {
         if (!$this->valid()) {
@@ -95,7 +97,7 @@ final class Joined implements Iterator
         $this->advance();
     }
 
-    #[\Override]
+    #[Override]
     public function valid(): bool
     {
         return $this->current->valid();

--- a/src/Iterator/Joined.php
+++ b/src/Iterator/Joined.php
@@ -52,7 +52,9 @@ final class Joined implements Iterator
             return;
         }
 
+        /** @psalm-suppress PossiblyNullPropertyAssignmentValue Guarded by valid() above */
         $this->current = $this->outer->current();
+        /** @psalm-suppress PossiblyNullReference Guarded by valid() above */
         $this->current->rewind();
 
         $this->advance();
@@ -109,7 +111,9 @@ final class Joined implements Iterator
             $this->outer->next();
 
             if ($this->outer->valid()) {
+                /** @psalm-suppress PossiblyNullPropertyAssignmentValue Guarded by valid() above */
                 $this->current = $this->outer->current();
+                /** @psalm-suppress PossiblyNullReference Guarded by valid() above */
                 $this->current->rewind();
             }
         }

--- a/src/Iterator/Joined.php
+++ b/src/Iterator/Joined.php
@@ -13,7 +13,6 @@ use RuntimeException;
  *
  * @template T
  * @implements Iterator<int, T>
- *
  * @since 0.5
  */
 final class Joined implements Iterator
@@ -21,9 +20,7 @@ final class Joined implements Iterator
     /** @phpstan-ignore haspadar.immutable */
     private int $position = 0;
 
-    /**
-     * @var Iterator<int, Iterator<int, T>>
-     */
+    /** @var Iterator<int, Iterator<int, T>> */
     private readonly Iterator $outer;
 
     /**

--- a/src/Iterator/Mapped.php
+++ b/src/Iterator/Mapped.php
@@ -15,7 +15,6 @@ use RuntimeException;
  * @template X
  * @template Y
  * @implements Iterator<mixed, Y>
- *
  * @since 0.5
  */
 final class Mapped implements Iterator
@@ -29,10 +28,7 @@ final class Mapped implements Iterator
      * @param Iterator<mixed, X> $origin The origin iterator.
      * @param Func<X, Y> $func The function used to transform elements.
      */
-    public function __construct(
-        private readonly Iterator $origin,
-        private readonly Func $func,
-    ) {}
+    public function __construct(private readonly Iterator $origin, private readonly Func $func) {}
 
     #[Override]
     public function rewind(): void

--- a/src/Iterator/Mapped.php
+++ b/src/Iterator/Mapped.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Primus\Iterator;
 
 use Iterator;
+use Override;
 use Primus\Func\Func;
+use RuntimeException;
 
 /**
  * Iterator that lazily transforms each element of the origin iterator using the provided function.
@@ -30,22 +32,21 @@ final class Mapped implements Iterator
     public function __construct(
         private readonly Iterator $origin,
         private readonly Func $func,
-    ) {
-    }
+    ) {}
 
-    #[\Override]
+    #[Override]
     public function rewind(): void
     {
         $this->position = 0;
         $this->origin->rewind();
     }
 
-    #[\Override]
+    #[Override]
     public function current(): mixed
     {
         if (!$this->valid()) {
             /** @phpstan-ignore missingType.checkedException */
-            throw new \RuntimeException('Mapped: current() past end');
+            throw new RuntimeException('Mapped: current() past end');
         }
 
         /** @var X $value */
@@ -54,30 +55,30 @@ final class Mapped implements Iterator
         return $this->func->apply($value);
     }
 
-    #[\Override]
+    #[Override]
     public function key(): int
     {
         if (!$this->valid()) {
             /** @phpstan-ignore missingType.checkedException */
-            throw new \RuntimeException('Mapped: key() past end');
+            throw new RuntimeException('Mapped: key() past end');
         }
 
         return $this->position;
     }
 
-    #[\Override]
+    #[Override]
     public function next(): void
     {
         if (!$this->valid()) {
             /** @phpstan-ignore missingType.checkedException */
-            throw new \RuntimeException('Mapped: next() past end');
+            throw new RuntimeException('Mapped: next() past end');
         }
 
         $this->position++;
         $this->origin->next();
     }
 
-    #[\Override]
+    #[Override]
     public function valid(): bool
     {
         return $this->origin->valid();

--- a/src/Iterator/NoNulls.php
+++ b/src/Iterator/NoNulls.php
@@ -13,7 +13,6 @@ use RuntimeException;
  *
  * @template T
  * @implements Iterator<mixed, T>
- *
  * @since 0.5
  */
 final class NoNulls implements Iterator
@@ -26,9 +25,7 @@ final class NoNulls implements Iterator
      *
      * @param Iterator<mixed, T|null> $origin The iterator validated for non-null values; nulls trigger RuntimeException on access.
      */
-    public function __construct(
-        private readonly Iterator $origin,
-    ) {}
+    public function __construct(private readonly Iterator $origin) {}
 
     #[Override]
     public function rewind(): void

--- a/src/Iterator/NoNulls.php
+++ b/src/Iterator/NoNulls.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Primus\Iterator;
 
 use Iterator;
+use Override;
 use RuntimeException;
 
 /**
@@ -26,18 +27,17 @@ final class NoNulls implements Iterator
      * @param Iterator<mixed, T|null> $origin The iterator validated for non-null values; nulls trigger RuntimeException on access.
      */
     public function __construct(
-        private readonly Iterator $origin
-    ) {
-    }
+        private readonly Iterator $origin,
+    ) {}
 
-    #[\Override]
+    #[Override]
     public function rewind(): void
     {
         $this->position = 0;
         $this->origin->rewind();
     }
 
-    #[\Override]
+    #[Override]
     public function current(): mixed
     {
         if (!$this->valid()) {
@@ -55,7 +55,7 @@ final class NoNulls implements Iterator
         return $value;
     }
 
-    #[\Override]
+    #[Override]
     public function key(): int
     {
         if (!$this->valid()) {
@@ -66,7 +66,7 @@ final class NoNulls implements Iterator
         return $this->position;
     }
 
-    #[\Override]
+    #[Override]
     public function next(): void
     {
         if (!$this->valid()) {
@@ -78,7 +78,7 @@ final class NoNulls implements Iterator
         $this->origin->next();
     }
 
-    #[\Override]
+    #[Override]
     public function valid(): bool
     {
         return $this->origin->valid();

--- a/src/Logic/IsAlphanumeric.php
+++ b/src/Logic/IsAlphanumeric.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Primus\Logic;
 
+use Override;
+
 /**
  * Logic that returns true if text contains only alphanumeric characters (A–Z, a–z, 0–9).
  *
  * Example:
  *     new IsAlphanumeric(new TextOf("abc123")) → true
- *
  */
 final readonly class IsAlphanumeric extends LogicEnvelope
 {
-    #[\Override]
+    #[Override]
     public function value(): bool
     {
         return ctype_alnum($this->text->value());

--- a/src/Logic/IsEmail.php
+++ b/src/Logic/IsEmail.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Primus\Logic;
 
+use Override;
+
 /**
  * Logic that returns true if the text is a valid email.
- *
  */
 final readonly class IsEmail extends LogicEnvelope
 {
-    #[\Override]
+    #[Override]
     public function value(): bool
     {
         return filter_var($this->text->value(), FILTER_VALIDATE_EMAIL) !== false;

--- a/src/Logic/IsEmpty.php
+++ b/src/Logic/IsEmpty.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Primus\Logic;
 
+use Override;
 use Primus\Text\Trimmed;
 
 /**
  * Logic that returns true if the text is empty or whitespace-only.
- *
  */
 final readonly class IsEmpty extends LogicEnvelope
 {
-    #[\Override]
+    #[Override]
     public function value(): bool
     {
         return (new Trimmed($this->text))->value() === '';

--- a/src/Logic/IsNumeric.php
+++ b/src/Logic/IsNumeric.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Primus\Logic;
 
+use Override;
+
 /**
  * Logic that returns true if text represents a valid numeric value.
  *
@@ -14,11 +16,10 @@ namespace Primus\Logic;
  *     new IsNumeric(new TextOf("3.14")) → true
  *     new IsNumeric(new TextOf("1e10")) → true
  *     new IsNumeric(new TextOf("abc")) → false
- *
  */
 final readonly class IsNumeric extends LogicEnvelope
 {
-    #[\Override]
+    #[Override]
     public function value(): bool
     {
         $value = $this->text->value();

--- a/src/Logic/IsUrl.php
+++ b/src/Logic/IsUrl.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Primus\Logic;
 
 use Override;
-use Primus\Text\Text;
 
 /**
  * Logic that returns true if a {@see Text} is a valid URL.

--- a/src/Logic/IsUrl.php
+++ b/src/Logic/IsUrl.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Primus\Logic;
 
+use Override;
 use Primus\Text\Text;
 
 /**
@@ -12,11 +13,10 @@ use Primus\Text\Text;
  * Example:
  *     new IsUrl(new TextOf("https://example.com")) → true
  *     new IsUrl(new TextOf("not-a-url")) → false
- *
  */
 final readonly class IsUrl extends LogicEnvelope
 {
-    #[\Override]
+    #[Override]
     public function value(): bool
     {
         return filter_var($this->text->value(), FILTER_VALIDATE_URL) !== false;

--- a/src/Logic/IsUuid.php
+++ b/src/Logic/IsUuid.php
@@ -4,20 +4,21 @@ declare(strict_types=1);
 
 namespace Primus\Logic;
 
+use Override;
+
 /**
  * Logic that returns true if the text is a valid UUID v1–v5.
  *
  * Matches 8-4-4-4-12 pattern with correct version and variant bits.
- *
  */
 final readonly class IsUuid extends LogicEnvelope
 {
-    #[\Override]
+    #[Override]
     public function value(): bool
     {
         return preg_match(
             '/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i',
-            $this->text->value()
+            $this->text->value(),
         ) === 1;
     }
 }

--- a/src/Logic/Logic.php
+++ b/src/Logic/Logic.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Primus\Logic;
 
+use Override;
 use Primus\Scalar\Scalar;
 
 /**
@@ -12,11 +13,9 @@ use Primus\Scalar\Scalar;
  * Represents a boolean condition.
  *
  * @extends Scalar<bool>
- *
  */
 interface Logic extends Scalar
 {
-    #[\Override]
+    #[Override]
     public function value(): bool;
-
 }

--- a/src/Logic/LogicEnvelope.php
+++ b/src/Logic/LogicEnvelope.php
@@ -16,6 +16,7 @@ abstract readonly class LogicEnvelope implements Logic
      * Ctor.
      *
      * @param Text $text The text to evaluate.
+     * @psalm-suppress PossiblyUnusedMethod Public API of the library
      */
     public function __construct(protected Text $text) {}
 

--- a/src/Logic/LogicEnvelope.php
+++ b/src/Logic/LogicEnvelope.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Primus\Logic;
 
+use Override;
 use Primus\Text\Text;
 
 /**
  * Envelope for {@see Logic}, delegating the call to the origin.
- *
  */
 abstract readonly class LogicEnvelope implements Logic
 {
@@ -17,10 +17,8 @@ abstract readonly class LogicEnvelope implements Logic
      *
      * @param Text $text The text to evaluate.
      */
-    public function __construct(protected Text $text)
-    {
-    }
+    public function __construct(protected Text $text) {}
 
-    #[\Override]
+    #[Override]
     abstract public function value(): bool;
 }

--- a/src/Logic/No.php
+++ b/src/Logic/No.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Primus\Logic;
 
+use Override;
+
 /**
  * Logic that always returns false.
  *
@@ -13,7 +15,7 @@ namespace Primus\Logic;
  */
 final readonly class No implements Logic
 {
-    #[\Override]
+    #[Override]
     public function value(): bool
     {
         return false;

--- a/src/Logic/Yes.php
+++ b/src/Logic/Yes.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Primus\Logic;
 
+use Override;
+
 /**
  * Logic that always returns true.
  *
@@ -13,7 +15,7 @@ namespace Primus\Logic;
  */
 final readonly class Yes implements Logic
 {
-    #[\Override]
+    #[Override]
     public function value(): bool
     {
         return true;

--- a/src/Scalar/AndOf.php
+++ b/src/Scalar/AndOf.php
@@ -29,14 +29,14 @@ final readonly class AndOf extends ScalarEnvelope
     {
         parent::__construct(
             new ScalarOf(
-                function () use ($conditions): bool {
+                static function () use ($conditions): bool {
                     if ($conditions === []) {
                         throw new InvalidArgumentException('AndOf requires at least one condition');
                     }
 
                     return array_reduce(
                         $conditions,
-                        fn(bool $carry, Scalar $cond): bool => $carry && $cond->value(),
+                        static fn(bool $carry, Scalar $cond): bool => $carry && $cond->value(),
                         true,
                     );
                 },

--- a/src/Scalar/AndOf.php
+++ b/src/Scalar/AndOf.php
@@ -36,7 +36,7 @@ final readonly class AndOf extends ScalarEnvelope
 
                     return array_reduce(
                         $conditions,
-                        fn (bool $carry, Scalar $cond): bool => $carry && $cond->value(),
+                        fn(bool $carry, Scalar $cond): bool => $carry && $cond->value(),
                         true,
                     );
                 },

--- a/src/Scalar/Between.php
+++ b/src/Scalar/Between.php
@@ -33,8 +33,8 @@ final readonly class Between extends ScalarEnvelope
         parent::__construct(
             new AndOf(
                 new GreaterThan($value, $lower),
-                new LessThan($value, $upper)
-            )
+                new LessThan($value, $upper),
+            ),
         );
     }
 }

--- a/src/Scalar/Constant.php
+++ b/src/Scalar/Constant.php
@@ -29,9 +29,7 @@ final readonly class Constant implements Scalar
      *
      * @param T $value The value returned on each call.
      */
-    public function __construct(private mixed $value)
-    {
-    }
+    public function __construct(private mixed $value) {}
 
     #[Override]
     public function value()

--- a/src/Scalar/Constant.php
+++ b/src/Scalar/Constant.php
@@ -19,7 +19,6 @@ use Override;
  *
  * @template T
  * @implements Scalar<T>
- *
  * @since 0.2
  */
 final readonly class Constant implements Scalar

--- a/src/Scalar/EqualTo.php
+++ b/src/Scalar/EqualTo.php
@@ -29,7 +29,7 @@ final readonly class EqualTo extends ScalarEnvelope
     public function __construct(Scalar $left, Scalar $right)
     {
         parent::__construct(
-            new ScalarOf(fn(): bool => $left->value() === $right->value()),
+            new ScalarOf(static fn(): bool => $left->value() === $right->value()),
         );
     }
 }

--- a/src/Scalar/EqualTo.php
+++ b/src/Scalar/EqualTo.php
@@ -29,7 +29,7 @@ final readonly class EqualTo extends ScalarEnvelope
     public function __construct(Scalar $left, Scalar $right)
     {
         parent::__construct(
-            new ScalarOf(fn (): bool => $left->value() === $right->value())
+            new ScalarOf(fn(): bool => $left->value() === $right->value()),
         );
     }
 }

--- a/src/Scalar/GreaterThan.php
+++ b/src/Scalar/GreaterThan.php
@@ -29,7 +29,7 @@ final readonly class GreaterThan extends ScalarEnvelope
     public function __construct(Scalar $left, Scalar $right)
     {
         parent::__construct(
-            new ScalarOf(fn (): bool => $left->value() > $right->value())
+            new ScalarOf(fn(): bool => $left->value() > $right->value()),
         );
     }
 }

--- a/src/Scalar/GreaterThan.php
+++ b/src/Scalar/GreaterThan.php
@@ -29,7 +29,7 @@ final readonly class GreaterThan extends ScalarEnvelope
     public function __construct(Scalar $left, Scalar $right)
     {
         parent::__construct(
-            new ScalarOf(fn(): bool => $left->value() > $right->value()),
+            new ScalarOf(static fn(): bool => $left->value() > $right->value()),
         );
     }
 }

--- a/src/Scalar/LessThan.php
+++ b/src/Scalar/LessThan.php
@@ -29,7 +29,7 @@ final readonly class LessThan extends ScalarEnvelope
     public function __construct(Scalar $left, Scalar $right)
     {
         parent::__construct(
-            new ScalarOf(fn (): bool => $left->value() < $right->value())
+            new ScalarOf(fn(): bool => $left->value() < $right->value()),
         );
     }
 }

--- a/src/Scalar/LessThan.php
+++ b/src/Scalar/LessThan.php
@@ -29,7 +29,7 @@ final readonly class LessThan extends ScalarEnvelope
     public function __construct(Scalar $left, Scalar $right)
     {
         parent::__construct(
-            new ScalarOf(fn(): bool => $left->value() < $right->value()),
+            new ScalarOf(static fn(): bool => $left->value() < $right->value()),
         );
     }
 }

--- a/src/Scalar/Not.php
+++ b/src/Scalar/Not.php
@@ -24,7 +24,7 @@ final readonly class Not extends ScalarEnvelope
     public function __construct(Scalar $origin)
     {
         parent::__construct(
-            new ScalarOf(fn (): bool => !$origin->value())
+            new ScalarOf(fn(): bool => !$origin->value()),
         );
     }
 }

--- a/src/Scalar/Not.php
+++ b/src/Scalar/Not.php
@@ -24,7 +24,7 @@ final readonly class Not extends ScalarEnvelope
     public function __construct(Scalar $origin)
     {
         parent::__construct(
-            new ScalarOf(fn(): bool => !$origin->value()),
+            new ScalarOf(static fn(): bool => !$origin->value()),
         );
     }
 }

--- a/src/Scalar/OrOf.php
+++ b/src/Scalar/OrOf.php
@@ -29,9 +29,10 @@ final readonly class OrOf extends ScalarEnvelope
                     if ($conditions === []) {
                         throw new InvalidArgumentException('OrOf requires at least one condition');
                     }
-                    return array_any($conditions, fn ($condition) => $condition->value());
-                }
-            )
+
+                    return array_any($conditions, fn($condition) => $condition->value());
+                },
+            ),
         );
     }
 }

--- a/src/Scalar/OrOf.php
+++ b/src/Scalar/OrOf.php
@@ -25,12 +25,12 @@ final readonly class OrOf extends ScalarEnvelope
     {
         parent::__construct(
             new ScalarOf(
-                function () use ($conditions): bool {
+                static function () use ($conditions): bool {
                     if ($conditions === []) {
                         throw new InvalidArgumentException('OrOf requires at least one condition');
                     }
 
-                    return array_any($conditions, fn($condition) => $condition->value());
+                    return array_any($conditions, static fn($condition) => $condition->value());
                 },
             ),
         );

--- a/src/Scalar/ScalarEnvelope.php
+++ b/src/Scalar/ScalarEnvelope.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Primus\Scalar;
 
+use Override;
+
 /**
  * Base class for scalar decorators.
  *
@@ -21,11 +23,9 @@ abstract readonly class ScalarEnvelope implements Scalar
      *
      * @param Scalar<T> $origin The wrapped scalar.
      */
-    public function __construct(protected Scalar $origin)
-    {
-    }
+    public function __construct(protected Scalar $origin) {}
 
-    #[\Override]
+    #[Override]
     final public function value()
     {
         return $this->origin->value();

--- a/src/Scalar/ScalarOf.php
+++ b/src/Scalar/ScalarOf.php
@@ -31,9 +31,7 @@ final readonly class ScalarOf implements Scalar
      *
      * @param Closure(): T $closure The deferred computation.
      */
-    public function __construct(private Closure $closure)
-    {
-    }
+    public function __construct(private Closure $closure) {}
 
     #[Override]
     public function value()

--- a/src/Scalar/Sticky.php
+++ b/src/Scalar/Sticky.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Primus\Scalar;
 
+use Override;
+
 /**
  * Cached version of a {@see Scalar}.
  *
@@ -28,7 +30,7 @@ final class Sticky implements Scalar
     private bool $computed = false;
 
     /**
-     * @var T $stored
+     * @var T
      * @phpstan-ignore haspadar.immutable
      */
     private $stored;
@@ -38,11 +40,9 @@ final class Sticky implements Scalar
      *
      * @param Scalar<T> $origin The scalar whose value is cached.
      */
-    public function __construct(private readonly Scalar $origin)
-    {
-    }
+    public function __construct(private readonly Scalar $origin) {}
 
-    #[\Override]
+    #[Override]
     public function value()
     {
         if (!$this->computed) {

--- a/src/Scalar/Sticky.php
+++ b/src/Scalar/Sticky.php
@@ -31,6 +31,7 @@ final class Sticky implements Scalar
 
     /**
      * @var T
+     * @psalm-suppress PropertyNotSetInConstructor Lazy-initialized in value()
      * @phpstan-ignore haspadar.immutable
      */
     private $stored;

--- a/src/Scalar/Ternary.php
+++ b/src/Scalar/Ternary.php
@@ -35,8 +35,8 @@ final readonly class Ternary extends ScalarEnvelope
     {
         parent::__construct(
             new ScalarOf(
-                fn () => $condition->value() ? $truthy->value() : $falsy->value()
-            )
+                fn() => $condition->value() ? $truthy->value() : $falsy->value(),
+            ),
         );
     }
 }

--- a/src/Scalar/Ternary.php
+++ b/src/Scalar/Ternary.php
@@ -35,7 +35,7 @@ final readonly class Ternary extends ScalarEnvelope
     {
         parent::__construct(
             new ScalarOf(
-                fn() => $condition->value() ? $truthy->value() : $falsy->value(),
+                static fn() => $condition->value() ? $truthy->value() : $falsy->value(),
             ),
         );
     }

--- a/src/Scalar/XorOf.php
+++ b/src/Scalar/XorOf.php
@@ -32,15 +32,15 @@ final readonly class XorOf extends ScalarEnvelope
     {
         parent::__construct(
             new ScalarOf(
-                fn (): bool => match (count($conditions)) {
+                fn(): bool => match (count($conditions)) {
                     0 => throw new InvalidArgumentException('XorOf requires at least one condition'),
                     default => array_reduce(
                         $conditions,
-                        fn (bool $carry, Scalar $cond): bool => $carry xor $cond->value(),
-                        false
+                        fn(bool $carry, Scalar $cond): bool => $carry xor $cond->value(),
+                        false,
                     ),
-                }
-            )
+                },
+            ),
         );
     }
 }

--- a/src/Scalar/XorOf.php
+++ b/src/Scalar/XorOf.php
@@ -32,11 +32,11 @@ final readonly class XorOf extends ScalarEnvelope
     {
         parent::__construct(
             new ScalarOf(
-                fn(): bool => match (count($conditions)) {
+                static fn(): bool => match (count($conditions)) {
                     0 => throw new InvalidArgumentException('XorOf requires at least one condition'),
                     default => array_reduce(
                         $conditions,
-                        fn(bool $carry, Scalar $cond): bool => $carry xor $cond->value(),
+                        static fn(bool $carry, Scalar $cond): bool => $carry xor $cond->value(),
                         false,
                     ),
                 },

--- a/src/Text/Abbreviated.php
+++ b/src/Text/Abbreviated.php
@@ -29,6 +29,7 @@ final readonly class Abbreviated extends TextEnvelope
         /** @phpstan-ignore haspadar.constructorInit */
         if ($limit <= 0) {
             parent::__construct(new TextOf(''));
+
             return;
         }
 
@@ -37,6 +38,7 @@ final readonly class Abbreviated extends TextEnvelope
         /** @phpstan-ignore haspadar.constructorInit */
         if ($length->value() <= $limit) {
             parent::__construct($origin);
+
             return;
         }
 

--- a/src/Text/Abbreviated.php
+++ b/src/Text/Abbreviated.php
@@ -35,6 +35,7 @@ final readonly class Abbreviated extends TextEnvelope
 
         /** @phpstan-ignore haspadar.constructorInit */
         $length = new LengthOfText($origin);
+
         /** @phpstan-ignore haspadar.constructorInit */
         if ($length->value() <= $limit) {
             parent::__construct($origin);
@@ -44,6 +45,7 @@ final readonly class Abbreviated extends TextEnvelope
 
         /** @phpstan-ignore haspadar.constructorInit */
         $truncated = sprintf('%s…', (new Sub($origin, 0, $limit - 1))->value());
+
         parent::__construct(new TextOf($truncated));
     }
 }

--- a/src/Text/Capitalized.php
+++ b/src/Text/Capitalized.php
@@ -27,6 +27,7 @@ final readonly class Capitalized extends TextEnvelope
     {
         /** @phpstan-ignore haspadar.constructorInit */
         $value = $origin->value();
+
         parent::__construct(
             new TextOf(
                 $value === ''

--- a/src/Text/Capitalized.php
+++ b/src/Text/Capitalized.php
@@ -34,9 +34,9 @@ final readonly class Capitalized extends TextEnvelope
                     : sprintf(
                         '%s%s',
                         mb_strtoupper(mb_substr($value, 0, 1, 'UTF-8'), 'UTF-8'),
-                        mb_substr($value, 1, null, 'UTF-8')
-                    )
-            )
+                        mb_substr($value, 1, null, 'UTF-8'),
+                    ),
+            ),
         );
     }
 }

--- a/src/Text/HtmlEscaped.php
+++ b/src/Text/HtmlEscaped.php
@@ -24,8 +24,8 @@ final readonly class HtmlEscaped extends TextEnvelope
     {
         parent::__construct(
             new TextOf(
-                htmlspecialchars($origin->value(), ENT_QUOTES | ENT_HTML5, 'UTF-8')
-            )
+                htmlspecialchars($origin->value(), ENT_QUOTES | ENT_HTML5, 'UTF-8'),
+            ),
         );
     }
 }

--- a/src/Text/Joined.php
+++ b/src/Text/Joined.php
@@ -28,11 +28,11 @@ final readonly class Joined extends TextEnvelope
                 implode(
                     $separator,
                     array_map(
-                        fn (Text $t): string => $t->value(),
-                        is_array($parts) ? $parts : iterator_to_array($parts, false)
-                    )
-                )
-            )
+                        fn(Text $t): string => $t->value(),
+                        is_array($parts) ? $parts : iterator_to_array($parts, false),
+                    ),
+                ),
+            ),
         );
     }
 }

--- a/src/Text/Joined.php
+++ b/src/Text/Joined.php
@@ -28,7 +28,7 @@ final readonly class Joined extends TextEnvelope
                 implode(
                     $separator,
                     array_map(
-                        fn(Text $t): string => $t->value(),
+                        static fn(Text $t): string => $t->value(),
                         is_array($parts) ? $parts : iterator_to_array($parts, false),
                     ),
                 ),

--- a/src/Text/LeftPadded.php
+++ b/src/Text/LeftPadded.php
@@ -25,11 +25,8 @@ final readonly class LeftPadded extends TextEnvelope
      * @param int $length The desired total length after padding.
      * @param string $padding The character to use for padding.
      */
-    public function __construct(
-        Text $origin,
-        int $length,
-        string $padding,
-    ) {
+    public function __construct(Text $origin, int $length, string $padding)
+    {
         parent::__construct(
             new TextOf(
                 str_pad(

--- a/src/Text/LeftPadded.php
+++ b/src/Text/LeftPadded.php
@@ -28,7 +28,7 @@ final readonly class LeftPadded extends TextEnvelope
     public function __construct(
         Text $origin,
         int $length,
-        string $padding
+        string $padding,
     ) {
         parent::__construct(
             new TextOf(
@@ -36,9 +36,9 @@ final readonly class LeftPadded extends TextEnvelope
                     $origin->value(),
                     $length,
                     $padding,
-                    STR_PAD_LEFT
-                )
-            )
+                    STR_PAD_LEFT,
+                ),
+            ),
         );
     }
 }

--- a/src/Text/LengthOfText.php
+++ b/src/Text/LengthOfText.php
@@ -30,7 +30,7 @@ final readonly class LengthOfText extends ScalarEnvelope
          * @phpstan-ignore haspadar.constructorInit
          */
         $scalar = new ScalarOf(
-            fn(): int => mb_strlen($origin->value(), 'UTF-8'),
+            static fn(): int => mb_strlen($origin->value(), 'UTF-8'),
         );
 
         parent::__construct($scalar);

--- a/src/Text/LengthOfText.php
+++ b/src/Text/LengthOfText.php
@@ -15,7 +15,6 @@ use Primus\Scalar\ScalarOf;
  *     echo $length->value(); // 9
  *
  * @extends ScalarEnvelope<int>
- *
  */
 final readonly class LengthOfText extends ScalarEnvelope
 {
@@ -31,7 +30,7 @@ final readonly class LengthOfText extends ScalarEnvelope
          * @phpstan-ignore haspadar.constructorInit
          */
         $scalar = new ScalarOf(
-            fn (): int => mb_strlen($origin->value(), 'UTF-8')
+            fn(): int => mb_strlen($origin->value(), 'UTF-8'),
         );
 
         parent::__construct($scalar);

--- a/src/Text/Lowered.php
+++ b/src/Text/Lowered.php
@@ -25,7 +25,7 @@ final readonly class Lowered extends TextEnvelope
     public function __construct(Text $origin)
     {
         parent::__construct(
-            new TextOf(mb_strtolower($origin->value(), 'UTF-8'))
+            new TextOf(mb_strtolower($origin->value(), 'UTF-8')),
         );
     }
 }

--- a/src/Text/Normalized.php
+++ b/src/Text/Normalized.php
@@ -31,11 +31,11 @@ final readonly class Normalized extends TextEnvelope
         parent::__construct(
             new TextOfScalar(
                 new ScalarOf(
-                    fn (): string =>
+                    fn(): string =>
                         preg_replace('/\s+/u', ' ', trim($origin->value()))
-                        ?? throw new InvalidArgumentException('Malformed UTF-8 input')
-                )
-            )
+                        ?? throw new InvalidArgumentException('Malformed UTF-8 input'),
+                ),
+            ),
         );
     }
 }

--- a/src/Text/Normalized.php
+++ b/src/Text/Normalized.php
@@ -14,7 +14,7 @@ use Primus\Scalar\ScalarOf;
  * with a single space and trims leading/trailing whitespace.
  *
  * Example:
- *     $text = new Normalized(new TextOf(" Hello \n\t  world "));
+ *     $text = new Normalized(new TextOf(" Hello \n\t world "));
  *     echo $text->value(); // 'Hello world'
  *
  * @since 0.2
@@ -31,8 +31,7 @@ final readonly class Normalized extends TextEnvelope
         parent::__construct(
             new TextOfScalar(
                 new ScalarOf(
-                    fn(): string =>
-                        preg_replace('/\s+/u', ' ', trim($origin->value()))
+                    static fn(): string => preg_replace('/\s+/u', ' ', trim($origin->value()))
                         ?? throw new InvalidArgumentException('Malformed UTF-8 input'),
                 ),
             ),

--- a/src/Text/RandomText.php
+++ b/src/Text/RandomText.php
@@ -41,9 +41,9 @@ final readonly class RandomText extends TextEnvelope
                         }
 
                         return implode('', $chars);
-                    }
-                ))->value()
-            )
+                    },
+                ))->value(),
+            ),
         );
     }
 }

--- a/src/Text/RandomText.php
+++ b/src/Text/RandomText.php
@@ -26,13 +26,17 @@ final readonly class RandomText extends TextEnvelope
      * @param int $length The length of the generated text.
      * @param string $alphabet The characters to pick from.
      */
-    public function __construct(int $length, string $alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789')
-    {
+    public function __construct(
+        int $length,
+        string $alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+    ) {
         parent::__construct(
             new TextOf(
                 (new ScalarOf(
-                    function () use ($length, $alphabet): string {
-                        $source = $alphabet !== '' ? $alphabet : 'a';
+                    static function () use ($length, $alphabet): string {
+                        $source = $alphabet !== ''
+                            ? $alphabet
+                            : 'a';
                         $size = mb_strlen($source, 'UTF-8');
                         $chars = [];
 

--- a/src/Text/Repeated.php
+++ b/src/Text/Repeated.php
@@ -25,8 +25,8 @@ final readonly class Repeated extends TextEnvelope
     {
         parent::__construct(
             new TextOf(
-                str_repeat($origin->value(), max(0, $count))
-            )
+                str_repeat($origin->value(), max(0, $count)),
+            ),
         );
     }
 }

--- a/src/Text/Replaced.php
+++ b/src/Text/Replaced.php
@@ -25,14 +25,11 @@ final readonly class Replaced extends TextEnvelope
      * Ctor.
      *
      * @param Text $origin The origin text.
-     * @param string|string[] $search The substrings to search for.
-     * @param string|string[] $replacement The replacements.
+     * @param string|list<string> $search The substrings to search for.
+     * @param string|list<string> $replacement The replacements.
      */
-    public function __construct(
-        Text $origin,
-        string|array $search,
-        string|array $replacement,
-    ) {
+    public function __construct(Text $origin, string|array $search, string|array $replacement)
+    {
         parent::__construct(
             new TextOf(
                 str_replace($search, $replacement, $origin->value()),

--- a/src/Text/Replaced.php
+++ b/src/Text/Replaced.php
@@ -31,12 +31,12 @@ final readonly class Replaced extends TextEnvelope
     public function __construct(
         Text $origin,
         string|array $search,
-        string|array $replacement
+        string|array $replacement,
     ) {
         parent::__construct(
             new TextOf(
-                str_replace($search, $replacement, $origin->value())
-            )
+                str_replace($search, $replacement, $origin->value()),
+            ),
         );
     }
 }

--- a/src/Text/RightPadded.php
+++ b/src/Text/RightPadded.php
@@ -27,16 +27,16 @@ final readonly class RightPadded extends TextEnvelope
     public function __construct(
         Text $origin,
         int $length,
-        string $padding
+        string $padding,
     ) {
         parent::__construct(
             new TextOf(
                 str_pad(
                     $origin->value(),
                     $length,
-                    $padding
-                )
-            )
+                    $padding,
+                ),
+            ),
         );
     }
 }

--- a/src/Text/RightPadded.php
+++ b/src/Text/RightPadded.php
@@ -24,11 +24,8 @@ final readonly class RightPadded extends TextEnvelope
      * @param int $length The desired total length after padding.
      * @param string $padding The character to use for padding.
      */
-    public function __construct(
-        Text $origin,
-        int $length,
-        string $padding,
-    ) {
+    public function __construct(Text $origin, int $length, string $padding)
+    {
         parent::__construct(
             new TextOf(
                 str_pad(

--- a/src/Text/Split.php
+++ b/src/Text/Split.php
@@ -29,10 +29,7 @@ final readonly class Split implements Scalar
      * @param non-empty-string $delimiter The delimiter used to split the text.
      * @param Text $origin The text to split.
      */
-    public function __construct(
-        private string $delimiter,
-        private Text $origin,
-    ) {}
+    public function __construct(private string $delimiter, private Text $origin) {}
 
     #[Override]
     public function value(): iterable

--- a/src/Text/Split.php
+++ b/src/Text/Split.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
+use Override;
 use Primus\Scalar\Scalar;
 
 /**
@@ -31,10 +32,9 @@ final readonly class Split implements Scalar
     public function __construct(
         private string $delimiter,
         private Text $origin,
-    ) {
-    }
+    ) {}
 
-    #[\Override]
+    #[Override]
     public function value(): iterable
     {
         foreach (explode($this->delimiter, $this->origin->value()) as $part) {

--- a/src/Text/Sub.php
+++ b/src/Text/Sub.php
@@ -28,7 +28,7 @@ final readonly class Sub extends TextEnvelope
     public function __construct(Text $text, int $start, int $length = PHP_INT_MAX)
     {
         parent::__construct(
-            new TextOf(mb_substr($text->value(), $start, $length, 'UTF-8'))
+            new TextOf(mb_substr($text->value(), $start, $length, 'UTF-8')),
         );
     }
 }

--- a/src/Text/TextEnvelope.php
+++ b/src/Text/TextEnvelope.php
@@ -18,9 +18,7 @@ abstract readonly class TextEnvelope implements Text
      *
      * @param Text $origin The text to delegate to.
      */
-    public function __construct(protected Text $origin)
-    {
-    }
+    public function __construct(protected Text $origin) {}
 
     #[Override]
     public function value(): string

--- a/src/Text/TextOf.php
+++ b/src/Text/TextOf.php
@@ -18,9 +18,7 @@ final readonly class TextOf implements Text
      *
      * @param string $value The string to wrap.
      */
-    public function __construct(private string $value)
-    {
-    }
+    public function __construct(private string $value) {}
 
     #[Override]
     public function value(): string

--- a/src/Text/TextOfScalar.php
+++ b/src/Text/TextOfScalar.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
+use Override;
 use Primus\Scalar\Scalar;
 
 /**
@@ -16,14 +17,11 @@ final readonly class TextOfScalar implements Text
      *
      * @param Scalar<string> $origin The scalar producing the string value.
      */
-    public function __construct(private Scalar $origin)
-    {
-    }
+    public function __construct(private Scalar $origin) {}
 
-    #[\Override]
+    #[Override]
     public function value(): string
     {
-        /** @var string */
         return $this->origin->value();
     }
 }

--- a/src/Text/Trimmed.php
+++ b/src/Text/Trimmed.php
@@ -25,7 +25,7 @@ final readonly class Trimmed extends TextEnvelope
     public function __construct(Text $origin)
     {
         parent::__construct(
-            new TextOf(trim($origin->value()))
+            new TextOf(trim($origin->value())),
         );
     }
 }

--- a/src/Text/Trimmed.php
+++ b/src/Text/Trimmed.php
@@ -10,7 +10,7 @@ namespace Primus\Text;
  * Applies {@see trim()} to the original text.
  *
  * Example:
- *     $text = new Trimmed(new TextOf('  hello  '));
+ *     $text = new Trimmed(new TextOf(' hello '));
  *     echo $text->value(); // 'hello'
  *
  * @since 0.1

--- a/src/Text/TrimmedLeft.php
+++ b/src/Text/TrimmedLeft.php
@@ -8,7 +8,7 @@ namespace Primus\Text;
  * Text with whitespace removed from the left side.
  *
  * Example:
- *     $text = new TrimmedLeft(new TextOf("   hello "));
+ *     $text = new TrimmedLeft(new TextOf(" hello "));
  *     echo $text->value(); // 'hello '
  *
  * @since 0.2

--- a/src/Text/TrimmedLeft.php
+++ b/src/Text/TrimmedLeft.php
@@ -24,8 +24,8 @@ final readonly class TrimmedLeft extends TextEnvelope
     {
         parent::__construct(
             new TextOf(
-                (string)preg_replace('/^\s+/u', '', $origin->value())
-            )
+                (string) preg_replace('/^\s+/u', '', $origin->value()),
+            ),
         );
     }
 }

--- a/src/Text/TrimmedRight.php
+++ b/src/Text/TrimmedRight.php
@@ -28,11 +28,11 @@ final readonly class TrimmedRight extends TextEnvelope
         parent::__construct(
             new TextOfScalar(
                 new ScalarOf(
-                    fn (): string =>
+                    fn(): string =>
                         preg_replace('/\s+$/u', '', $origin->value())
-                        ?? throw new InvalidArgumentException('Malformed UTF-8 input')
-                )
-            )
+                        ?? throw new InvalidArgumentException('Malformed UTF-8 input'),
+                ),
+            ),
         );
     }
 }

--- a/src/Text/TrimmedRight.php
+++ b/src/Text/TrimmedRight.php
@@ -11,7 +11,7 @@ use Primus\Scalar\ScalarOf;
  * Text with whitespace removed from the right side.
  *
  * Example:
- *     $text = new TrimmedRight(new TextOf(" hello   "));
+ *     $text = new TrimmedRight(new TextOf(" hello "));
  *     echo $text->value(); // ' hello'
  *
  * @since 0.2
@@ -28,8 +28,7 @@ final readonly class TrimmedRight extends TextEnvelope
         parent::__construct(
             new TextOfScalar(
                 new ScalarOf(
-                    fn(): string =>
-                        preg_replace('/\s+$/u', '', $origin->value())
+                    static fn(): string => preg_replace('/\s+$/u', '', $origin->value())
                         ?? throw new InvalidArgumentException('Malformed UTF-8 input'),
                 ),
             ),

--- a/src/Text/Uppered.php
+++ b/src/Text/Uppered.php
@@ -12,7 +12,6 @@ namespace Primus\Text;
  * Example:
  *     $text = new Uppered(new TextOf('touché résumé'));
  *     echo $text->value(); // 'TOUCHÉ RÉSUMÉ'
- *
  */
 final readonly class Uppered extends TextEnvelope
 {
@@ -24,7 +23,7 @@ final readonly class Uppered extends TextEnvelope
     public function __construct(Text $origin)
     {
         parent::__construct(
-            new TextOf(mb_strtoupper($origin->value(), 'UTF-8'))
+            new TextOf(mb_strtoupper($origin->value(), 'UTF-8')),
         );
     }
 }

--- a/src/Text/WithoutTags.php
+++ b/src/Text/WithoutTags.php
@@ -12,7 +12,6 @@ namespace Primus\Text;
  * Example:
  *     $text = new WithoutTags(new TextOf('<b>John & "Jane"</b>'));
  *     echo $text->value(); // 'John & "Jane"'
- *
  */
 final readonly class WithoutTags extends TextEnvelope
 {
@@ -25,8 +24,8 @@ final readonly class WithoutTags extends TextEnvelope
     {
         parent::__construct(
             new TextOf(
-                strip_tags($origin->value())
-            )
+                strip_tags($origin->value()),
+            ),
         );
     }
 }


### PR DESCRIPTION
- Added piqule configs for all quality tools and CI workflow
- Overrode phpunit testsuites and phpmetrics afferent coupling
- Disabled phpdoc_types and assertion sniffs that break generics and Exception semantics
- Added targeted @psalm-suppress for public API and lazy init
- Applied phpcs and php-cs-fixer autofixes across src

Closes #31