### PR TITLE
Rename IterableOf to Iterable_

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Func, FuncOf, FuncEnvelope, BiFunc, Proc, Predicate, StickyFunc, Repeated
 IteratorOf, Mapped, Filtered, Joined, NoNulls
 
 ### **Iterable**
-IterableOf, Mapped, Filtered, Joined, NoNulls
+Iterable_, Mapped, Filtered, Joined, NoNulls
 
 ### **Numeric (WIP)**
 Positive, NonZero, Rounded

--- a/src/Iterable/Filtered.php
+++ b/src/Iterable/Filtered.php
@@ -15,7 +15,7 @@ use Traversable;
  *
  * Example:
  *     $it = new Filtered(
- *         new IterableOf([10, 5, 40, 3]),
+ *         new Iterable_([10, 5, 40, 3]),
  *         new PredicateOf(fn (int $x): bool => $x > 10)
  *     );
  *

--- a/src/Iterable/Iterable_.php
+++ b/src/Iterable/Iterable_.php
@@ -12,7 +12,7 @@ use Override;
  * Iterable wrapper over an array of items.
  *
  * Example:
- *     $it = new IterableOf([10, 20, 30]);
+ *     $it = new Iterable_([10, 20, 30]);
  *     foreach ($it as $value) {
  *         echo $value . ' ';
  *     }
@@ -22,7 +22,7 @@ use Override;
  * @implements IteratorAggregate<array-key, T>
  * @since 0.5
  */
-final readonly class IterableOf implements IteratorAggregate
+final readonly class Iterable_ implements IteratorAggregate
 {
     /**
      * Ctor.

--- a/src/Iterable/Mapped.php
+++ b/src/Iterable/Mapped.php
@@ -15,7 +15,7 @@ use Traversable;
  *
  * Example:
  *     $it = new Mapped(
- *         new IterableOf([1, 2, 3]),
+ *         new Iterable_([1, 2, 3]),
  *         new FuncOf(fn (int $x): int => $x * 10)
  *     );
  *

--- a/tests/Iterable/FilteredTest.php
+++ b/tests/Iterable/FilteredTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Primus\Func\PredicateOf;
 use Primus\Iterable\Filtered;
-use Primus\Iterable\IterableOf;
+use Primus\Iterable\Iterable_;
 use Primus\Tests\Constraint\HasIteratorValues;
 
 /**
@@ -21,7 +21,7 @@ final class FilteredTest extends TestCase
     {
         self::assertThat(
             new Filtered(
-                new IterableOf([10, 5, 40, 3]),
+                new Iterable_([10, 5, 40, 3]),
                 new PredicateOf(fn (int $x): bool => $x > 10),
             ),
             new HasIteratorValues([40]),
@@ -34,7 +34,7 @@ final class FilteredTest extends TestCase
     {
         self::assertThat(
             new Filtered(
-                new IterableOf([1, 2, 3, 4, 5]),
+                new Iterable_([1, 2, 3, 4, 5]),
                 new PredicateOf(fn (int $x): bool => $x % 2 === 0),
             ),
             new HasIteratorValues([2, 4]),
@@ -47,7 +47,7 @@ final class FilteredTest extends TestCase
     {
         self::assertThat(
             new Filtered(
-                new IterableOf([1, 3, 5]),
+                new Iterable_([1, 3, 5]),
                 new PredicateOf(fn (int $x): bool => $x > 10),
             ),
             new HasIteratorValues([]),
@@ -60,7 +60,7 @@ final class FilteredTest extends TestCase
     {
         self::assertThat(
             new Filtered(
-                new IterableOf([]),
+                new Iterable_([]),
                 new PredicateOf(fn (int $_): bool => true),
             ),
             new HasIteratorValues([]),
@@ -72,7 +72,7 @@ final class FilteredTest extends TestCase
     public function rewindingProducesSameSequence(): void
     {
         $filtered = new Filtered(
-            new IterableOf([1, 2, 3, 4]),
+            new Iterable_([1, 2, 3, 4]),
             new PredicateOf(fn (int $x): bool => $x > 2),
         );
 

--- a/tests/Iterable/Iterable_Test.php
+++ b/tests/Iterable/Iterable_Test.php
@@ -6,19 +6,19 @@ namespace Primus\Tests\Iterable;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Primus\Iterable\IterableOf;
+use Primus\Iterable\Iterable_;
 use Primus\Tests\Constraint\HasIteratorValues;
 
 /**
  * @since 0.5
  */
-final class IterableOfTest extends TestCase
+final class Iterable_Test extends TestCase
 {
     #[Test]
     public function yieldsAllValuesInOrder(): void
     {
         self::assertThat(
-            new IterableOf([10, 20, 30]),
+            new Iterable_([10, 20, 30]),
             new HasIteratorValues([10, 20, 30]),
         );
     }
@@ -27,7 +27,7 @@ final class IterableOfTest extends TestCase
     public function yieldsEmptySequence(): void
     {
         self::assertThat(
-            new IterableOf([]),
+            new Iterable_([]),
             new HasIteratorValues([]),
         );
     }
@@ -35,7 +35,7 @@ final class IterableOfTest extends TestCase
     #[Test]
     public function eachIterationStartsFromBeginning(): void
     {
-        $iterable = new IterableOf([1, 2]);
+        $iterable = new Iterable_([1, 2]);
 
         iterator_to_array($iterable);
 
@@ -49,7 +49,7 @@ final class IterableOfTest extends TestCase
     public function ignoresOriginalArrayKeys(): void
     {
         self::assertThat(
-            new IterableOf([2 => 5, 10 => 6, 50 => 7]),
+            new Iterable_([2 => 5, 10 => 6, 50 => 7]),
             new HasIteratorValues([5, 6, 7]),
         );
     }
@@ -62,7 +62,7 @@ final class IterableOfTest extends TestCase
         $arr[20] = 'b';
 
         self::assertThat(
-            new IterableOf($arr),
+            new Iterable_($arr),
             new HasIteratorValues(['a', 'b']),
         );
     }

--- a/tests/Iterable/JoinedTest.php
+++ b/tests/Iterable/JoinedTest.php
@@ -6,7 +6,7 @@ namespace Primus\Tests\Iterable;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Primus\Iterable\IterableOf;
+use Primus\Iterable\Iterable_;
 use Primus\Iterable\Joined;
 use Primus\Tests\Constraint\HasIteratorValues;
 
@@ -20,9 +20,9 @@ final class JoinedTest extends TestCase
     {
         self::assertThat(
             new Joined([
-                new IterableOf([1, 2]),
-                new IterableOf([3]),
-                new IterableOf([4]),
+                new Iterable_([1, 2]),
+                new Iterable_([3]),
+                new Iterable_([4]),
             ]),
             new HasIteratorValues([1, 2, 3, 4]),
         );
@@ -41,8 +41,8 @@ final class JoinedTest extends TestCase
     public function producesSameValuesOnSecondIteration(): void
     {
         $joined = new Joined([
-            new IterableOf([10]),
-            new IterableOf([20]),
+            new Iterable_([10]),
+            new Iterable_([20]),
         ]);
 
         iterator_to_array($joined);
@@ -57,8 +57,8 @@ final class JoinedTest extends TestCase
     public function keysAreSequential(): void
     {
         $it = new Joined([
-            new IterableOf([5]),
-            new IterableOf([6]),
+            new Iterable_([5]),
+            new Iterable_([6]),
         ]);
 
         self::assertSame([0 => 5, 1 => 6], iterator_to_array($it));

--- a/tests/Iterable/MappedTest.php
+++ b/tests/Iterable/MappedTest.php
@@ -7,7 +7,7 @@ namespace Primus\Tests\Iterable;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Primus\Func\FuncOf;
-use Primus\Iterable\IterableOf;
+use Primus\Iterable\Iterable_;
 use Primus\Iterable\Mapped;
 use Primus\Tests\Constraint\EqualsValue;
 use Primus\Tests\Constraint\HasIteratorValues;
@@ -22,7 +22,7 @@ final class MappedTest extends TestCase
     {
         self::assertThat(
             new Mapped(
-                new IterableOf([1, 2, 3]),
+                new Iterable_([1, 2, 3]),
                 new FuncOf(fn (int $x): int => $x * 10),
             ),
             new HasIteratorValues([10, 20, 30]),
@@ -35,7 +35,7 @@ final class MappedTest extends TestCase
     {
         self::assertThat(
             new Mapped(
-                new IterableOf([]),
+                new Iterable_([]),
                 new FuncOf(fn (mixed $x): mixed => $x),
             ),
             new HasIteratorValues([]),
@@ -48,7 +48,7 @@ final class MappedTest extends TestCase
     {
         self::assertThat(
             new Mapped(
-                new IterableOf(['a', 'b', 'c']),
+                new Iterable_(['a', 'b', 'c']),
                 new FuncOf(fn (string $s): string => strtoupper($s)),
             ),
             new HasIteratorValues(['A', 'B', 'C']),
@@ -60,7 +60,7 @@ final class MappedTest extends TestCase
     public function producesFreshIteratorEachTime(): void
     {
         $mapped = new Mapped(
-            new IterableOf([1, 2]),
+            new Iterable_([1, 2]),
             new FuncOf(fn (int $x): int => $x + 10),
         );
 

--- a/tests/Iterable/NoNullsTest.php
+++ b/tests/Iterable/NoNullsTest.php
@@ -7,7 +7,7 @@ namespace Primus\Tests\Iterable;
 use ArrayIterator;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Primus\Iterable\IterableOf;
+use Primus\Iterable\Iterable_;
 use Primus\Iterable\NoNulls;
 use Primus\Tests\Constraint\HasIteratorValues;
 use Primus\Tests\Constraint\ThrowsClosure;
@@ -23,7 +23,7 @@ final class NoNullsTest extends TestCase
     {
         self::assertThat(
             static function (): void {
-                foreach (new NoNulls(new IterableOf([1, null, 3])) as $value) {
+                foreach (new NoNulls(new Iterable_([1, null, 3])) as $value) {
                     // consume
                     unset($value);
                 }
@@ -37,7 +37,7 @@ final class NoNullsTest extends TestCase
     public function iteratesOverNonNullValues(): void
     {
         self::assertThat(
-            new NoNulls(new IterableOf([1, 2])),
+            new NoNulls(new Iterable_([1, 2])),
             new HasIteratorValues([1, 2]),
             'NoNulls must yield non-null values only'
         );
@@ -48,7 +48,7 @@ final class NoNullsTest extends TestCase
     {
         self::assertThat(
             static function (): void {
-                foreach (new NoNulls(new IterableOf([null])) as $value) {
+                foreach (new NoNulls(new Iterable_([null])) as $value) {
                     // consume
                     unset($value);
                 }
@@ -62,7 +62,7 @@ final class NoNullsTest extends TestCase
     public function yieldsSequentialIntegerKeys(): void
     {
         $keys = [];
-        foreach (new NoNulls(new IterableOf(['a', 'b', 'c'])) as $key => $value) {
+        foreach (new NoNulls(new Iterable_(['a', 'b', 'c'])) as $key => $value) {
             $keys[] = $key;
             unset($value);
         }


### PR DESCRIPTION
- Renamed Iterable\IterableOf to Iterable\Iterable_ to free the Of suffix for adapter classes
- Updated all call sites, tests, and the README to reference the new class

Closes #50

**Breaking changes:**
- `Primus\Iterable\IterableOf` removed; use `Primus\Iterable\Iterable_`