### PR TITLE
Filter Map Pairs By Shared Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Objects are immutable, final, and easy to combine.
 | `array_keys($a)` | `new Keys(new MapOf($a))` |
 | `array_values($a)` | `new Values(new MapOf($a))` |
 | `array_diff_key($a, $b)` | `new Diff(new MapOf($a), new MapOf($b))` |
+| `array_intersect_key($a, $b)` | `new Intersect(new MapOf($a), new MapOf($b))` |
 
 ---
 
@@ -89,7 +90,7 @@ FuncWithFallback, Predicate, PredicateOf, Proc, ProcOf, Repeated, StickyFunc
 List_, ListEnvelope, ListOf, Filtered, Joined, Mapped, NoNulls, Reversed
 
 ### **Map**
-Map, MapEnvelope, MapOf, BiFiltered, BiMapped, Diff, Filtered, Keys, Mapped, Merged, NoNulls, Values
+Map, MapEnvelope, MapOf, BiFiltered, BiMapped, Diff, Filtered, Intersect, Keys, Mapped, Merged, NoNulls, Values
 
 ### **Numeric**
 Number

--- a/src/Map/Intersect.php
+++ b/src/Map/Intersect.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Map;
+
+use Generator;
+use Override;
+
+/**
+ * Map keeping pairs of the first source whose keys are present in every other source.
+ *
+ * Example:
+ *     $intersect = new Intersect(
+ *         new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+ *         new MapOf(['b' => 99, 'c' => 0]),
+ *         new MapOf(['c' => 7, 'd' => 1]),
+ *     );
+ *     // ['c' => 3]
+ *
+ * @template K of array-key
+ * @template V
+ * @implements Map<K, V>
+ * @since 0.3
+ */
+final readonly class Intersect implements Map
+{
+    /** @var array<array-key, Map<K, mixed>> */
+    private array $required;
+
+    /**
+     * Ctor.
+     *
+     * @param Map<K, V> $first The map to draw pairs from.
+     * @param Map<K, mixed> ...$required Maps whose keys must contain a first-source key for it to be kept.
+     */
+    public function __construct(private Map $first, Map ...$required)
+    {
+        $this->required = $required;
+    }
+
+    #[Override]
+    public function value(): array
+    {
+        $pairs = [];
+
+        foreach ($this->first->value() as $key => $value) {
+            if ($this->presentInAllRequired($key)) {
+                $pairs[$key] = $value;
+            }
+        }
+
+        return $pairs;
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return count($this->value());
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->value();
+    }
+
+    private function presentInAllRequired(int|string $key): bool
+    {
+        foreach ($this->required as $source) {
+            if (!array_key_exists($key, $source->value())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/Map/IntersectTest.php
+++ b/tests/Map/IntersectTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Map;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Map\Intersect;
+use Primus\Map\MapOf;
+
+final class IntersectTest extends TestCase
+{
+    #[Test]
+    public function returnsFirstSourceUntouchedWhenNoOtherSources(): void
+    {
+        $this->assertSame(
+            ['a' => 1, 'b' => 2],
+            (new Intersect(new MapOf(['a' => 1, 'b' => 2])))->value(),
+        );
+    }
+
+    #[Test]
+    public function keepsKeysSharedWithLaterSource(): void
+    {
+        $this->assertSame(
+            ['b' => 2],
+            (new Intersect(
+                new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+                new MapOf(['b' => 99]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function keepsKeysSharedWithEveryLaterSource(): void
+    {
+        $this->assertSame(
+            ['c' => 3],
+            (new Intersect(
+                new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+                new MapOf(['b' => 99, 'c' => 0]),
+                new MapOf(['c' => 7, 'd' => 1]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesFirstSourceValuesUnchanged(): void
+    {
+        $this->assertSame(
+            ['b' => 2, 'c' => 3],
+            (new Intersect(
+                new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+                new MapOf(['b' => 'replacement-ignored', 'c' => 'also-ignored']),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function ignoresRequiredSourceValuesWhenSelectingPairs(): void
+    {
+        $this->assertSame(
+            ['a' => 1],
+            (new Intersect(
+                new MapOf(['a' => 1, 'b' => 2]),
+                new MapOf(['a' => 0]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesFirstSourceIterationOrder(): void
+    {
+        $this->assertSame(
+            ['c' => 3, 'a' => 1],
+            (new Intersect(
+                new MapOf(['c' => 3, 'b' => 2, 'a' => 1]),
+                new MapOf(['a' => 0, 'c' => 0]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function distinguishesNumericStringKeyFromIntegerKey(): void
+    {
+        $this->assertSame(
+            [1 => 'one'],
+            (new Intersect(
+                new MapOf([1 => 'one', '01' => 'leadingZero']),
+                new MapOf([1 => 'shared-canonical-int-only']),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyWhenNoKeysShared(): void
+    {
+        $this->assertSame(
+            [],
+            (new Intersect(
+                new MapOf(['a' => 1, 'b' => 2]),
+                new MapOf(['c' => 0, 'd' => 0]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function iteratorYieldsSameSequenceAsValue(): void
+    {
+        $intersect = new Intersect(
+            new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+            new MapOf(['b' => 0, 'c' => 0]),
+        );
+        $this->assertSame(
+            $intersect->value(),
+            iterator_to_array($intersect),
+        );
+    }
+
+    #[Test]
+    public function countsPairsAfterIntersection(): void
+    {
+        $this->assertCount(
+            2,
+            new Intersect(
+                new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+                new MapOf(['a' => 0, 'b' => 0]),
+            ),
+        );
+    }
+
+    #[Test]
+    public function leavesSourcesUntouchedAfterReading(): void
+    {
+        $first = new MapOf(['a' => 1, 'b' => 2]);
+        $required = new MapOf(['b' => 99]);
+        $intersect = new Intersect($first, $required);
+        $intersect->value();
+        iterator_to_array($intersect);
+        $this->assertSame(['a' => 1, 'b' => 2], $first->value());
+        $this->assertSame(['b' => 99], $required->value());
+    }
+}


### PR DESCRIPTION
- Added a map decorator that keeps pairs of the first source whose keys are present in every later source
- Updated README with the new Map module entry and quick reference row

Closes #94