### PR TITLE
Filter Map Pairs By Excluded Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Objects are immutable, final, and easy to combine.
 | `array_merge` for lists | `new Joined(new ListOf(...$a), new ListOf(...$b))` |
 | `array_keys($a)` | `new Keys(new MapOf($a))` |
 | `array_values($a)` | `new Values(new MapOf($a))` |
+| `array_diff_key($a, $b)` | `new Diff(new MapOf($a), new MapOf($b))` |
 
 ---
 
@@ -88,7 +89,7 @@ FuncWithFallback, Predicate, PredicateOf, Proc, ProcOf, Repeated, StickyFunc
 List_, ListEnvelope, ListOf, Filtered, Joined, Mapped, NoNulls, Reversed
 
 ### **Map**
-Map, MapEnvelope, MapOf, BiFiltered, BiMapped, Filtered, Keys, Mapped, Merged, NoNulls, Values
+Map, MapEnvelope, MapOf, BiFiltered, BiMapped, Diff, Filtered, Keys, Mapped, Merged, NoNulls, Values
 
 ### **Numeric**
 Number

--- a/src/Map/Diff.php
+++ b/src/Map/Diff.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Map;
+
+use Generator;
+use Override;
+
+/**
+ * Map keeping pairs of the first source whose keys are absent from all other sources.
+ *
+ * Example:
+ *     $diff = new Diff(
+ *         new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+ *         new MapOf(['b' => 99]),
+ *         new MapOf(['c' => 0]),
+ *     );
+ *     // ['a' => 1]
+ *
+ * @template K of array-key
+ * @template V
+ * @implements Map<K, V>
+ * @since 0.3
+ */
+final readonly class Diff implements Map
+{
+    /** @var array<array-key, Map<K, mixed>> */
+    private array $excluded;
+
+    /**
+     * Ctor.
+     *
+     * @param Map<K, V> $first The map to draw pairs from.
+     * @param Map<K, mixed> ...$excluded Maps whose keys remove pairs from the first.
+     */
+    public function __construct(private Map $first, Map ...$excluded)
+    {
+        $this->excluded = $excluded;
+    }
+
+    #[Override]
+    public function value(): array
+    {
+        $excludedKeys = [];
+
+        foreach ($this->excluded as $source) {
+            foreach (array_keys($source->value()) as $key) {
+                $excludedKeys[$key] = true;
+            }
+        }
+
+        $pairs = [];
+
+        foreach ($this->first->value() as $key => $value) {
+            if (!array_key_exists($key, $excludedKeys)) {
+                $pairs[$key] = $value;
+            }
+        }
+
+        return $pairs;
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return count($this->value());
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->value();
+    }
+}

--- a/tests/Map/DiffTest.php
+++ b/tests/Map/DiffTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Map;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Map\Diff;
+use Primus\Map\MapOf;
+
+final class DiffTest extends TestCase
+{
+    #[Test]
+    public function returnsFirstSourceUntouchedWhenNoOtherSources(): void
+    {
+        $this->assertSame(
+            ['a' => 1, 'b' => 2],
+            (new Diff(new MapOf(['a' => 1, 'b' => 2])))->value(),
+        );
+    }
+
+    #[Test]
+    public function dropsKeysPresentInLaterSource(): void
+    {
+        $this->assertSame(
+            ['a' => 1, 'c' => 3],
+            (new Diff(
+                new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+                new MapOf(['b' => 99]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function dropsKeysPresentInAnyLaterSource(): void
+    {
+        $this->assertSame(
+            ['a' => 1],
+            (new Diff(
+                new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+                new MapOf(['b' => 99]),
+                new MapOf(['c' => 0]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesFirstSourceValuesUnchanged(): void
+    {
+        $this->assertSame(
+            ['a' => 1, 'c' => 3],
+            (new Diff(
+                new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+                new MapOf(['b' => 'replacement-value-ignored']),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function ignoresExcludedSourceValuesWhenSelectingPairs(): void
+    {
+        $this->assertSame(
+            ['a' => 1, 'b' => 2],
+            (new Diff(
+                new MapOf(['a' => 1, 'b' => 2]),
+                new MapOf(['c' => 1]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesFirstSourceIterationOrder(): void
+    {
+        $this->assertSame(
+            ['c' => 3, 'a' => 1],
+            (new Diff(
+                new MapOf(['c' => 3, 'b' => 2, 'a' => 1]),
+                new MapOf(['b' => 0]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function distinguishesNumericStringKeyFromIntegerKey(): void
+    {
+        $this->assertSame(
+            ['01' => 'leadingZero'],
+            (new Diff(
+                new MapOf([1 => 'one', '01' => 'leadingZero']),
+                new MapOf([1 => 'remove-canonical-int-only']),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyWhenAllKeysExcluded(): void
+    {
+        $this->assertSame(
+            [],
+            (new Diff(
+                new MapOf(['a' => 1, 'b' => 2]),
+                new MapOf(['a' => 0, 'b' => 0]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function iteratorYieldsSameSequenceAsValue(): void
+    {
+        $diff = new Diff(
+            new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+            new MapOf(['b' => 0]),
+        );
+        $this->assertSame(
+            $diff->value(),
+            iterator_to_array($diff),
+        );
+    }
+
+    #[Test]
+    public function countsPairsAfterExclusion(): void
+    {
+        $this->assertCount(
+            1,
+            new Diff(
+                new MapOf(['a' => 1, 'b' => 2]),
+                new MapOf(['a' => 0]),
+            ),
+        );
+    }
+
+    #[Test]
+    public function leavesSourcesUntouchedAfterReading(): void
+    {
+        $first = new MapOf(['a' => 1, 'b' => 2]);
+        $excluded = new MapOf(['b' => 99]);
+        $diff = new Diff($first, $excluded);
+        $diff->value();
+        iterator_to_array($diff);
+        $this->assertSame(['a' => 1, 'b' => 2], $first->value());
+        $this->assertSame(['b' => 99], $excluded->value());
+    }
+}


### PR DESCRIPTION
- Added a map decorator that keeps pairs of the first source whose keys are absent from later sources
- Updated README with the new Map module entry and quick reference row

Closes #92