### PR TITLE
Block PRs Without Release-Drafter Label

### DIFF
--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize, edited]
 
+concurrency:
+  group: require-pr-label-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: read
 
@@ -33,5 +37,6 @@ jobs:
             if (matching.length === 0) {
               core.setFailed(`PR must carry exactly one release-drafter label: ${list} (or \`skip-changelog\`).`);
             } else {
-              core.setFailed(`PR carries multiple release-drafter labels (${matching.join(', ')}); only one is allowed.`);
+              const found = matching.join(', ');
+              core.setFailed(`PR carries multiple release-drafter labels (${found}); only one is allowed.`);
             }

--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -1,0 +1,37 @@
+name: Require PR Label
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize, edited]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify exactly one release-drafter label
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          script: |
+            const accepted = ['feat', 'fix', 'refactor', 'docs', 'ci', 'chore', 'test', 'dependencies'];
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+
+            if (labels.includes('skip-changelog')) {
+              core.info('skip-changelog present — release-drafter label not required');
+              return;
+            }
+
+            const matching = labels.filter(name => accepted.includes(name));
+            if (matching.length === 1) {
+              core.info(`Found release-drafter label: ${matching[0]}`);
+              return;
+            }
+
+            const list = accepted.map(l => `\`${l}\``).join(', ');
+            if (matching.length === 0) {
+              core.setFailed(`PR must carry exactly one release-drafter label: ${list} (or \`skip-changelog\`).`);
+            } else {
+              core.setFailed(`PR carries multiple release-drafter labels (${matching.join(', ')}); only one is allowed.`);
+            }

--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -2,7 +2,7 @@ name: Require PR Label
 
 on:
   pull_request:
-    types: [opened, labeled, unlabeled, synchronize, edited]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 concurrency:
   group: require-pr-label-${{ github.event.pull_request.number }}
@@ -19,6 +19,7 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
+            // Source of truth: .github/release-drafter.yml (version-resolver)
             const accepted = ['feat', 'fix', 'refactor', 'docs', 'ci', 'chore', 'test', 'dependencies'];
             const labels = context.payload.pull_request.labels.map(l => l.name);
 


### PR DESCRIPTION
- Added a workflow that fails CI when a PR has zero or multiple release-drafter labels
- Updated the workflow to cancel stale runs on rapid edits

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated pull request label validation workflow has been introduced. Each pull request must now include exactly one label from a predefined set of approved categories to proceed. A dedicated skip-changelog label is available to exempt contributions from standard category requirements when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->