### PR TITLE
Narrow Phpdoc Types Via Piqule Extend

### DIFF
--- a/.piqule.yaml
+++ b/.piqule.yaml
@@ -13,4 +13,5 @@ override:
     phpunit.testsuites.unit: ["../../tests"]
     phpunit.testsuites.integration: []
     phpmetrics.coupling.max_afferent: 20
-    php_cs_fixer.disabled_rules: ["phpdoc_types"]
+    php_cs_fixer.extend: |
+        'phpdoc_types' => ['exclude' => ['scalar']],

--- a/.piqule/config.yaml
+++ b/.piqule/config.yaml
@@ -56,13 +56,13 @@ defaults:
 
   php-cs-fixer.cli: true
   php_cs_fixer.allow_unsupported: ["true"]
-  php_cs_fixer.disabled_rules: []
   php_cs_fixer.exclude: ["vendor", "tests", ".git"]
+  php_cs_fixer.extend: ""
   php_cs_fixer.paths: ["../.."]
 
   phpcs.cli: true
-  phpcs.disabled_rules: []
   phpcs.excludes: ["vendor/*", "tests/*", ".git/*"]
+  phpcs.extend: ""
   phpcs.files: ["../../src"]
   phpcs.root_namespace: ""
 

--- a/.piqule/php-cs-fixer/php-cs-fixer.php
+++ b/.piqule/php-cs-fixer/php-cs-fixer.php
@@ -106,6 +106,7 @@ return (new PhpCsFixer\Config())
         // PHP 8.4 compatibility: keep parentheses around `new` expressions
         // so tools based on pdepend (phpmd) can still parse the code
         'new_expression_parentheses' => ['use_parentheses' => true],
-        'phpdoc_types' => false,
+'phpdoc_types' => ['exclude' => ['scalar']],
+
     ]))
     ->setUnsupportedPhpVersionAllowed(true);

--- a/composer.lock
+++ b/composer.lock
@@ -1872,12 +1872,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/piqule.git",
-                "reference": "9850f64caada613000e824bb1cab9d1d33ae35c8"
+                "reference": "f79cc60643a628de7dc614eed0e0933435b05eab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/piqule/zipball/9850f64caada613000e824bb1cab9d1d33ae35c8",
-                "reference": "9850f64caada613000e824bb1cab9d1d33ae35c8",
+                "url": "https://api.github.com/repos/haspadar/piqule/zipball/f79cc60643a628de7dc614eed0e0933435b05eab",
+                "reference": "f79cc60643a628de7dc614eed0e0933435b05eab",
                 "shasum": ""
             },
             "require": {
@@ -1925,7 +1925,7 @@
                 "issues": "https://github.com/haspadar/piqule/issues",
                 "source": "https://github.com/haspadar/piqule/tree/main"
             },
-            "time": "2026-04-24T09:42:40+00:00"
+            "time": "2026-04-24T11:36:02+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",


### PR DESCRIPTION
- Replaced php_cs_fixer.disabled_rules with php_cs_fixer.extend (piqule migrated the API)
- Narrowed phpdoc_types from fully disabled to { exclude: [scalar] }, restoring boolean/integer/STRING normalization
- Bumped piqule to pick up the new extend mechanism