### PR TITLE
Drop Missing-Throws Suppresses After Rule Replacement

### DIFF
--- a/.piqule/phpstan/phpstan.neon
+++ b/.piqule/phpstan/phpstan.neon
@@ -16,8 +16,6 @@ parameters:
     checkDynamicProperties: true
 
     exceptions:
-        check:
-            missingCheckedExceptionInThrows: true
         checkedExceptionClasses:
             - \Throwable
 

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,7 @@
         "php": "~8.3.16 || ~8.4.3 || ~8.5.0"
     },
     "require-dev": {
-        "haspadar/phpstan-rules": "0.42.1",
-        "haspadar/piqule": "dev-main",
-        "slevomat/coding-standard": "^8.28",
-        "kubawerlos/php-cs-fixer-custom-fixers": "^3.36"
+        "haspadar/piqule": "dev-main"
     },
     "scripts": {
         "update-piqule": "bash -c 'COMPOSER_ROOT_VERSION=$(git describe --tags --abbrev=0 | sed s/^v//) composer update haspadar/piqule -W'"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a361bbad933e906ee672bdb7b0b23015",
+    "content-hash": "b88fba4cd9a8272d72951184a32629eb",
     "packages": [],
     "packages-dev": [
         {
@@ -1815,16 +1815,16 @@
         },
         {
             "name": "haspadar/phpstan-rules",
-            "version": "v0.42.1",
+            "version": "v0.44.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/phpstan-rules.git",
-                "reference": "bc3aa5840c0b52b6208ea399ab94987f79463050"
+                "reference": "94dbf1f1c1648dca9a36f919423ac58e24f7e511"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/bc3aa5840c0b52b6208ea399ab94987f79463050",
-                "reference": "bc3aa5840c0b52b6208ea399ab94987f79463050",
+                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/94dbf1f1c1648dca9a36f919423ac58e24f7e511",
+                "reference": "94dbf1f1c1648dca9a36f919423ac58e24f7e511",
                 "shasum": ""
             },
             "require": {
@@ -1862,9 +1862,9 @@
             "description": "PHPStan design rules for immutability and structure",
             "support": {
                 "issues": "https://github.com/haspadar/phpstan-rules/issues",
-                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.42.1"
+                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.44.1"
             },
-            "time": "2026-04-23T12:56:16+00:00"
+            "time": "2026-04-24T12:59:00+00:00"
         },
         {
             "name": "haspadar/piqule",
@@ -1872,12 +1872,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/piqule.git",
-                "reference": "f79cc60643a628de7dc614eed0e0933435b05eab"
+                "reference": "d0d6144e63d54c3f6eb8d889b4fa150a6b1acfd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/piqule/zipball/f79cc60643a628de7dc614eed0e0933435b05eab",
-                "reference": "f79cc60643a628de7dc614eed0e0933435b05eab",
+                "url": "https://api.github.com/repos/haspadar/piqule/zipball/d0d6144e63d54c3f6eb8d889b4fa150a6b1acfd4",
+                "reference": "d0d6144e63d54c3f6eb8d889b4fa150a6b1acfd4",
                 "shasum": ""
             },
             "require": {
@@ -1925,7 +1925,7 @@
                 "issues": "https://github.com/haspadar/piqule/issues",
                 "source": "https://github.com/haspadar/piqule/tree/main"
             },
-            "time": "2026-04-24T11:36:02+00:00"
+            "time": "2026-04-24T13:15:16+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",
@@ -2106,16 +2106,16 @@
         },
         {
             "name": "infection/infection",
-            "version": "0.32.6",
+            "version": "0.32.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/infection/infection.git",
-                "reference": "4ed769947eaf2ecf42203027301bad2bedf037e5"
+                "reference": "066ee69f1e8e6dec8965a79d5ba020656c590b5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/infection/infection/zipball/4ed769947eaf2ecf42203027301bad2bedf037e5",
-                "reference": "4ed769947eaf2ecf42203027301bad2bedf037e5",
+                "url": "https://api.github.com/repos/infection/infection/zipball/066ee69f1e8e6dec8965a79d5ba020656c590b5e",
+                "reference": "066ee69f1e8e6dec8965a79d5ba020656c590b5e",
                 "shasum": ""
             },
             "require": {
@@ -2134,7 +2134,7 @@
                 "justinrainbow/json-schema": "^6.0",
                 "nikic/php-parser": "^5.6.2",
                 "ondram/ci-detector": "^4.1.0",
-                "php": "^8.2",
+                "php": "^8.3",
                 "psr/log": "^2.0 || ^3.0",
                 "sanmai/di-container": "^0.1.12",
                 "sanmai/duoclock": "^0.1.0",
@@ -2154,9 +2154,11 @@
                 "dg/bypass-finals": "<1.4.1"
             },
             "require-dev": {
+                "carthage-software/mago": "^1.20",
                 "ext-simplexml": "*",
                 "fidry/makefile": "^1.0",
                 "fig/log-test": "^1.2",
+                "phpat/phpat": "^0.12.4",
                 "phpbench/phpbench": "^1.4",
                 "phpstan/extension-installer": "^1.4",
                 "phpstan/phpstan": "^2.1",
@@ -2165,7 +2167,7 @@
                 "phpstan/phpstan-webmozart-assert": "^2.0",
                 "phpunit/phpunit": "^11.5.27",
                 "rector/rector": "^2.2.4",
-                "shipmonk/dead-code-detector": "^0.14.0",
+                "shipmonk/dead-code-detector": "^0.15",
                 "shipmonk/name-collision-detector": "^2.1",
                 "sidz/phpstan-rules": "^0.5.1",
                 "symfony/yaml": "^6.4 || ^7.0 || ^8.0",
@@ -2226,7 +2228,7 @@
             ],
             "support": {
                 "issues": "https://github.com/infection/infection/issues",
-                "source": "https://github.com/infection/infection/tree/0.32.6"
+                "source": "https://github.com/infection/infection/tree/0.32.7"
             },
             "funding": [
                 {
@@ -2238,7 +2240,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2026-02-26T14:34:26+00:00"
+            "time": "2026-04-23T21:11:41+00:00"
         },
         {
             "name": "infection/mutator",

--- a/src/Func/Repeated.php
+++ b/src/Func/Repeated.php
@@ -35,7 +35,6 @@ final readonly class Repeated implements Func
     public function apply(mixed $input): mixed
     {
         if ($this->times <= 0) {
-            /** @phpstan-ignore missingType.checkedException */
             throw new RuntimeException('Repeated time must be >= 1');
         }
 

--- a/src/Iterator/Filtered.php
+++ b/src/Iterator/Filtered.php
@@ -42,7 +42,6 @@ final class Filtered implements Iterator
     public function next(): void
     {
         if (!$this->isValid) {
-            /** @phpstan-ignore missingType.checkedException */
             throw new RuntimeException('Iterator is past the end');
         }
 
@@ -54,7 +53,6 @@ final class Filtered implements Iterator
     public function current(): mixed
     {
         if (!$this->isValid) {
-            /** @phpstan-ignore missingType.checkedException */
             throw new RuntimeException('Iterator is past the end');
         }
 
@@ -65,7 +63,6 @@ final class Filtered implements Iterator
     public function key(): mixed
     {
         if (!$this->isValid) {
-            /** @phpstan-ignore missingType.checkedException */
             throw new RuntimeException('Iterator is past the end');
         }
 

--- a/src/Iterator/IteratorOf.php
+++ b/src/Iterator/IteratorOf.php
@@ -44,7 +44,6 @@ final class IteratorOf implements Iterator
     public function current(): mixed
     {
         if (!$this->valid()) {
-            /** @phpstan-ignore missingType.checkedException */
             throw new RuntimeException('Iterator is past the end');
         }
 
@@ -55,7 +54,6 @@ final class IteratorOf implements Iterator
     public function key(): int|string
     {
         if (!$this->valid()) {
-            /** @phpstan-ignore missingType.checkedException */
             throw new RuntimeException('Iterator key is undefined because iterator is past the end');
         }
 

--- a/src/Iterator/Joined.php
+++ b/src/Iterator/Joined.php
@@ -64,7 +64,6 @@ final class Joined implements Iterator
     public function current(): mixed
     {
         if (!$this->valid()) {
-            /** @phpstan-ignore missingType.checkedException */
             throw new RuntimeException('Joined iterator is past the end');
         }
 
@@ -75,7 +74,6 @@ final class Joined implements Iterator
     public function key(): int
     {
         if (!$this->valid()) {
-            /** @phpstan-ignore missingType.checkedException */
             throw new RuntimeException('Iterator key is undefined because iterator is past the end');
         }
 
@@ -86,7 +84,6 @@ final class Joined implements Iterator
     public function next(): void
     {
         if (!$this->valid()) {
-            /** @phpstan-ignore missingType.checkedException */
             throw new RuntimeException('Joined iterator is past the end');
         }
 

--- a/src/Iterator/Mapped.php
+++ b/src/Iterator/Mapped.php
@@ -41,7 +41,6 @@ final class Mapped implements Iterator
     public function current(): mixed
     {
         if (!$this->valid()) {
-            /** @phpstan-ignore missingType.checkedException */
             throw new RuntimeException('Mapped: current() past end');
         }
 
@@ -55,7 +54,6 @@ final class Mapped implements Iterator
     public function key(): int
     {
         if (!$this->valid()) {
-            /** @phpstan-ignore missingType.checkedException */
             throw new RuntimeException('Mapped: key() past end');
         }
 
@@ -66,7 +64,6 @@ final class Mapped implements Iterator
     public function next(): void
     {
         if (!$this->valid()) {
-            /** @phpstan-ignore missingType.checkedException */
             throw new RuntimeException('Mapped: next() past end');
         }
 

--- a/src/Iterator/NoNulls.php
+++ b/src/Iterator/NoNulls.php
@@ -38,14 +38,12 @@ final class NoNulls implements Iterator
     public function current(): mixed
     {
         if (!$this->valid()) {
-            /** @phpstan-ignore missingType.checkedException */
             throw new RuntimeException('Iterator is past the end');
         }
 
         $value = $this->origin->current();
 
         if ($value === null) {
-            /** @phpstan-ignore missingType.checkedException */
             throw new RuntimeException('Null value encountered in NoNulls iterator');
         }
 
@@ -56,7 +54,6 @@ final class NoNulls implements Iterator
     public function key(): int
     {
         if (!$this->valid()) {
-            /** @phpstan-ignore missingType.checkedException */
             throw new RuntimeException('Iterator key is undefined because iterator is past the end');
         }
 
@@ -67,7 +64,6 @@ final class NoNulls implements Iterator
     public function next(): void
     {
         if (!$this->valid()) {
-            /** @phpstan-ignore missingType.checkedException */
             throw new RuntimeException('Iterator is past the end');
         }
 


### PR DESCRIPTION
- Removed 16 @phpstan-ignore missingType.checkedException directives in iterators and Repeated
- Simplified require-dev to just piqule, letting it pull phpstan-rules/slevomat/kubawerlos transitively
- Relied on new haspadar.missingThrows rule from phpstan-rules v0.44.1 which skips override methods