### PR TITLE
Expose Map Keys As A List Decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Objects are immutable, final, and easy to combine.
 | key-aware pair filtering | `new BiFiltered(new MapOf($a), new BiFuncOf(fn))` |
 | `array_merge($a, $b)` | `new Merged(new MapOf($a), new MapOf($b))` |
 | `array_merge` for lists | `new Joined(new ListOf(...$a), new ListOf(...$b))` |
+| `array_keys($a)` | `new Keys(new MapOf($a))` |
 
 ---
 
@@ -86,7 +87,7 @@ FuncWithFallback, Predicate, PredicateOf, Proc, ProcOf, Repeated, StickyFunc
 List_, ListEnvelope, ListOf, Filtered, Joined, Mapped, NoNulls, Reversed
 
 ### **Map**
-Map, MapEnvelope, MapOf, BiFiltered, BiMapped, Filtered, Mapped, Merged, NoNulls
+Map, MapEnvelope, MapOf, BiFiltered, BiMapped, Filtered, Keys, Mapped, Merged, NoNulls
 
 ### **Numeric**
 Number

--- a/src/Map/Keys.php
+++ b/src/Map/Keys.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Map;
+
+use Generator;
+use Override;
+use Primus\List\List_;
+
+/**
+ * List of keys from a map.
+ *
+ * Example:
+ *     $keys = new Keys(new MapOf(['a' => 1, 'b' => 2]));
+ *     // ['a', 'b']
+ *
+ * @template K of array-key
+ * @template V
+ * @implements List_<K>
+ * @since 0.3
+ */
+final readonly class Keys implements List_
+{
+    /**
+     * Ctor.
+     *
+     * @param Map<K, V> $origin The map to read keys from.
+     */
+    public function __construct(private Map $origin) {}
+
+    #[Override]
+    public function value(): array
+    {
+        return array_keys($this->origin->value());
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return $this->origin->count();
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->value();
+    }
+}

--- a/tests/Map/KeysTest.php
+++ b/tests/Map/KeysTest.php
@@ -30,8 +30,13 @@ final class KeysTest extends TestCase
     public function preservesMixedIntegerAndStringKeys(): void
     {
         $this->assertSame(
-            [0, 'name', 7],
-            (new Keys(new MapOf([0 => 'first', 'name' => 'Alice', 7 => 'lucky'])))->value(),
+            [0, 'name', '01', 7],
+            (new Keys(new MapOf([
+                0 => 'first',
+                'name' => 'Alice',
+                '01' => 'leadingZero',
+                7 => 'lucky',
+            ])))->value(),
         );
     }
 

--- a/tests/Map/KeysTest.php
+++ b/tests/Map/KeysTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Map;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Map\Keys;
+use Primus\Map\MapOf;
+
+final class KeysTest extends TestCase
+{
+    #[Test]
+    public function exposesKeysOfEmptyMapAsEmptyList(): void
+    {
+        $this->assertSame([], (new Keys(new MapOf([])))->value());
+    }
+
+    #[Test]
+    public function exposesKeysInSourceOrder(): void
+    {
+        $this->assertSame(
+            ['a', 'b', 'c'],
+            (new Keys(new MapOf(['a' => 1, 'b' => 2, 'c' => 3])))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesMixedIntegerAndStringKeys(): void
+    {
+        $this->assertSame(
+            [0, 'name', 7],
+            (new Keys(new MapOf([0 => 'first', 'name' => 'Alice', 7 => 'lucky'])))->value(),
+        );
+    }
+
+    #[Test]
+    public function iteratorYieldsSameSequenceAsValue(): void
+    {
+        $keys = new Keys(new MapOf(['x' => 1, 'y' => 2]));
+        $this->assertSame(
+            $keys->value(),
+            iterator_to_array($keys),
+        );
+    }
+
+    #[Test]
+    public function countsAsManyAsPairsInSource(): void
+    {
+        $this->assertCount(
+            3,
+            new Keys(new MapOf(['a' => 1, 'b' => 2, 'c' => 3])),
+        );
+    }
+
+    #[Test]
+    public function leavesSourceUntouchedAfterReading(): void
+    {
+        $source = new MapOf(['a' => 1, 'b' => 2]);
+        $keys = new Keys($source);
+        $keys->value();
+        iterator_to_array($keys);
+        $this->assertSame(['a' => 1, 'b' => 2], $source->value());
+    }
+}


### PR DESCRIPTION
- Added a map decorator that exposes the source map keys as a list
- Updated README with the new Map module entry and quick reference row

Closes #88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functionality to extract and iterate over all keys from a map while preserving original order and key types.

* **Documentation**
  * Updated quick reference guide to include mapping for key extraction operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->