### PR TITLE
Add Mapping, Filtering And Merging Decorators To Map

### DIFF
--- a/src/Map/Filtered.php
+++ b/src/Map/Filtered.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Map;
+
+use Generator;
+use Override;
+use Primus\Func\Predicate;
+
+/**
+ * Map of pairs whose values match a predicate.
+ *
+ * Example:
+ *     $map = new Filtered(
+ *         new MapOf(['a' => 10, 'b' => 5, 'c' => 40]),
+ *         new PredicateOf(fn (int $v): bool => $v > 10),
+ *     );
+ *     foreach ($map as $key => $value) {
+ *         echo "$key=$value ";
+ *     }
+ *     // c=40
+ *
+ * @template K of array-key
+ * @template V
+ * @extends MapEnvelope<K, V>
+ * @since 0.3
+ */
+final readonly class Filtered extends MapEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Map<K, V> $origin The map whose pairs are filtered.
+     * @param Predicate<V> $predicate The predicate that selects values.
+     */
+    public function __construct(Map $origin, private Predicate $predicate)
+    {
+        parent::__construct($origin);
+    }
+
+    #[Override]
+    public function value(): array
+    {
+        $pairs = [];
+
+        foreach ($this->origin->value() as $key => $value) {
+            if ($this->predicate->apply($value)) {
+                $pairs[$key] = $value;
+            }
+        }
+
+        return $pairs;
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return count($this->value());
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        foreach ($this->origin->value() as $key => $value) {
+            if ($this->predicate->apply($value)) {
+                yield $key => $value;
+            }
+        }
+    }
+}

--- a/src/Map/Mapped.php
+++ b/src/Map/Mapped.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Map;
+
+use Generator;
+use Override;
+use Primus\Func\Func;
+
+/**
+ * Map with each value transformed by a function while preserving keys.
+ *
+ * Example:
+ *     $map = new Mapped(
+ *         new MapOf(['a' => 1, 'b' => 2]),
+ *         new FuncOf(fn (int $v): int => $v * 10),
+ *     );
+ *     foreach ($map as $key => $value) {
+ *         echo "$key=$value ";
+ *     }
+ *     // a=10 b=20
+ *
+ * @template K of array-key
+ * @template V
+ * @template W
+ * @implements Map<K, W>
+ * @since 0.3
+ */
+final readonly class Mapped implements Map
+{
+    /**
+     * Ctor.
+     *
+     * @param Map<K, V> $origin The map whose values are transformed.
+     * @param Func<V, W> $func The transformation function.
+     */
+    public function __construct(private Map $origin, private Func $func) {}
+
+    #[Override]
+    public function value(): array
+    {
+        $pairs = [];
+
+        foreach ($this->origin->value() as $key => $value) {
+            $pairs[$key] = $this->func->apply($value);
+        }
+
+        return $pairs;
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return $this->origin->count();
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        foreach ($this->origin->value() as $key => $value) {
+            yield $key => $this->func->apply($value);
+        }
+    }
+}

--- a/src/Map/Merged.php
+++ b/src/Map/Merged.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Map;
+
+use Generator;
+use Override;
+
+/**
+ * Map merged from several source maps with last-wins precedence on key conflicts.
+ *
+ * Example:
+ *     $merged = new Merged(
+ *         new MapOf(['a' => 1, 'b' => 2]),
+ *         new MapOf(['b' => 99, 'c' => 3]),
+ *     );
+ *     // ['a' => 1, 'b' => 99, 'c' => 3]
+ *
+ * @template K of array-key
+ * @template V
+ * @implements Map<K, V>
+ * @since 0.3
+ */
+final readonly class Merged implements Map
+{
+    /** @var array<array-key, Map<K, V>> */
+    private array $sources;
+
+    /**
+     * Ctor.
+     *
+     * @param Map<K, V> ...$sources The maps to merge in order; later sources override earlier ones.
+     */
+    public function __construct(Map ...$sources)
+    {
+        $this->sources = $sources;
+    }
+
+    #[Override]
+    public function value(): array
+    {
+        $pairs = [];
+
+        foreach ($this->sources as $source) {
+            foreach ($source->value() as $key => $value) {
+                $pairs[$key] = $value;
+            }
+        }
+
+        return $pairs;
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return count($this->value());
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->value();
+    }
+}

--- a/tests/Map/FilteredTest.php
+++ b/tests/Map/FilteredTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Map;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Func\PredicateOf;
+use Primus\Map\Filtered;
+use Primus\Map\MapOf;
+
+final class FilteredTest extends TestCase
+{
+    #[Test]
+    public function yieldsPairsWithMatchingValues(): void
+    {
+        $this->assertSame(
+            ['c' => 40, 'e' => 50],
+            (new Filtered(
+                new MapOf(['a' => 10, 'b' => 5, 'c' => 40, 'd' => 3, 'e' => 50]),
+                new PredicateOf(static fn (int $v): bool => $v > 10),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesRelativeOrderAndKeys(): void
+    {
+        $this->assertSame(
+            ['banana' => 6, 'cherry' => 6],
+            (new Filtered(
+                new MapOf(['apple' => 5, 'banana' => 6, 'cherry' => 6]),
+                new PredicateOf(static fn (int $v): bool => $v > 5),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function yieldsNothingWhenNoneMatch(): void
+    {
+        $this->assertCount(
+            0,
+            new Filtered(
+                new MapOf(['a' => 1, 'b' => 2]),
+                new PredicateOf(static fn (int $v): bool => $v > 100),
+            ),
+        );
+    }
+
+    #[Test]
+    public function countReflectsMatchedPairs(): void
+    {
+        $this->assertCount(
+            2,
+            new Filtered(
+                new MapOf(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4]),
+                new PredicateOf(static fn (int $v): bool => $v % 2 === 0),
+            ),
+        );
+    }
+
+    #[Test]
+    public function leavesSourceUntouchedAfterReading(): void
+    {
+        $source = new MapOf(['a' => 1, 'b' => 2, 'c' => 3]);
+        $filtered = new Filtered(
+            $source,
+            new PredicateOf(static fn (int $v): bool => $v > 1),
+        );
+        $filtered->value();
+        iterator_to_array($filtered);
+        $this->assertSame(['a' => 1, 'b' => 2, 'c' => 3], $source->value());
+    }
+}

--- a/tests/Map/FilteredTest.php
+++ b/tests/Map/FilteredTest.php
@@ -6,8 +6,10 @@ namespace Primus\Tests\Map;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Primus\Func\FuncOf;
 use Primus\Func\PredicateOf;
 use Primus\Map\Filtered;
+use Primus\Map\Mapped;
 use Primus\Map\MapOf;
 
 final class FilteredTest extends TestCase
@@ -71,5 +73,32 @@ final class FilteredTest extends TestCase
         $filtered->value();
         iterator_to_array($filtered);
         $this->assertSame(['a' => 1, 'b' => 2, 'c' => 3], $source->value());
+    }
+
+    #[Test]
+    public function composesWithMapped(): void
+    {
+        $this->assertSame(
+            ['b' => 200, 'c' => 300],
+            (new Filtered(
+                new Mapped(
+                    new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+                    new FuncOf(static fn (int $v): int => $v * 100),
+                ),
+                new PredicateOf(static fn (int $v): bool => $v > 100),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function yieldsNothingWhenSourceIsEmpty(): void
+    {
+        $this->assertCount(
+            0,
+            new Filtered(
+                new MapOf([]),
+                new PredicateOf(static fn (int $v): bool => $v > 0),
+            ),
+        );
     }
 }

--- a/tests/Map/FilteredTest.php
+++ b/tests/Map/FilteredTest.php
@@ -71,7 +71,7 @@ final class FilteredTest extends TestCase
             new PredicateOf(static fn (int $v): bool => $v > 1),
         );
         $filtered->value();
-        iterator_to_array($filtered);
+        $this->assertSame(['b' => 2, 'c' => 3], iterator_to_array($filtered));
         $this->assertSame(['a' => 1, 'b' => 2, 'c' => 3], $source->value());
     }
 

--- a/tests/Map/MappedTest.php
+++ b/tests/Map/MappedTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Map;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Func\FuncOf;
+use Primus\Map\Mapped;
+use Primus\Map\MapOf;
+use Primus\Map\NoNulls;
+
+final class MappedTest extends TestCase
+{
+    #[Test]
+    public function transformsEachValuePreservingKeys(): void
+    {
+        $this->assertSame(
+            ['a' => 10, 'b' => 20, 'c' => 30],
+            (new Mapped(
+                new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+                new FuncOf(static fn (int $v): int => $v * 10),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesCount(): void
+    {
+        $this->assertCount(
+            3,
+            new Mapped(
+                new MapOf(['x' => 'a', 'y' => 'b', 'z' => 'c']),
+                new FuncOf(static fn (string $v): string => strtoupper($v)),
+            ),
+        );
+    }
+
+    #[Test]
+    public function iteratesOverTransformedPairs(): void
+    {
+        $collected = [];
+        foreach (
+            new Mapped(
+                new MapOf(['k1' => 1, 'k2' => 2]),
+                new FuncOf(static fn (int $v): int => $v + 100),
+            ) as $key => $value
+        ) {
+            $collected[$key] = $value;
+        }
+        $this->assertSame(['k1' => 101, 'k2' => 102], $collected);
+    }
+
+    #[Test]
+    public function leavesSourceUntouchedAfterReading(): void
+    {
+        $source = new MapOf(['a' => 1, 'b' => 2]);
+        $mapped = new Mapped(
+            $source,
+            new FuncOf(static fn (int $v): int => $v * 5),
+        );
+        $mapped->value();
+        iterator_to_array($mapped);
+        $this->assertSame(['a' => 1, 'b' => 2], $source->value());
+    }
+
+    #[Test]
+    public function composesWithNoNulls(): void
+    {
+        $this->assertSame(
+            ['a' => 10, 'b' => 20],
+            (new Mapped(
+                new NoNulls(new MapOf(['a' => 1, 'b' => 2])),
+                new FuncOf(static fn (int $v): int => $v * 10),
+            ))->value(),
+        );
+    }
+}

--- a/tests/Map/MappedTest.php
+++ b/tests/Map/MappedTest.php
@@ -7,9 +7,10 @@ namespace Primus\Tests\Map;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Primus\Func\FuncOf;
+use Primus\Func\PredicateOf;
+use Primus\Map\Filtered;
 use Primus\Map\Mapped;
 use Primus\Map\MapOf;
-use Primus\Map\NoNulls;
 
 final class MappedTest extends TestCase
 {
@@ -66,14 +67,29 @@ final class MappedTest extends TestCase
     }
 
     #[Test]
-    public function composesWithNoNulls(): void
+    public function composesWithFiltered(): void
     {
         $this->assertSame(
-            ['a' => 10, 'b' => 20],
+            ['c' => 30],
             (new Mapped(
-                new NoNulls(new MapOf(['a' => 1, 'b' => 2])),
+                new Filtered(
+                    new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+                    new PredicateOf(static fn (int $v): bool => $v > 2),
+                ),
                 new FuncOf(static fn (int $v): int => $v * 10),
             ))->value(),
+        );
+    }
+
+    #[Test]
+    public function yieldsEmptyWhenSourceIsEmpty(): void
+    {
+        $this->assertCount(
+            0,
+            new Mapped(
+                new MapOf([]),
+                new FuncOf(static fn (int $v): int => $v * 10),
+            ),
         );
     }
 }

--- a/tests/Map/MergedTest.php
+++ b/tests/Map/MergedTest.php
@@ -6,6 +6,8 @@ namespace Primus\Tests\Map;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Primus\Func\FuncOf;
+use Primus\Map\Mapped;
 use Primus\Map\MapOf;
 use Primus\Map\Merged;
 
@@ -64,5 +66,30 @@ final class MergedTest extends TestCase
         iterator_to_array($merged);
         $this->assertSame(['a' => 1], $first->value());
         $this->assertSame(['a' => 2, 'b' => 3], $second->value());
+    }
+
+    #[Test]
+    public function iteratesPreservingKeys(): void
+    {
+        $collected = [];
+        foreach (new Merged(new MapOf(['a' => 1]), new MapOf(['b' => 2])) as $key => $value) {
+            $collected[$key] = $value;
+        }
+        $this->assertSame(['a' => 1, 'b' => 2], $collected);
+    }
+
+    #[Test]
+    public function composesWithMapped(): void
+    {
+        $this->assertSame(
+            ['a' => 10, 'b' => 200, 'c' => 30],
+            (new Merged(
+                new Mapped(
+                    new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+                    new FuncOf(static fn (int $v): int => $v * 10),
+                ),
+                new MapOf(['b' => 200]),
+            ))->value(),
+        );
     }
 }

--- a/tests/Map/MergedTest.php
+++ b/tests/Map/MergedTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Map;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Map\MapOf;
+use Primus\Map\Merged;
+
+final class MergedTest extends TestCase
+{
+    #[Test]
+    public function combinesAllPairsWithoutCollision(): void
+    {
+        $this->assertSame(
+            ['a' => 1, 'b' => 2, 'c' => 3],
+            (new Merged(
+                new MapOf(['a' => 1]),
+                new MapOf(['b' => 2, 'c' => 3]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function laterSourceWinsOnKeyCollision(): void
+    {
+        $this->assertSame(
+            ['a' => 1, 'b' => 99, 'c' => 3],
+            (new Merged(
+                new MapOf(['a' => 1, 'b' => 2]),
+                new MapOf(['b' => 99, 'c' => 3]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function lastOfThreeWinsOnTripleCollision(): void
+    {
+        $this->assertSame(
+            ['k' => 'third'],
+            (new Merged(
+                new MapOf(['k' => 'first']),
+                new MapOf(['k' => 'second']),
+                new MapOf(['k' => 'third']),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function emptyMergeYieldsEmpty(): void
+    {
+        $this->assertCount(0, new Merged());
+    }
+
+    #[Test]
+    public function leavesSourcesUntouchedAfterReading(): void
+    {
+        $first = new MapOf(['a' => 1]);
+        $second = new MapOf(['a' => 2, 'b' => 3]);
+        $merged = new Merged($first, $second);
+        $merged->value();
+        iterator_to_array($merged);
+        $this->assertSame(['a' => 1], $first->value());
+        $this->assertSame(['a' => 2, 'b' => 3], $second->value());
+    }
+}


### PR DESCRIPTION
- Added a value-mapping decorator that transforms each value through a function
- Added a value-filtering decorator that keeps pairs whose value matches a predicate
- Added a merging decorator that combines several maps with last-wins precedence

Closes #70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Filtered map to view entries matching a predicate while preserving original keys and order.
  * Added Mapped map to transform map values while preserving keys and counts.
  * Added Merged map to combine multiple maps, with later sources overriding on key collisions.

* **Tests**
  * Added comprehensive tests covering edge cases, composition between maps, iteration/value behavior, and ensuring source maps remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->