### PR TITLE
Rename XorOf to Xor_

### DIFF
--- a/src/Scalar/Xor_.php
+++ b/src/Scalar/Xor_.php
@@ -12,7 +12,7 @@ use InvalidArgumentException;
  * Returns true only if an odd number of conditions are true.
  *
  * Example:
- *     $scalar = new XorOf(
+ *     $scalar = new Xor_(
  *         new ScalarOf(fn() => true),
  *         new ScalarOf(fn() => false)
  *     );
@@ -21,7 +21,7 @@ use InvalidArgumentException;
  * @extends ScalarEnvelope<bool>
  * @since 0.2
  */
-final readonly class XorOf extends ScalarEnvelope
+final readonly class Xor_ extends ScalarEnvelope
 {
     /**
      * Ctor.
@@ -33,7 +33,7 @@ final readonly class XorOf extends ScalarEnvelope
         parent::__construct(
             new ScalarOf(
                 static fn(): bool => match (count($conditions)) {
-                    0 => throw new InvalidArgumentException('XorOf requires at least one condition'),
+                    0 => throw new InvalidArgumentException('Xor requires at least one condition'),
                     default => array_reduce(
                         $conditions,
                         static fn(bool $carry, Scalar $cond): bool => $carry xor $cond->value(),

--- a/tests/Scalar/Xor_Test.php
+++ b/tests/Scalar/Xor_Test.php
@@ -8,25 +8,25 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Primus\Scalar\ScalarOf;
-use Primus\Scalar\XorOf;
+use Primus\Scalar\Xor_;
 use Primus\Tests\Constraint\HasScalarBoolValue;
 use Primus\Tests\Constraint\ThrowsValue;
 
 /**
  * @since 0.2
  */
-final class XorOfTest extends TestCase
+final class Xor_Test extends TestCase
 {
     #[Test]
     public function returnsTrueWhenExactlyOneConditionTrue(): void
     {
         self::assertThat(
-            new XorOf(
+            new Xor_(
                 new ScalarOf(fn (): true => true),
                 new ScalarOf(fn (): false => false),
             ),
             new HasScalarBoolValue(true),
-            'XorOf must return true when exactly one condition is true'
+            'Xor must return true when exactly one condition is true'
         );
     }
 
@@ -34,12 +34,12 @@ final class XorOfTest extends TestCase
     public function returnsFalseWhenBothTrue(): void
     {
         self::assertThat(
-            new XorOf(
+            new Xor_(
                 new ScalarOf(fn (): true => true),
                 new ScalarOf(fn (): true => true),
             ),
             new HasScalarBoolValue(false),
-            'XorOf must return false when both conditions are true'
+            'Xor must return false when both conditions are true'
         );
     }
 
@@ -47,12 +47,12 @@ final class XorOfTest extends TestCase
     public function returnsFalseWhenBothFalse(): void
     {
         self::assertThat(
-            new XorOf(
+            new Xor_(
                 new ScalarOf(fn (): false => false),
                 new ScalarOf(fn (): false => false),
             ),
             new HasScalarBoolValue(false),
-            'XorOf must return false when both conditions are false'
+            'Xor must return false when both conditions are false'
         );
     }
 
@@ -60,13 +60,13 @@ final class XorOfTest extends TestCase
     public function returnsFalseWhenEvenNumberTrue(): void
     {
         self::assertThat(
-            new XorOf(
+            new Xor_(
                 new ScalarOf(fn (): true => true),
                 new ScalarOf(fn (): false => false),
                 new ScalarOf(fn (): true => true),
             ),
             new HasScalarBoolValue(false),
-            'XorOf must return false when an even number of conditions are true'
+            'Xor must return false when an even number of conditions are true'
         );
     }
 
@@ -74,9 +74,9 @@ final class XorOfTest extends TestCase
     public function throwsWhenNoConditionsProvided(): void
     {
         self::assertThat(
-            new ScalarOf(fn () => (new XorOf())->value()),
+            new ScalarOf(fn () => (new Xor_())->value()),
             new ThrowsValue(InvalidArgumentException::class),
-            'XorOf must throw an exception when no conditions are provided'
+            'Xor must throw an exception when no conditions are provided'
         );
     }
 }


### PR DESCRIPTION
- Renamed Scalar\XorOf to Scalar\Xor_ to free the Of suffix for adapter classes
- Updated tests and user-facing messages to read "Xor" without the keyword-workaround underscore

Part of #50

**Breaking changes:**
- `Primus\Scalar\XorOf` removed; use `Primus\Scalar\Xor_`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed the `XorOf` scalar class to `Xor_`. Users must update their code references to use the new class name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->