### PR TITLE
Key Aware Map Value Transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Objects are immutable, final, and easy to combine.
 | `strip_tags($s)` | `new WithoutTags($s)` |
 | `strlen($s)` | `new LengthOfText($s)` |
 | `array_map(fn, $a)` | `new Mapped(new MapOf($a), new FuncOf(fn))` |
+| key-aware value mapping | `new BiMapped(new MapOf($a), new BiFuncOf(fn))` |
 | `array_filter($a, fn)` | `new Filtered(new MapOf($a), new PredicateOf(fn))` |
 | `array_merge($a, $b)` | `new Merged(new MapOf($a), new MapOf($b))` |
 
@@ -83,7 +84,7 @@ FuncWithFallback, Predicate, PredicateOf, Proc, ProcOf, Repeated, StickyFunc
 List_, ListEnvelope, ListOf, Filtered, Mapped, NoNulls, Reversed
 
 ### **Map**
-Map, MapEnvelope, MapOf, Filtered, Mapped, Merged, NoNulls
+Map, MapEnvelope, MapOf, BiMapped, Filtered, Mapped, Merged, NoNulls
 
 ### **Numeric**
 Number

--- a/src/Map/BiMapped.php
+++ b/src/Map/BiMapped.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Map;
+
+use Generator;
+use Override;
+use Primus\Func\BiFunc;
+
+/**
+ * Map with each value transformed by a function of key and value while preserving keys.
+ *
+ * Example:
+ *     $map = new BiMapped(
+ *         new MapOf(['a' => 1, 'b' => 2]),
+ *         new BiFuncOf(fn (string $key, int $value): string => "$key=$value"),
+ *     );
+ *     foreach ($map as $key => $value) {
+ *         echo "$key:$value ";
+ *     }
+ *     // a:a=1 b:b=2
+ *
+ * @template K of array-key
+ * @template V
+ * @template W
+ * @implements Map<K, W>
+ * @since 0.7
+ */
+final readonly class BiMapped implements Map
+{
+    /**
+     * Ctor.
+     *
+     * @param Map<K, V> $origin The map whose values are transformed.
+     * @param BiFunc<K, V, W> $func The transformation function.
+     */
+    public function __construct(private Map $origin, private BiFunc $func) {}
+
+    #[Override]
+    public function value(): array
+    {
+        $pairs = [];
+
+        foreach ($this->origin->value() as $key => $value) {
+            $pairs[$key] = $this->func->apply($key, $value);
+        }
+
+        return $pairs;
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return $this->origin->count();
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        foreach ($this->origin->value() as $key => $value) {
+            yield $key => $this->func->apply($key, $value);
+        }
+    }
+}

--- a/tests/Map/BiMappedTest.php
+++ b/tests/Map/BiMappedTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Map;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Func\BiFuncOf;
+use Primus\Func\PredicateOf;
+use Primus\Map\BiMapped;
+use Primus\Map\Filtered;
+use Primus\Map\MapOf;
+
+final class BiMappedTest extends TestCase
+{
+    #[Test]
+    public function transformsEachValueWithItsKey(): void
+    {
+        $this->assertSame(
+            ['name' => 'name:Ada', 'role' => 'role:admin'],
+            (new BiMapped(
+                new MapOf(['name' => 'Ada', 'role' => 'admin']),
+                new BiFuncOf(static fn (string $key, string $value): string => "$key:$value"),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesCount(): void
+    {
+        $this->assertCount(
+            3,
+            new BiMapped(
+                new MapOf(['low' => 1, 'mid' => 5, 'high' => 9]),
+                new BiFuncOf(static fn (string $key, int $value): string => "$key=$value"),
+            ),
+        );
+    }
+
+    #[Test]
+    public function iteratesOverTransformedPairs(): void
+    {
+        $collected = [];
+        foreach (
+            new BiMapped(
+                new MapOf(['draft' => 2, 'done' => 7]),
+                new BiFuncOf(static fn (string $key, int $value): string => "$key:$value"),
+            ) as $key => $value
+        ) {
+            $collected[$key] = $value;
+        }
+        $this->assertSame(['draft' => 'draft:2', 'done' => 'done:7'], $collected);
+    }
+
+    #[Test]
+    public function leavesSourceUntouchedAfterReading(): void
+    {
+        $source = new MapOf(['city' => 'Minsk', 'river' => 'Svislach']);
+        $mapped = new BiMapped(
+            $source,
+            new BiFuncOf(static fn (string $key, string $value): string => "$key=$value"),
+        );
+        $mapped->value();
+        iterator_to_array($mapped);
+        $this->assertSame(['city' => 'Minsk', 'river' => 'Svislach'], $source->value());
+    }
+
+    #[Test]
+    public function composesWithFiltered(): void
+    {
+        $this->assertSame(
+            ['urgent' => 'urgent:8'],
+            (new BiMapped(
+                new Filtered(
+                    new MapOf(['later' => 3, 'urgent' => 8]),
+                    new PredicateOf(static fn (int $value): bool => $value > 5),
+                ),
+                new BiFuncOf(static fn (string $key, int $value): string => "$key:$value"),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function yieldsEmptyWhenSourceIsEmpty(): void
+    {
+        $this->assertCount(
+            0,
+            new BiMapped(
+                new MapOf([]),
+                new BiFuncOf(static fn (string $key, int $value): string => "$key:$value"),
+            ),
+        );
+    }
+}


### PR DESCRIPTION
- Added key-aware map value transformation while preserving original keys
- Added coverage for value output, iteration, count, empty source, and composition
- Updated README with the new map decorator

Closes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced key-aware value mapping to transform map elements using both the key and current value together.

* **Documentation**
  * Updated Map module reference documentation to include the new mapping operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->