### PR TITLE
Whitelist TextEnvelope In Piqule Afferent Coupling Check

### DIFF
--- a/.piqule.yaml
+++ b/.piqule.yaml
@@ -13,5 +13,7 @@ override:
     phpunit.testsuites.unit: ["../../tests"]
     phpunit.testsuites.integration: []
     phpmetrics.coupling.max_afferent: 20
+    phpstan.afferent_coupling.excluded_classes:
+        - Primus\Text\TextEnvelope
     php_cs_fixer.extend: |
         'phpdoc_types' => ['exclude' => ['scalar']],

--- a/.piqule/phpstan/phpstan.neon
+++ b/.piqule/phpstan/phpstan.neon
@@ -22,4 +22,5 @@ parameters:
     haspadar:
         afferentCoupling:
             ignoreInterfaces: true
-
+            excludedClasses:
+                - Primus\Text\TextEnvelope

--- a/src/Text/TextEnvelope.php
+++ b/src/Text/TextEnvelope.php
@@ -8,8 +8,6 @@ use Override;
 
 /**
  * Envelope for {@see Text}, delegating all calls to the origin.
- *
- * @phpstan-ignore haspadar.afferentCoupling
  */
 abstract readonly class TextEnvelope implements Text
 {


### PR DESCRIPTION
- Added Primus\Text\TextEnvelope to phpstan.afferent_coupling.excluded_classes in .piqule.yaml
- Dropped @phpstan-ignore haspadar.afferentCoupling from TextEnvelope class docblock
- TextEnvelope is the abstract root of 17 Text subclasses, high afferent coupling is by design

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PHPStan code analysis configuration.
  * Removed inline code analysis suppression comment in favor of external configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->