### PR TITLE
Catch Throwable In Fallback, Move Phpdoc Types Override

### DIFF
--- a/.piqule.yaml
+++ b/.piqule.yaml
@@ -13,3 +13,4 @@ override:
     phpunit.testsuites.unit: ["../../tests"]
     phpunit.testsuites.integration: []
     phpmetrics.coupling.max_afferent: 20
+    php_cs_fixer.disabled_rules: ["phpdoc_types"]

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -56,10 +56,12 @@ defaults:
 
   php-cs-fixer.cli: true
   php_cs_fixer.allow_unsupported: ["true"]
+  php_cs_fixer.disabled_rules: []
   php_cs_fixer.exclude: ["vendor", "tests", ".git"]
   php_cs_fixer.paths: ["../.."]
 
   phpcs.cli: true
+  phpcs.disabled_rules: []
   phpcs.excludes: ["vendor/*", "tests/*", ".git/*"]
   phpcs.files: ["../../src"]
   phpcs.root_namespace: ""

--- a/.piqule/php-cs-fixer/php-cs-fixer.php
+++ b/.piqule/php-cs-fixer/php-cs-fixer.php
@@ -76,7 +76,7 @@ return (new PhpCsFixer\Config())
         'phpdoc_order' => true,
         'phpdoc_scalar' => true,
         'phpdoc_trim' => true,
-        'phpdoc_types' => false,
+        'phpdoc_types' => true,
         'phpdoc_var_without_name' => true,
 
         // Clean code
@@ -106,5 +106,6 @@ return (new PhpCsFixer\Config())
         // PHP 8.4 compatibility: keep parentheses around `new` expressions
         // so tools based on pdepend (phpmd) can still parse the code
         'new_expression_parentheses' => ['use_parentheses' => true],
+        'phpdoc_types' => false,
     ]))
     ->setUnsupportedPhpVersionAllowed(true);

--- a/.piqule/phpcs/phpcs.xml
+++ b/.piqule/phpcs/phpcs.xml
@@ -20,4 +20,5 @@
     <rule ref=".piqule/phpcs/slevomat-flow.xml"/>
     <rule ref=".piqule/phpcs/slevomat-style.xml"/>
 
+
 </ruleset>

--- a/.piqule/phpcs/slevomat-flow.xml
+++ b/.piqule/phpcs/slevomat-flow.xml
@@ -20,6 +20,7 @@
 
     <rule ref="SlevomatCodingStandard.Exceptions.CatchExceptionsOrder"/>
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
+    <rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly"/>
     <rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch"/>
 
     <rule ref="SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable"/>

--- a/.piqule/psalm/psalm.xml
+++ b/.piqule/psalm/psalm.xml
@@ -21,5 +21,6 @@
                 <directory name="../../src" />
             </errorLevel>
         </UnusedClass>
+
     </issueHandlers>
 </psalm>

--- a/composer.lock
+++ b/composer.lock
@@ -1872,12 +1872,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/piqule.git",
-                "reference": "01dc7fda0396d56583014a4c4ee229c58b0705ad"
+                "reference": "9850f64caada613000e824bb1cab9d1d33ae35c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/piqule/zipball/01dc7fda0396d56583014a4c4ee229c58b0705ad",
-                "reference": "01dc7fda0396d56583014a4c4ee229c58b0705ad",
+                "url": "https://api.github.com/repos/haspadar/piqule/zipball/9850f64caada613000e824bb1cab9d1d33ae35c8",
+                "reference": "9850f64caada613000e824bb1cab9d1d33ae35c8",
                 "shasum": ""
             },
             "require": {
@@ -1925,7 +1925,7 @@
                 "issues": "https://github.com/haspadar/piqule/issues",
                 "source": "https://github.com/haspadar/piqule/tree/main"
             },
-            "time": "2026-04-23T21:23:37+00:00"
+            "time": "2026-04-24T09:42:40+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",

--- a/src/Func/FuncWithFallback.php
+++ b/src/Func/FuncWithFallback.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Primus\Func;
 
-use Exception;
+use Throwable;
 
 /**
  * Func with fallback.
@@ -34,7 +34,7 @@ final readonly class FuncWithFallback extends FuncEnvelope
                     try {
                         return $origin->apply($input);
                         // @phpstan-ignore-next-line haspadar.illegalCatch
-                    } catch (Exception) {
+                    } catch (Throwable) {
                         return $fallback->apply($input);
                     }
                 },


### PR DESCRIPTION
- Fixed FuncWithFallback catching only Exception, missing Error subclasses
- Moved phpdoc_types disable from .piqule/ template patch to .piqule.yaml override
- Bumped piqule to pick up new disabled_rules mechanism