### PR TITLE
Combine Two Lists Into A Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Objects are immutable, final, and easy to combine.
 | `array_values($a)` | `new Values(new MapOf($a))` |
 | `array_diff_key($a, $b)` | `new Diff(new MapOf($a), new MapOf($b))` |
 | `array_intersect_key($a, $b)` | `new Intersect(new MapOf($a), new MapOf($b))` |
+| `array_combine($k, $v)` | `new Combined(new ListOf(...$k), new ListOf(...$v))` |
 
 ---
 
@@ -90,7 +91,7 @@ FuncWithFallback, Predicate, PredicateOf, Proc, ProcOf, Repeated, StickyFunc
 List_, ListEnvelope, ListOf, Filtered, Joined, Mapped, NoNulls, Reversed
 
 ### **Map**
-Map, MapEnvelope, MapOf, BiFiltered, BiMapped, Diff, Filtered, Intersect, Keys, Mapped, Merged, NoNulls, Values
+Map, MapEnvelope, MapOf, BiFiltered, BiMapped, Combined, Diff, Filtered, Intersect, Keys, Mapped, Merged, NoNulls, Values
 
 ### **Numeric**
 Number

--- a/src/Map/Combined.php
+++ b/src/Map/Combined.php
@@ -50,13 +50,7 @@ final readonly class Combined implements Map
             ));
         }
 
-        $pairs = [];
-
-        foreach ($keysArray as $position => $key) {
-            $pairs[$key] = $valuesArray[$position];
-        }
-
-        return $pairs;
+        return array_combine($keysArray, $valuesArray);
     }
 
     #[Override]

--- a/src/Map/Combined.php
+++ b/src/Map/Combined.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Map;
+
+use Generator;
+use Override;
+use Primus\List\List_;
+use RuntimeException;
+
+/**
+ * Map built from two parallel lists used as keys and values.
+ *
+ * Pairs are formed by zipping the keys list with the values list at the same positions.
+ * Sources of different lengths fail fast on first observation.
+ *
+ * Example:
+ *     $map = new Combined(
+ *         new ListOf('a', 'b', 'c'),
+ *         new ListOf(1, 2, 3),
+ *     );
+ *     // ['a' => 1, 'b' => 2, 'c' => 3]
+ *
+ * @template V
+ * @implements Map<array-key, V>
+ * @since 0.3
+ */
+final readonly class Combined implements Map
+{
+    /**
+     * Ctor.
+     *
+     * @param List_<array-key> $keys Source list of keys.
+     * @param List_<V> $values Source list of values, parallel to $keys.
+     */
+    public function __construct(private List_ $keys, private List_ $values) {}
+
+    #[Override]
+    public function value(): array
+    {
+        $keysArray = array_values($this->keys->value());
+        $valuesArray = array_values($this->values->value());
+
+        if (count($keysArray) !== count($valuesArray)) {
+            throw new RuntimeException(sprintf(
+                'Combined map sources differ in length: %d keys vs %d values',
+                count($keysArray),
+                count($valuesArray),
+            ));
+        }
+
+        $pairs = [];
+
+        foreach ($keysArray as $position => $key) {
+            $pairs[$key] = $valuesArray[$position];
+        }
+
+        return $pairs;
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return count($this->value());
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->value();
+    }
+}

--- a/tests/Map/CombinedTest.php
+++ b/tests/Map/CombinedTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Map;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\List\ListOf;
+use Primus\Map\Combined;
+use RuntimeException;
+
+final class CombinedTest extends TestCase
+{
+    #[Test]
+    public function buildsEmptyMapFromTwoEmptyLists(): void
+    {
+        $this->assertSame(
+            [],
+            (new Combined(new ListOf(), new ListOf()))->value(),
+        );
+    }
+
+    #[Test]
+    public function zipsKeysAndValuesByPosition(): void
+    {
+        $this->assertSame(
+            ['a' => 1, 'b' => 2, 'c' => 3],
+            (new Combined(
+                new ListOf('a', 'b', 'c'),
+                new ListOf(1, 2, 3),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesPositionOrderInResult(): void
+    {
+        $this->assertSame(
+            ['z' => 'first', 'a' => 'second'],
+            (new Combined(
+                new ListOf('z', 'a'),
+                new ListOf('first', 'second'),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function supportsIntegerKeys(): void
+    {
+        $this->assertSame(
+            [10 => 'ten', 20 => 'twenty'],
+            (new Combined(
+                new ListOf(10, 20),
+                new ListOf('ten', 'twenty'),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function distinguishesNumericStringKeyFromIntegerKey(): void
+    {
+        $this->assertSame(
+            [1 => 'one', '01' => 'leadingZero'],
+            (new Combined(
+                new ListOf(1, '01'),
+                new ListOf('one', 'leadingZero'),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function laterDuplicateKeyOverwritesEarlier(): void
+    {
+        $this->assertSame(
+            ['a' => 2],
+            (new Combined(
+                new ListOf('a', 'a'),
+                new ListOf(1, 2),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function failsWhenKeysListLongerThanValues(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Combined map sources differ in length: 3 keys vs 2 values');
+
+        (new Combined(
+            new ListOf('a', 'b', 'c'),
+            new ListOf(1, 2),
+        ))->value();
+    }
+
+    #[Test]
+    public function failsWhenValuesListLongerThanKeys(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Combined map sources differ in length: 1 keys vs 4 values');
+
+        (new Combined(
+            new ListOf('only'),
+            new ListOf(1, 2, 3, 4),
+        ))->value();
+    }
+
+    #[Test]
+    public function iteratorYieldsSameSequenceAsValue(): void
+    {
+        $combined = new Combined(
+            new ListOf('a', 'b'),
+            new ListOf(1, 2),
+        );
+        $this->assertSame(
+            $combined->value(),
+            iterator_to_array($combined),
+        );
+    }
+
+    #[Test]
+    public function countsZippedPairs(): void
+    {
+        $this->assertCount(
+            3,
+            new Combined(
+                new ListOf('a', 'b', 'c'),
+                new ListOf(1, 2, 3),
+            ),
+        );
+    }
+
+    #[Test]
+    public function leavesSourcesUntouchedAfterReading(): void
+    {
+        $keys = new ListOf('a', 'b');
+        $values = new ListOf(1, 2);
+        $combined = new Combined($keys, $values);
+        $combined->value();
+        iterator_to_array($combined);
+        $this->assertSame(['a', 'b'], $keys->value());
+        $this->assertSame([1, 2], $values->value());
+    }
+}


### PR DESCRIPTION
- Added a map decorator that zips two parallel lists by position into key-value pairs
- Added fail-fast behavior on length mismatch through RuntimeException in value()
- Updated README with the new Map module entry and quick reference row

Closes #96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mapping feature that zips two lists (keys and values) into an associative map with validation for mismatched lengths.

* **Documentation**
  * Quick reference updated to document the new combined-list mapping primitive and include it in the modules list.

* **Tests**
  * Added comprehensive tests covering zipping behavior, key handling, overwrite semantics, iteration, count, and length-mismatch errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->