### PR TITLE
Add Map Namespace

### DIFF
--- a/src/Map/Map.php
+++ b/src/Map/Map.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Map;
+
+use Countable;
+use IteratorAggregate;
+
+/**
+ * Represents an associative collection of key-value pairs.
+ *
+ * Used for composition and decoration of map-based logic.
+ *
+ * @template K of array-key
+ * @template V
+ * @extends IteratorAggregate<K, V>
+ * @since 0.3
+ */
+interface Map extends Countable, IteratorAggregate
+{
+    /**
+     * Returns the underlying pairs as an associative array.
+     *
+     * @return array<K, V>
+     */
+    public function value(): array;
+}

--- a/src/Map/MapEnvelope.php
+++ b/src/Map/MapEnvelope.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Map;
+
+use Generator;
+use Override;
+
+/**
+ * Envelope for {@see Map}, delegating all calls to the origin.
+ *
+ * @template K of array-key
+ * @template V
+ * @implements Map<K, V>
+ * @since 0.3
+ */
+abstract readonly class MapEnvelope implements Map
+{
+    /**
+     * Ctor.
+     *
+     * @param Map<K, V> $origin The map to delegate to.
+     */
+    public function __construct(protected Map $origin) {}
+
+    #[Override]
+    public function value(): array
+    {
+        return $this->origin->value();
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return $this->origin->count();
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->origin->getIterator();
+    }
+}

--- a/src/Map/MapOf.php
+++ b/src/Map/MapOf.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Map;
+
+use Generator;
+use Override;
+
+/**
+ * Map built from an associative array.
+ *
+ * Example:
+ *     $map = new MapOf(['a' => 1, 'b' => 2]);
+ *     echo count($map); // 2
+ *
+ * @template K of array-key
+ * @template V
+ * @implements Map<K, V>
+ * @since 0.3
+ */
+final readonly class MapOf implements Map
+{
+    /**
+     * Ctor.
+     *
+     * @param array<K, V> $pairs The associative array to wrap.
+     */
+    public function __construct(private array $pairs) {}
+
+    #[Override]
+    public function value(): array
+    {
+        return $this->pairs;
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return count($this->pairs);
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->pairs;
+    }
+}

--- a/src/Map/NoNulls.php
+++ b/src/Map/NoNulls.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Map;
+
+use Generator;
+use Override;
+use RuntimeException;
+
+/**
+ * Map that forbids null values.
+ *
+ * Any access (value, count, foreach) throws when the source map contains
+ * a null value, enforcing a non-null invariant by failing fast.
+ *
+ * @template K of array-key
+ * @template V
+ * @extends MapEnvelope<K, V>
+ * @since 0.3
+ */
+final readonly class NoNulls extends MapEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Map<K, V> $origin The map whose null values should be rejected.
+     */
+    public function __construct(Map $origin)
+    {
+        parent::__construct($origin);
+    }
+
+    #[Override]
+    public function value(): array
+    {
+        $pairs = [];
+
+        foreach ($this->origin->value() as $key => $value) {
+            if ($value === null) {
+                throw new RuntimeException('Null value encountered in NoNulls map');
+            }
+
+            $pairs[$key] = $value;
+        }
+
+        return $pairs;
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return count($this->value());
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        foreach ($this->origin->value() as $key => $value) {
+            if ($value === null) {
+                throw new RuntimeException('Null value encountered in NoNulls map');
+            }
+
+            yield $key => $value;
+        }
+    }
+}

--- a/src/Map/NoNulls.php
+++ b/src/Map/NoNulls.php
@@ -34,17 +34,7 @@ final readonly class NoNulls extends MapEnvelope
     #[Override]
     public function value(): array
     {
-        $pairs = [];
-
-        foreach ($this->origin->value() as $key => $value) {
-            if ($value === null) {
-                throw new RuntimeException('Null value encountered in NoNulls map');
-            }
-
-            $pairs[$key] = $value;
-        }
-
-        return $pairs;
+        return iterator_to_array($this->getIterator());
     }
 
     #[Override]

--- a/tests/Map/MapEnvelopeTest.php
+++ b/tests/Map/MapEnvelopeTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Map;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Map\Map;
+use Primus\Map\MapEnvelope;
+use Primus\Map\MapOf;
+
+final class MapEnvelopeTest extends TestCase
+{
+    #[Test]
+    public function delegatesValueToOrigin(): void
+    {
+        $this->assertSame(
+            ['a' => 1, 'b' => 2],
+            $this->wrap(new MapOf(['a' => 1, 'b' => 2]))->value(),
+        );
+    }
+
+    #[Test]
+    public function delegatesCountToOrigin(): void
+    {
+        $this->assertCount(3, $this->wrap(new MapOf(['x' => 1, 'y' => 2, 'z' => 3])));
+    }
+
+    #[Test]
+    public function delegatesIterationToOrigin(): void
+    {
+        $collected = [];
+        foreach ($this->wrap(new MapOf(['a' => 10, 'b' => 20])) as $key => $value) {
+            $collected[$key] = $value;
+        }
+        $this->assertSame(['a' => 10, 'b' => 20], $collected);
+    }
+
+    /**
+     * @param Map<array-key, mixed> $origin
+     */
+    private function wrap(Map $origin): MapEnvelope
+    {
+        return new readonly class ($origin) extends MapEnvelope {};
+    }
+}

--- a/tests/Map/MapOfTest.php
+++ b/tests/Map/MapOfTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Map;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Map\MapOf;
+
+final class MapOfTest extends TestCase
+{
+    #[Test]
+    public function exposesPairsAsArray(): void
+    {
+        $this->assertSame(
+            ['a' => 1, 'b' => 2],
+            (new MapOf(['a' => 1, 'b' => 2]))->value(),
+        );
+    }
+
+    #[Test]
+    public function countsPairs(): void
+    {
+        $this->assertCount(3, new MapOf(['x' => 10, 'y' => 20, 'z' => 30]));
+    }
+
+    #[Test]
+    public function iteratesPreservingOrderAndKeys(): void
+    {
+        $collected = [];
+        foreach (new MapOf(['a' => 1, 'b' => 2, 'c' => 3]) as $key => $value) {
+            $collected[$key] = $value;
+        }
+        $this->assertSame(['a' => 1, 'b' => 2, 'c' => 3], $collected);
+    }
+
+    #[Test]
+    public function emptyMapHasZeroCount(): void
+    {
+        $this->assertCount(0, new MapOf([]));
+    }
+}

--- a/tests/Map/NoNullsTest.php
+++ b/tests/Map/NoNullsTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Map;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Map\MapOf;
+use Primus\Map\NoNulls;
+use RuntimeException;
+
+final class NoNullsTest extends TestCase
+{
+    #[Test]
+    public function yieldsSourceUnchangedWhenNoNulls(): void
+    {
+        $this->assertSame(
+            ['a' => 1, 'b' => 2],
+            (new NoNulls(new MapOf(['a' => 1, 'b' => 2])))->value(),
+        );
+    }
+
+    #[Test]
+    public function iteratesOverNonNullPairs(): void
+    {
+        $collected = [];
+        foreach (new NoNulls(new MapOf(['x' => 10, 'y' => 20])) as $key => $value) {
+            $collected[$key] = $value;
+        }
+        $this->assertSame(['x' => 10, 'y' => 20], $collected);
+    }
+
+    #[Test]
+    public function throwsOnNullDuringIteration(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Null value encountered in NoNulls map');
+        iterator_to_array(new NoNulls(new MapOf(['a' => 1, 'b' => null])));
+    }
+
+    #[Test]
+    public function throwsOnNullWhenAccessingValue(): void
+    {
+        $this->expectException(RuntimeException::class);
+        (new NoNulls(new MapOf(['x' => 'ok', 'y' => null])))->value();
+    }
+
+    #[Test]
+    public function throwsOnNullWhenCounting(): void
+    {
+        $this->expectException(RuntimeException::class);
+        (new NoNulls(new MapOf(['a' => 1, 'b' => null, 'c' => 3])))->count();
+    }
+}

--- a/tests/Map/NoNullsTest.php
+++ b/tests/Map/NoNullsTest.php
@@ -52,4 +52,13 @@ final class NoNullsTest extends TestCase
         $this->expectException(RuntimeException::class);
         (new NoNulls(new MapOf(['a' => 1, 'b' => null, 'c' => 3])))->count();
     }
+
+    #[Test]
+    public function composesWithItself(): void
+    {
+        $this->assertSame(
+            ['a' => 1, 'b' => 2],
+            (new NoNulls(new NoNulls(new MapOf(['a' => 1, 'b' => 2]))))->value(),
+        );
+    }
 }


### PR DESCRIPTION
- Added a Map interface extending Countable and IteratorAggregate with associative-array exposure
- Added a base envelope delegating to a map origin
- Added an associative-array adapter wrapping a plain array as a map
- Added a null-rejecting decorator that throws on null values across every accessor

Closes #68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new key-value collection interface for associative data handling.
  * Added a concrete map implementation supporting iteration and counting.
  * Added a wrapper to enforce non-null values with runtime validation.
  * Added an envelope pattern base for extending map functionality.

* **Tests**
  * Added comprehensive test coverage for all new collection components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->