### PR TITLE
Key Aware Map Pair Filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Objects are immutable, final, and easy to combine.
 | `array_map(fn, $a)` | `new Mapped(new MapOf($a), new FuncOf(fn))` |
 | key-aware value mapping | `new BiMapped(new MapOf($a), new BiFuncOf(fn))` |
 | `array_filter($a, fn)` | `new Filtered(new MapOf($a), new PredicateOf(fn))` |
+| key-aware pair filtering | `new BiFiltered(new MapOf($a), new BiFuncOf(fn))` |
 | `array_merge($a, $b)` | `new Merged(new MapOf($a), new MapOf($b))` |
 
 ---
@@ -84,7 +85,7 @@ FuncWithFallback, Predicate, PredicateOf, Proc, ProcOf, Repeated, StickyFunc
 List_, ListEnvelope, ListOf, Filtered, Mapped, NoNulls, Reversed
 
 ### **Map**
-Map, MapEnvelope, MapOf, BiMapped, Filtered, Mapped, Merged, NoNulls
+Map, MapEnvelope, MapOf, BiFiltered, BiMapped, Filtered, Mapped, Merged, NoNulls
 
 ### **Numeric**
 Number

--- a/src/Map/BiFiltered.php
+++ b/src/Map/BiFiltered.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Map;
+
+use Generator;
+use Override;
+use Primus\Func\BiFunc;
+
+/**
+ * Map of pairs whose key and value match a function.
+ *
+ * Example:
+ *     $map = new BiFiltered(
+ *         new MapOf(['adult' => 19, 'minor' => 12]),
+ *         new BiFuncOf(fn (string $key, int $value): bool => $key === 'adult' && $value >= 18),
+ *     );
+ *     foreach ($map as $key => $value) {
+ *         echo "$key=$value ";
+ *     }
+ *     // adult=19
+ *
+ * @template K of array-key
+ * @template V
+ * @extends MapEnvelope<K, V>
+ * @since 0.7
+ */
+final readonly class BiFiltered extends MapEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Map<K, V> $origin The map whose pairs are filtered.
+     * @param BiFunc<K, V, bool> $predicate The function that selects pairs.
+     */
+    public function __construct(Map $origin, private BiFunc $predicate)
+    {
+        parent::__construct($origin);
+    }
+
+    #[Override]
+    public function value(): array
+    {
+        $pairs = [];
+
+        foreach ($this->origin->value() as $key => $value) {
+            if ($this->predicate->apply($key, $value)) {
+                $pairs[$key] = $value;
+            }
+        }
+
+        return $pairs;
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return count($this->value());
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        foreach ($this->origin->value() as $key => $value) {
+            if ($this->predicate->apply($key, $value)) {
+                yield $key => $value;
+            }
+        }
+    }
+}

--- a/tests/Map/BiFilteredTest.php
+++ b/tests/Map/BiFilteredTest.php
@@ -40,13 +40,14 @@ final class BiFilteredTest extends TestCase
     #[Test]
     public function yieldsNothingWhenNoneMatch(): void
     {
-        $this->assertCount(
-            0,
-            new BiFiltered(
-                new MapOf(['draft' => 2, 'queued' => 4]),
-                new BiFuncOf(static fn (string $key, int $value): bool => str_starts_with($key, 'done') && $value > 5),
+        $filtered = new BiFiltered(
+            new MapOf(['draft' => 2, 'queued' => 4]),
+            new BiFuncOf(
+                static fn (string $key, int $value): bool => str_starts_with($key, 'done') && $value > 5
             ),
         );
+        $this->assertCount(0, $filtered);
+        $this->assertSame([], iterator_to_array($filtered));
     }
 
     #[Test]
@@ -92,12 +93,11 @@ final class BiFilteredTest extends TestCase
     #[Test]
     public function yieldsNothingWhenSourceIsEmpty(): void
     {
-        $this->assertCount(
-            0,
-            new BiFiltered(
-                new MapOf([]),
-                new BiFuncOf(static fn (string $key, int $value): bool => strlen($key) > 1 && $value > 0),
-            ),
+        $filtered = new BiFiltered(
+            new MapOf([]),
+            new BiFuncOf(static fn (string $key, int $value): bool => strlen($key) > 1 && $value > 0),
         );
+        $this->assertCount(0, $filtered);
+        $this->assertSame([], iterator_to_array($filtered));
     }
 }

--- a/tests/Map/BiFilteredTest.php
+++ b/tests/Map/BiFilteredTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Map;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Func\BiFuncOf;
+use Primus\Map\BiFiltered;
+use Primus\Map\BiMapped;
+use Primus\Map\MapOf;
+
+final class BiFilteredTest extends TestCase
+{
+    #[Test]
+    public function yieldsPairsWithMatchingKeysAndValues(): void
+    {
+        $this->assertSame(
+            ['critical' => 9, 'major' => 7],
+            (new BiFiltered(
+                new MapOf(['minor' => 2, 'critical' => 9, 'major' => 7, 'trivial' => 1]),
+                new BiFuncOf(static fn (string $key, int $value): bool => strlen($key) >= 5 && $value > 5),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesRelativeOrderAndKeys(): void
+    {
+        $this->assertSame(
+            ['east' => 12, 'west' => 14],
+            (new BiFiltered(
+                new MapOf(['north' => 8, 'east' => 12, 'west' => 14]),
+                new BiFuncOf(static fn (string $key, int $value): bool => strlen($key) === 4 && $value > 10),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function yieldsNothingWhenNoneMatch(): void
+    {
+        $this->assertCount(
+            0,
+            new BiFiltered(
+                new MapOf(['draft' => 2, 'queued' => 4]),
+                new BiFuncOf(static fn (string $key, int $value): bool => str_starts_with($key, 'done') && $value > 5),
+            ),
+        );
+    }
+
+    #[Test]
+    public function countReflectsMatchedPairs(): void
+    {
+        $this->assertCount(
+            2,
+            new BiFiltered(
+                new MapOf(['home' => 1, 'work' => 2, 'park' => 3]),
+                new BiFuncOf(static fn (string $key, int $value): bool => strlen($key) === 4 && $value > 1),
+            ),
+        );
+    }
+
+    #[Test]
+    public function leavesSourceUntouchedAfterReading(): void
+    {
+        $source = new MapOf(['admin' => 10, 'guest' => 1, 'editor' => 6]);
+        $filtered = new BiFiltered(
+            $source,
+            new BiFuncOf(static fn (string $key, int $value): bool => strlen($key) > 5 && $value > 5),
+        );
+        $filtered->value();
+        $this->assertSame(['editor' => 6], iterator_to_array($filtered));
+        $this->assertSame(['admin' => 10, 'guest' => 1, 'editor' => 6], $source->value());
+    }
+
+    #[Test]
+    public function composesWithBiMapped(): void
+    {
+        $this->assertSame(
+            ['open' => 'open:3'],
+            (new BiFiltered(
+                new BiMapped(
+                    new MapOf(['open' => 3, 'closed' => 9]),
+                    new BiFuncOf(static fn (string $key, int $value): string => "$key:$value"),
+                ),
+                new BiFuncOf(static fn (string $key, string $value): bool => $key === 'open' && $value === 'open:3'),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function yieldsNothingWhenSourceIsEmpty(): void
+    {
+        $this->assertCount(
+            0,
+            new BiFiltered(
+                new MapOf([]),
+                new BiFuncOf(static fn (string $key, int $value): bool => strlen($key) > 1 && $value > 0),
+            ),
+        );
+    }
+}


### PR DESCRIPTION
- Added key-aware map pair filtering while preserving selected keys and values
- Added coverage for selection, iteration, count, empty source, and composition
- Updated README with the new map decorator

Closes #75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a key-aware pair filtering primitive for maps that lets you filter entries by a predicate.

* **Documentation**
  * Quick reference and module index updated to include the new filtering operation and its usage example.

* **Tests**
  * Added comprehensive tests covering matching, ordering, empty-source cases, count accuracy, non‑mutation, and composition with mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->