### PR TITLE
Expose Map Values As A List Decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Objects are immutable, final, and easy to combine.
 | `array_merge($a, $b)` | `new Merged(new MapOf($a), new MapOf($b))` |
 | `array_merge` for lists | `new Joined(new ListOf(...$a), new ListOf(...$b))` |
 | `array_keys($a)` | `new Keys(new MapOf($a))` |
+| `array_values($a)` | `new Values(new MapOf($a))` |
 
 ---
 
@@ -87,7 +88,7 @@ FuncWithFallback, Predicate, PredicateOf, Proc, ProcOf, Repeated, StickyFunc
 List_, ListEnvelope, ListOf, Filtered, Joined, Mapped, NoNulls, Reversed
 
 ### **Map**
-Map, MapEnvelope, MapOf, BiFiltered, BiMapped, Filtered, Keys, Mapped, Merged, NoNulls
+Map, MapEnvelope, MapOf, BiFiltered, BiMapped, Filtered, Keys, Mapped, Merged, NoNulls, Values
 
 ### **Numeric**
 Number

--- a/src/Map/Values.php
+++ b/src/Map/Values.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Map;
+
+use Generator;
+use Override;
+use Primus\List\List_;
+
+/**
+ * List of values from a map.
+ *
+ * Example:
+ *     $values = new Values(new MapOf(['a' => 1, 'b' => 2]));
+ *     // [1, 2]
+ *
+ * @template K of array-key
+ * @template V
+ * @implements List_<V>
+ * @since 0.3
+ */
+final readonly class Values implements List_
+{
+    /**
+     * Ctor.
+     *
+     * @param Map<K, V> $origin The map to read values from.
+     */
+    public function __construct(private Map $origin) {}
+
+    #[Override]
+    public function value(): array
+    {
+        return array_values($this->origin->value());
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return $this->origin->count();
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->value();
+    }
+}

--- a/tests/Map/ValuesTest.php
+++ b/tests/Map/ValuesTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Map;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Map\MapOf;
+use Primus\Map\Values;
+
+final class ValuesTest extends TestCase
+{
+    #[Test]
+    public function exposesValuesOfEmptyMapAsEmptyList(): void
+    {
+        $this->assertSame([], (new Values(new MapOf([])))->value());
+    }
+
+    #[Test]
+    public function exposesValuesInSourceOrder(): void
+    {
+        $this->assertSame(
+            [1, 2, 3],
+            (new Values(new MapOf(['a' => 1, 'b' => 2, 'c' => 3])))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesValuesRegardlessOfKeyTypes(): void
+    {
+        $this->assertSame(
+            ['first', 'Alice', 'leadingZero', 'lucky'],
+            (new Values(new MapOf([
+                0 => 'first',
+                'name' => 'Alice',
+                '01' => 'leadingZero',
+                7 => 'lucky',
+            ])))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesDuplicateValues(): void
+    {
+        $this->assertSame(
+            [1, 1, 2],
+            (new Values(new MapOf(['a' => 1, 'b' => 1, 'c' => 2])))->value(),
+        );
+    }
+
+    #[Test]
+    public function iteratorYieldsSameSequenceAsValue(): void
+    {
+        $values = new Values(new MapOf(['x' => 1, 'y' => 2]));
+        $this->assertSame(
+            $values->value(),
+            iterator_to_array($values),
+        );
+    }
+
+    #[Test]
+    public function countsAsManyAsPairsInSource(): void
+    {
+        $this->assertCount(
+            3,
+            new Values(new MapOf(['a' => 1, 'b' => 2, 'c' => 3])),
+        );
+    }
+
+    #[Test]
+    public function leavesSourceUntouchedAfterReading(): void
+    {
+        $source = new MapOf(['a' => 1, 'b' => 2]);
+        $values = new Values($source);
+        $values->value();
+        iterator_to_array($values);
+        $this->assertSame(['a' => 1, 'b' => 2], $source->value());
+    }
+}


### PR DESCRIPTION
- Added a map decorator that exposes the source map values as a list
- Updated README with the new Map module entry and quick reference row

Closes #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Values class providing list-like access to map values with support for iteration, counting entries, and retrieving all values.

* **Documentation**
  * Updated Quick Reference guide with documentation on working with array values and their library equivalents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->