### PR TITLE
Add Transformation Decorators To List

### DIFF
--- a/src/List/Filtered.php
+++ b/src/List/Filtered.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\List;
+
+use Generator;
+use Override;
+use Primus\Func\Predicate;
+
+/**
+ * List of elements that match a predicate.
+ *
+ * Example:
+ *     $list = new Filtered(
+ *         new ListOf(10, 5, 40, 3),
+ *         new PredicateOf(fn (int $x): bool => $x > 10),
+ *     );
+ *     foreach ($list as $value) {
+ *         echo $value . ' '; // 40
+ *     }
+ *
+ * @template T
+ * @extends ListEnvelope<T>
+ * @since 0.3
+ */
+final readonly class Filtered extends ListEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param List_<T> $origin The list whose elements are filtered.
+     * @param Predicate<T> $predicate The predicate that selects elements.
+     */
+    public function __construct(List_ $origin, private Predicate $predicate)
+    {
+        parent::__construct($origin);
+    }
+
+    #[Override]
+    public function value(): array
+    {
+        return iterator_to_array($this->getIterator(), false);
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return count($this->value());
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        foreach ($this->origin->value() as $item) {
+            if ($this->predicate->apply($item)) {
+                yield $item;
+            }
+        }
+    }
+}

--- a/src/List/Mapped.php
+++ b/src/List/Mapped.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\List;
+
+use Generator;
+use Override;
+use Primus\Func\Func;
+
+/**
+ * List with each element transformed by a function.
+ *
+ * Example:
+ *     $list = new Mapped(
+ *         new ListOf(1, 2, 3),
+ *         new FuncOf(fn (int $x): int => $x * 10),
+ *     );
+ *     foreach ($list as $value) {
+ *         echo $value . ' ';
+ *     }
+ *     // 10 20 30
+ *
+ * @template X
+ * @template Y
+ * @implements List_<Y>
+ * @since 0.3
+ */
+final readonly class Mapped implements List_
+{
+    /**
+     * Ctor.
+     *
+     * @param List_<X> $origin The list whose elements are transformed.
+     * @param Func<X, Y> $func The transformation function.
+     */
+    public function __construct(private List_ $origin, private Func $func) {}
+
+    #[Override]
+    public function value(): array
+    {
+        return iterator_to_array($this->getIterator(), false);
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return $this->origin->count();
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        foreach ($this->origin->value() as $item) {
+            yield $this->func->apply($item);
+        }
+    }
+}

--- a/src/List/NoNulls.php
+++ b/src/List/NoNulls.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\List;
+
+use Generator;
+use Override;
+use RuntimeException;
+
+/**
+ * List that forbids null values.
+ *
+ * Iteration throws when the source list contains a null element,
+ * enforcing a non-null invariant by failing fast.
+ *
+ * @template T
+ * @extends ListEnvelope<T>
+ * @since 0.3
+ */
+final readonly class NoNulls extends ListEnvelope
+{
+    #[Override]
+    public function value(): array
+    {
+        return iterator_to_array($this->getIterator(), false);
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        foreach ($this->origin->value() as $value) {
+            if ($value === null) {
+                throw new RuntimeException('Null value encountered in NoNulls list');
+            }
+
+            yield $value;
+        }
+    }
+}

--- a/src/List/NoNulls.php
+++ b/src/List/NoNulls.php
@@ -27,6 +27,12 @@ final readonly class NoNulls extends ListEnvelope
     }
 
     #[Override]
+    public function count(): int
+    {
+        return count($this->value());
+    }
+
+    #[Override]
     public function getIterator(): Generator
     {
         foreach ($this->origin->value() as $value) {

--- a/tests/List/FilteredTest.php
+++ b/tests/List/FilteredTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Primus\Func\PredicateOf;
 use Primus\List\Filtered;
 use Primus\List\ListOf;
+use Primus\List\Reversed;
 
 final class FilteredTest extends TestCase
 {
@@ -71,5 +72,19 @@ final class FilteredTest extends TestCase
         $filtered->value();
         iterator_to_array($filtered);
         $this->assertSame([1, 2, 3, 4], $source->value());
+    }
+
+    #[Test]
+    public function composesWithReversed(): void
+    {
+        $this->assertSame(
+            [4, 3],
+            (new Reversed(
+                new Filtered(
+                    new ListOf(1, 2, 3, 4),
+                    new PredicateOf(static fn (int $x): bool => $x > 2),
+                ),
+            ))->value(),
+        );
     }
 }

--- a/tests/List/FilteredTest.php
+++ b/tests/List/FilteredTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\List;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Func\PredicateOf;
+use Primus\List\Filtered;
+use Primus\List\ListOf;
+
+final class FilteredTest extends TestCase
+{
+    #[Test]
+    public function yieldsMatchingElements(): void
+    {
+        $this->assertSame(
+            [40, 50],
+            (new Filtered(
+                new ListOf(10, 5, 40, 3, 50),
+                new PredicateOf(static fn (int $x): bool => $x > 10),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesRelativeOrder(): void
+    {
+        $this->assertSame(
+            ['banana', 'cherry'],
+            (new Filtered(
+                new ListOf('apple', 'banana', 'cherry'),
+                new PredicateOf(static fn (string $x): bool => strlen($x) > 5),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function yieldsNothingWhenNoneMatch(): void
+    {
+        $this->assertCount(
+            0,
+            new Filtered(
+                new ListOf(1, 2, 3),
+                new PredicateOf(static fn (int $x): bool => $x > 100),
+            ),
+        );
+    }
+
+    #[Test]
+    public function countReflectsMatchedElements(): void
+    {
+        $this->assertCount(
+            2,
+            new Filtered(
+                new ListOf(1, 2, 3, 4),
+                new PredicateOf(static fn (int $x): bool => $x % 2 === 0),
+            ),
+        );
+    }
+
+    #[Test]
+    public function leavesSourceUntouchedAfterReading(): void
+    {
+        $source = new ListOf(1, 2, 3, 4);
+        $filtered = new Filtered(
+            $source,
+            new PredicateOf(static fn (int $x): bool => $x > 2),
+        );
+        $filtered->value();
+        iterator_to_array($filtered);
+        $this->assertSame([1, 2, 3, 4], $source->value());
+    }
+}

--- a/tests/List/MappedTest.php
+++ b/tests/List/MappedTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\List;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Func\FuncOf;
+use Primus\List\ListOf;
+use Primus\List\Mapped;
+use Primus\List\Reversed;
+
+final class MappedTest extends TestCase
+{
+    #[Test]
+    public function transformsEachElement(): void
+    {
+        $this->assertSame(
+            [10, 20, 30],
+            (new Mapped(
+                new ListOf(1, 2, 3),
+                new FuncOf(static fn (int $x): int => $x * 10),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesCount(): void
+    {
+        $this->assertCount(
+            4,
+            new Mapped(
+                new ListOf('a', 'b', 'c', 'd'),
+                new FuncOf(static fn (string $x): string => strtoupper($x)),
+            ),
+        );
+    }
+
+    #[Test]
+    public function iteratesOverTransformedValues(): void
+    {
+        $collected = [];
+        foreach (
+            new Mapped(
+                new ListOf(1, 2, 3),
+                new FuncOf(static fn (int $x): int => $x + 100),
+            ) as $value
+        ) {
+            $collected[] = $value;
+        }
+        $this->assertSame([101, 102, 103], $collected);
+    }
+
+    #[Test]
+    public function leavesSourceUntouchedAfterReading(): void
+    {
+        $source = new ListOf(1, 2, 3);
+        $mapped = new Mapped(
+            $source,
+            new FuncOf(static fn (int $x): int => $x * 2),
+        );
+        $mapped->value();
+        iterator_to_array($mapped);
+        $this->assertSame([1, 2, 3], $source->value());
+    }
+
+    #[Test]
+    public function composesWithReversed(): void
+    {
+        $this->assertSame(
+            [30, 20, 10],
+            (new Reversed(
+                new Mapped(
+                    new ListOf(1, 2, 3),
+                    new FuncOf(static fn (int $x): int => $x * 10),
+                ),
+            ))->value(),
+        );
+    }
+}

--- a/tests/List/NoNullsTest.php
+++ b/tests/List/NoNullsTest.php
@@ -51,7 +51,7 @@ final class NoNullsTest extends TestCase
     public function throwsOnNullWhenCounting(): void
     {
         $this->expectException(RuntimeException::class);
-        count(new NoNulls(new ListOf(1, null, 3)));
+        (new NoNulls(new ListOf(1, null, 3)))->count();
     }
 
     #[Test]

--- a/tests/List/NoNullsTest.php
+++ b/tests/List/NoNullsTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Primus\List\ListOf;
 use Primus\List\NoNulls;
+use Primus\List\Reversed;
 use RuntimeException;
 
 final class NoNullsTest extends TestCase
@@ -44,5 +45,21 @@ final class NoNullsTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         (new NoNulls(new ListOf('x', null)))->value();
+    }
+
+    #[Test]
+    public function throwsOnNullWhenCounting(): void
+    {
+        $this->expectException(RuntimeException::class);
+        count(new NoNulls(new ListOf(1, null, 3)));
+    }
+
+    #[Test]
+    public function composesWithReversed(): void
+    {
+        $this->assertSame(
+            [3, 2, 1],
+            (new Reversed(new NoNulls(new ListOf(1, 2, 3))))->value(),
+        );
     }
 }

--- a/tests/List/NoNullsTest.php
+++ b/tests/List/NoNullsTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\List;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\List\ListOf;
+use Primus\List\NoNulls;
+use RuntimeException;
+
+final class NoNullsTest extends TestCase
+{
+    #[Test]
+    public function yieldsSourceUnchangedWhenNoNulls(): void
+    {
+        $this->assertSame(
+            [1, 2, 3],
+            (new NoNulls(new ListOf(1, 2, 3)))->value(),
+        );
+    }
+
+    #[Test]
+    public function iteratesOverNonNullValues(): void
+    {
+        $collected = [];
+        foreach (new NoNulls(new ListOf('a', 'b')) as $value) {
+            $collected[] = $value;
+        }
+        $this->assertSame(['a', 'b'], $collected);
+    }
+
+    #[Test]
+    public function throwsOnNullDuringIteration(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Null value encountered in NoNulls list');
+        iterator_to_array(new NoNulls(new ListOf(1, null, 3)));
+    }
+
+    #[Test]
+    public function throwsOnNullWhenAccessingValue(): void
+    {
+        $this->expectException(RuntimeException::class);
+        (new NoNulls(new ListOf('x', null)))->value();
+    }
+}


### PR DESCRIPTION
- Added a mapping decorator that transforms each list element through a function
- Added a filtering decorator that keeps elements matching a predicate
- Added a null-rejecting decorator that throws on null elements during iteration

Closes #64