### PR TITLE
Tidy Exception Annotations In Scalar And FuncWithFallback

### DIFF
--- a/src/Func/FuncWithFallback.php
+++ b/src/Func/FuncWithFallback.php
@@ -33,7 +33,7 @@ final readonly class FuncWithFallback extends FuncEnvelope
                 static function ($input) use ($origin, $fallback) {
                     try {
                         return $origin->apply($input);
-                        // @phpstan-ignore-next-line haspadar.illegalCatch
+                        // @phpstan-ignore-next-line haspadar.illegalCatch (fallback catches anything by design)
                     } catch (Throwable) {
                         return $fallback->apply($input);
                     }

--- a/src/Scalar/Scalar.php
+++ b/src/Scalar/Scalar.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Primus\Scalar;
 
-use Throwable;
-
 /**
  * Represents a lazily-evaluated value of any type.
  *
@@ -21,8 +19,6 @@ interface Scalar
      * Returns the computed value.
      *
      * @noinspection ReturnTypeCanBeDeclaredInspection
-     * @phpstan-ignore-next-line haspadar.illegalThrows
-     * @throws Throwable if the value cannot be computed
      * @return T The value represented by this scalar.
      */
     public function value();


### PR DESCRIPTION
- Removed @throws Throwable from Scalar::value() — vague contract adds no documentation
- Annotated illegalCatch suppress in FuncWithFallback explaining the fallback-pattern intent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated method documentation for exception-handling behavior clarity.

* **Chores**
  * Removed unnecessary static analysis annotations and cleaned up unused references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->