### PR TITLE
Drop Constructor-Init Suppresses via Composition And Covariance

### DIFF
--- a/src/Scalar/Scalar.php
+++ b/src/Scalar/Scalar.php
@@ -12,7 +12,7 @@ use Throwable;
  * Serves as a generic interface for deferred computation and value composition.
  * Used as a base abstraction for all primitive-like types (Text, Number, etc).
  *
- * @template T
+ * @template-covariant T
  * @since 0.1
  */
 interface Scalar

--- a/src/Text/Abbreviated.php
+++ b/src/Text/Abbreviated.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
+use Primus\Scalar\ScalarOf;
+
 /**
  * Abbreviated {@see Text}.
  *
@@ -26,26 +28,22 @@ final readonly class Abbreviated extends TextEnvelope
      */
     public function __construct(Text $origin, int $limit = 50)
     {
-        /** @phpstan-ignore haspadar.constructorInit */
-        if ($limit <= 0) {
-            parent::__construct(new TextOf(''));
+        parent::__construct(
+            new TextOfScalar(
+                new ScalarOf(
+                    static function () use ($origin, $limit): string {
+                        if ($limit <= 0) {
+                            return '';
+                        }
 
-            return;
-        }
+                        if (mb_strlen($origin->value(), 'UTF-8') <= $limit) {
+                            return $origin->value();
+                        }
 
-        /** @phpstan-ignore haspadar.constructorInit */
-        $length = new LengthOfText($origin);
-
-        /** @phpstan-ignore haspadar.constructorInit */
-        if ($length->value() <= $limit) {
-            parent::__construct($origin);
-
-            return;
-        }
-
-        /** @phpstan-ignore haspadar.constructorInit */
-        $truncated = sprintf('%s…', (new Sub($origin, 0, $limit - 1))->value());
-
-        parent::__construct(new TextOf($truncated));
+                        return sprintf('%s…', mb_substr($origin->value(), 0, $limit - 1, 'UTF-8'));
+                    },
+                ),
+            ),
+        );
     }
 }

--- a/src/Text/Capitalized.php
+++ b/src/Text/Capitalized.php
@@ -25,19 +25,11 @@ final readonly class Capitalized extends TextEnvelope
      */
     public function __construct(Text $origin)
     {
-        /** @phpstan-ignore haspadar.constructorInit */
-        $value = $origin->value();
-
         parent::__construct(
-            new TextOf(
-                $value === ''
-                    ? ''
-                    : sprintf(
-                        '%s%s',
-                        mb_strtoupper(mb_substr($value, 0, 1, 'UTF-8'), 'UTF-8'),
-                        mb_substr($value, 1, null, 'UTF-8'),
-                    ),
-            ),
+            new Joined('', [
+                new Uppered(new Sub($origin, 0, 1)),
+                new Sub($origin, 1),
+            ]),
         );
     }
 }

--- a/src/Text/LengthOfText.php
+++ b/src/Text/LengthOfText.php
@@ -25,14 +25,10 @@ final readonly class LengthOfText extends ScalarEnvelope
      */
     public function __construct(Text $origin)
     {
-        /**
-         * @var ScalarOf<int> $scalar
-         * @phpstan-ignore haspadar.constructorInit
-         */
-        $scalar = new ScalarOf(
-            static fn(): int => mb_strlen($origin->value(), 'UTF-8'),
+        parent::__construct(
+            new ScalarOf(
+                static fn(): int => mb_strlen($origin->value(), 'UTF-8'),
+            ),
         );
-
-        parent::__construct($scalar);
     }
 }

--- a/src/Text/TextOf.php
+++ b/src/Text/TextOf.php
@@ -8,8 +8,6 @@ use Override;
 
 /**
  * Text of a plain string.
- *
- * @phpstan-ignore haspadar.afferentCoupling
  */
 final readonly class TextOf implements Text
 {


### PR DESCRIPTION
- Moved Abbreviated branching into a ScalarOf closure passed to TextOfScalar
- Rewrote Capitalized as composition of Joined, Uppered and Sub
- Marked Scalar<T> covariant so LengthOfText factory passes type check inline
- Dropped TextOf afferentCoupling suppress after callers stopped wrapping directly