### PR TITLE
Rename AndOf to And_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## [Unreleased]
 
-### Changed
+### Removed
 
-- Renamed `Scalar\AndOf` to `Scalar\And_` to free the `Of` suffix for adapter classes.
+- `Scalar\AndOf` removed; renamed to `Scalar\And_` to free the `Of` suffix for adapter classes.
 
 ## [0.5.0] – 2025-11-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Renamed `Scalar\AndOf` to `Scalar\And_` to free the `Of` suffix for adapter classes.
+
 ## [0.5.0] – 2025-11-19
 
 ### Added

--- a/src/Scalar/And_.php
+++ b/src/Scalar/And_.php
@@ -12,13 +12,13 @@ use InvalidArgumentException;
  * Returns true only if all provided scalars evaluate to true.
  *
  * Example:
- *     $and = new AndOf(new True_(), new False_());
+ *     $and = new And_(new True_(), new False_());
  *     echo $and->value(); // false
  *
  * @extends ScalarEnvelope<bool>
  * @since 0.2
  */
-final readonly class AndOf extends ScalarEnvelope
+final readonly class And_ extends ScalarEnvelope
 {
     /**
      * Ctor.
@@ -31,7 +31,7 @@ final readonly class AndOf extends ScalarEnvelope
             new ScalarOf(
                 static function () use ($conditions): bool {
                     if ($conditions === []) {
-                        throw new InvalidArgumentException('AndOf requires at least one condition');
+                        throw new InvalidArgumentException('And_ requires at least one condition');
                     }
 
                     return array_reduce(

--- a/src/Scalar/And_.php
+++ b/src/Scalar/And_.php
@@ -31,7 +31,7 @@ final readonly class And_ extends ScalarEnvelope
             new ScalarOf(
                 static function () use ($conditions): bool {
                     if ($conditions === []) {
-                        throw new InvalidArgumentException('And_ requires at least one condition');
+                        throw new InvalidArgumentException('And requires at least one condition');
                     }
 
                     return array_reduce(

--- a/src/Scalar/Between.php
+++ b/src/Scalar/Between.php
@@ -31,7 +31,7 @@ final readonly class Between extends ScalarEnvelope
     public function __construct(Scalar $value, Scalar $lower, Scalar $upper)
     {
         parent::__construct(
-            new AndOf(
+            new And_(
                 new GreaterThan($value, $lower),
                 new LessThan($value, $upper),
             ),

--- a/tests/Scalar/And_Test.php
+++ b/tests/Scalar/And_Test.php
@@ -7,7 +7,7 @@ namespace Primus\Tests\Scalar;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Primus\Scalar\AndOf;
+use Primus\Scalar\And_;
 use Primus\Scalar\ScalarOf;
 use Primus\Tests\Constraint\HasScalarBoolValue;
 use Primus\Tests\Constraint\ThrowsValue;
@@ -15,18 +15,18 @@ use Primus\Tests\Constraint\ThrowsValue;
 /**
  * @since 0.2
  */
-final class AndOfTest extends TestCase
+final class And_Test extends TestCase
 {
     #[Test]
     public function returnsTrueWhenAllTrue(): void
     {
         self::assertThat(
-            new AndOf(
+            new And_(
                 new ScalarOf(fn (): true => true),
                 new ScalarOf(fn (): true => true)
             ),
             new HasScalarBoolValue(true),
-            'AndOf must return true when all scalars are true'
+            'And_ must return true when all scalars are true'
         );
     }
 
@@ -34,12 +34,12 @@ final class AndOfTest extends TestCase
     public function returnsFalseWhenOneIsFalse(): void
     {
         self::assertThat(
-            new AndOf(
+            new And_(
                 new ScalarOf(fn (): true => true),
                 new ScalarOf(fn (): false => false)
             ),
             new HasScalarBoolValue(false),
-            'AndOf must return false when at least one scalar is false'
+            'And_ must return false when at least one scalar is false'
         );
     }
 
@@ -47,12 +47,12 @@ final class AndOfTest extends TestCase
     public function returnsFalseWhenAllFalse(): void
     {
         self::assertThat(
-            new AndOf(
+            new And_(
                 new ScalarOf(fn (): false => false),
                 new ScalarOf(fn (): false => false)
             ),
             new HasScalarBoolValue(false),
-            'AndOf must return false when all scalars are false'
+            'And_ must return false when all scalars are false'
         );
     }
 
@@ -60,9 +60,9 @@ final class AndOfTest extends TestCase
     public function throwsWhenNoScalarsProvided(): void
     {
         self::assertThat(
-            new ScalarOf(fn () => (new AndOf())->value()),
+            new ScalarOf(fn () => (new And_())->value()),
             new ThrowsValue(InvalidArgumentException::class),
-            'AndOf must throw an exception when no scalars are provided'
+            'And_ must throw an exception when no scalars are provided'
         );
     }
 }

--- a/tests/Scalar/And_Test.php
+++ b/tests/Scalar/And_Test.php
@@ -26,7 +26,7 @@ final class And_Test extends TestCase
                 new ScalarOf(fn (): true => true)
             ),
             new HasScalarBoolValue(true),
-            'And_ must return true when all scalars are true'
+            'And must return true when all scalars are true'
         );
     }
 
@@ -39,7 +39,7 @@ final class And_Test extends TestCase
                 new ScalarOf(fn (): false => false)
             ),
             new HasScalarBoolValue(false),
-            'And_ must return false when at least one scalar is false'
+            'And must return false when at least one scalar is false'
         );
     }
 
@@ -52,7 +52,7 @@ final class And_Test extends TestCase
                 new ScalarOf(fn (): false => false)
             ),
             new HasScalarBoolValue(false),
-            'And_ must return false when all scalars are false'
+            'And must return false when all scalars are false'
         );
     }
 
@@ -62,7 +62,7 @@ final class And_Test extends TestCase
         self::assertThat(
             new ScalarOf(fn () => (new And_())->value()),
             new ThrowsValue(InvalidArgumentException::class),
-            'And_ must throw an exception when no scalars are provided'
+            'And must throw an exception when no scalars are provided'
         );
     }
 }


### PR DESCRIPTION
- Renamed Scalar\AndOf to Scalar\And_ to free the Of suffix for adapter classes
- Updated Between, tests, and changelog to reference the new class
- Updated user-facing messages to read "And" without the keyword-workaround underscore

Part of #50

**Breaking changes:**
- `Primus\Scalar\AndOf` removed; use `Primus\Scalar\And_`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed `AndOf` scalar class to `And_` for improved API naming consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->