### PR TITLE
Concatenate Several Lists Into One Ordered List

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Objects are immutable, final, and easy to combine.
 | `array_filter($a, fn)` | `new Filtered(new MapOf($a), new PredicateOf(fn))` |
 | key-aware pair filtering | `new BiFiltered(new MapOf($a), new BiFuncOf(fn))` |
 | `array_merge($a, $b)` | `new Merged(new MapOf($a), new MapOf($b))` |
+| `array_merge` for lists | `new Joined(new ListOf(...$a), new ListOf(...$b))` |
 
 ---
 
@@ -82,7 +83,7 @@ BiFunc, BiFuncOf, BiProc, BiProcOf, Func, FuncEnvelope, FuncOf,
 FuncWithFallback, Predicate, PredicateOf, Proc, ProcOf, Repeated, StickyFunc
 
 ### **List**
-List_, ListEnvelope, ListOf, Filtered, Mapped, NoNulls, Reversed
+List_, ListEnvelope, ListOf, Filtered, Joined, Mapped, NoNulls, Reversed
 
 ### **Map**
 Map, MapEnvelope, MapOf, BiFiltered, BiMapped, Filtered, Mapped, Merged, NoNulls

--- a/src/List/Joined.php
+++ b/src/List/Joined.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\List;
+
+use Generator;
+use Override;
+
+/**
+ * List that concatenates several source lists in the order they were passed.
+ *
+ * Element keys are reindexed as sequential integers starting at zero.
+ *
+ * Example:
+ *     $joined = new Joined(
+ *         new ListOf(1, 2),
+ *         new ListOf(3, 4, 5),
+ *     );
+ *     // [1, 2, 3, 4, 5]
+ *
+ * @template T
+ * @implements List_<T>
+ * @since 0.3
+ */
+final readonly class Joined implements List_
+{
+    /** @var array<array-key, List_<T>> */
+    private array $sources;
+
+    /**
+     * Ctor.
+     *
+     * @param List_<T> ...$sources The lists to concatenate.
+     */
+    public function __construct(List_ ...$sources)
+    {
+        $this->sources = $sources;
+    }
+
+    #[Override]
+    public function value(): array
+    {
+        $items = [];
+
+        foreach ($this->sources as $source) {
+            foreach ($source->value() as $item) {
+                $items[] = $item;
+            }
+        }
+
+        return $items;
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        $total = 0;
+
+        foreach ($this->sources as $source) {
+            $total += $source->count();
+        }
+
+        return $total;
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        $index = 0;
+
+        foreach ($this->sources as $source) {
+            foreach ($source as $item) {
+                yield $index => $item;
+
+                $index++;
+            }
+        }
+    }
+}

--- a/src/List/Joined.php
+++ b/src/List/Joined.php
@@ -55,26 +55,12 @@ final readonly class Joined implements List_
     #[Override]
     public function count(): int
     {
-        $total = 0;
-
-        foreach ($this->sources as $source) {
-            $total += $source->count();
-        }
-
-        return $total;
+        return count($this->value());
     }
 
     #[Override]
     public function getIterator(): Generator
     {
-        $index = 0;
-
-        foreach ($this->sources as $source) {
-            foreach ($source as $item) {
-                yield $index => $item;
-
-                $index++;
-            }
-        }
+        yield from $this->value();
     }
 }

--- a/tests/List/JoinedTest.php
+++ b/tests/List/JoinedTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Primus\Tests\List;
 
+use Generator;
+use Override;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Primus\List\Joined;
+use Primus\List\List_;
 use Primus\List\ListOf;
 
 final class JoinedTest extends TestCase
@@ -47,6 +50,35 @@ final class JoinedTest extends TestCase
                 new ListOf('a', 'b'),
                 new ListOf('c', 'd'),
             ))->value(),
+        );
+    }
+
+    #[Test]
+    public function reindexesEvenWhenSourceExposesNonSequentialKeys(): void
+    {
+        $stringKeyed = new readonly class implements List_ {
+            #[Override]
+            public function value(): array
+            {
+                return ['x' => 'a', 'y' => 'b'];
+            }
+
+            #[Override]
+            public function count(): int
+            {
+                return count($this->value());
+            }
+
+            #[Override]
+            public function getIterator(): Generator
+            {
+                yield from $this->value();
+            }
+        };
+
+        $this->assertSame(
+            [0 => 'a', 1 => 'b', 2 => 'c'],
+            (new Joined($stringKeyed, new ListOf('c')))->value(),
         );
     }
 

--- a/tests/List/JoinedTest.php
+++ b/tests/List/JoinedTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\List;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\List\Joined;
+use Primus\List\ListOf;
+
+final class JoinedTest extends TestCase
+{
+    #[Test]
+    public function joinsZeroSourcesIntoEmptyList(): void
+    {
+        $this->assertSame([], (new Joined())->value());
+    }
+
+    #[Test]
+    public function joinsSingleSourcePreservingOrder(): void
+    {
+        $this->assertSame(
+            [1, 2, 3],
+            (new Joined(new ListOf(1, 2, 3)))->value(),
+        );
+    }
+
+    #[Test]
+    public function concatenatesSourcesInOrder(): void
+    {
+        $this->assertSame(
+            [1, 2, 3, 4, 5],
+            (new Joined(
+                new ListOf(1, 2),
+                new ListOf(3, 4, 5),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function reindexesKeysSequentiallyFromZero(): void
+    {
+        $this->assertSame(
+            [0 => 'a', 1 => 'b', 2 => 'c', 3 => 'd'],
+            (new Joined(
+                new ListOf('a', 'b'),
+                new ListOf('c', 'd'),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function iteratorYieldsSameSequenceAsValue(): void
+    {
+        $joined = new Joined(
+            new ListOf(1, 2),
+            new ListOf(3, 4),
+        );
+        $this->assertSame(
+            $joined->value(),
+            iterator_to_array($joined),
+        );
+    }
+
+    #[Test]
+    public function countsAcrossAllSources(): void
+    {
+        $this->assertCount(
+            5,
+            new Joined(
+                new ListOf('a'),
+                new ListOf('b', 'c'),
+                new ListOf('d', 'e'),
+            ),
+        );
+    }
+
+    #[Test]
+    public function leavesSourcesUntouchedAfterReading(): void
+    {
+        $first = new ListOf(1, 2);
+        $second = new ListOf(3, 4);
+        $joined = new Joined($first, $second);
+        $joined->value();
+        iterator_to_array($joined);
+        $this->assertSame([1, 2], $first->value());
+        $this->assertSame([3, 4], $second->value());
+    }
+
+    #[Test]
+    public function composesWithItself(): void
+    {
+        $this->assertSame(
+            [1, 2, 3, 4],
+            (new Joined(
+                new Joined(new ListOf(1), new ListOf(2)),
+                new Joined(new ListOf(3), new ListOf(4)),
+            ))->value(),
+        );
+    }
+}


### PR DESCRIPTION
- Added a list decorator that concatenates several source lists in passed order
- Added test coverage for the reindex contract on sources with non-sequential keys
- Updated README with the new List module entry and quick reference row

Closes #86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functionality to join multiple lists into a single concatenated list with automatic sequential re-indexing.

* **Documentation**
  * Updated quick reference guide with a new list-joining example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->