### PR TITLE
Pluck Single Column From Row List

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Objects are immutable, final, and easy to combine.
 | `array_diff_key($a, $b)` | `new Diff(new MapOf($a), new MapOf($b))` |
 | `array_intersect_key($a, $b)` | `new Intersect(new MapOf($a), new MapOf($b))` |
 | `array_combine($k, $v)` | `new Combined(new ListOf(...$k), new ListOf(...$v))` |
+| `array_column($rows, $key)` | `new Plucked(new ListOf(...$rows), $key)` |
 
 ---
 
@@ -88,7 +89,7 @@ BiFunc, BiFuncOf, BiProc, BiProcOf, Func, FuncEnvelope, FuncOf,
 FuncWithFallback, Predicate, PredicateOf, Proc, ProcOf, Repeated, StickyFunc
 
 ### **List**
-List_, ListEnvelope, ListOf, Filtered, Joined, Mapped, NoNulls, Reversed
+List_, ListEnvelope, ListOf, Filtered, Joined, Mapped, NoNulls, Plucked, Reversed
 
 ### **Map**
 Map, MapEnvelope, MapOf, BiFiltered, BiMapped, Combined, Diff, Filtered, Intersect, Keys, Mapped, Merged, NoNulls, Values

--- a/src/List/Plucked.php
+++ b/src/List/Plucked.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\List;
+
+use Generator;
+use Override;
+use RuntimeException;
+
+/**
+ * List of values picked at a single key from every row of a source list of rows.
+ *
+ * Example:
+ *     $names = new Plucked(
+ *         new ListOf(
+ *             ['id' => 1, 'name' => 'Alice'],
+ *             ['id' => 2, 'name' => 'Bob'],
+ *         ),
+ *         'name',
+ *     );
+ *     // ['Alice', 'Bob']
+ *
+ * @template V
+ * @implements List_<V>
+ * @since 0.3
+ */
+final readonly class Plucked implements List_
+{
+    /**
+     * Ctor.
+     *
+     * @param List_<array<array-key, V>> $origin Source list of row arrays.
+     * @param array-key $key Column key to pluck from every row.
+     */
+    public function __construct(private List_ $origin, private int|string $key) {}
+
+    #[Override]
+    public function value(): array
+    {
+        $values = [];
+
+        foreach ($this->origin->value() as $position => $row) {
+            if (!array_key_exists($this->key, $row)) {
+                throw new RuntimeException(sprintf(
+                    'Plucked key %s missing in row at position %s',
+                    var_export($this->key, true),
+                    var_export($position, true),
+                ));
+            }
+
+            $values[] = $row[$this->key];
+        }
+
+        return $values;
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return count($this->value());
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->value();
+    }
+}

--- a/tests/List/PluckedTest.php
+++ b/tests/List/PluckedTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\List;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\List\ListOf;
+use Primus\List\Plucked;
+use RuntimeException;
+
+final class PluckedTest extends TestCase
+{
+    #[Test]
+    public function exposesEmptyResultForEmptySource(): void
+    {
+        $this->assertSame(
+            [],
+            (new Plucked(new ListOf(), 'name'))->value(),
+        );
+    }
+
+    #[Test]
+    public function picksColumnFromEveryRowInSourceOrder(): void
+    {
+        $this->assertSame(
+            ['Alice', 'Bob', 'Carol'],
+            (new Plucked(
+                new ListOf(
+                    ['id' => 1, 'name' => 'Alice'],
+                    ['id' => 2, 'name' => 'Bob'],
+                    ['id' => 3, 'name' => 'Carol'],
+                ),
+                'name',
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesNullValuesInColumn(): void
+    {
+        $this->assertSame(
+            [1, null, 3],
+            (new Plucked(
+                new ListOf(
+                    ['v' => 1],
+                    ['v' => null],
+                    ['v' => 3],
+                ),
+                'v',
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function supportsIntegerKey(): void
+    {
+        $this->assertSame(
+            ['first', 'second'],
+            (new Plucked(
+                new ListOf(
+                    [0 => 'first', 1 => 'extra'],
+                    [0 => 'second', 1 => 'extra'],
+                ),
+                0,
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function distinguishesNumericStringKeyFromIntegerKey(): void
+    {
+        $this->assertSame(
+            ['leadingZero'],
+            (new Plucked(
+                new ListOf(
+                    [1 => 'one', '01' => 'leadingZero'],
+                ),
+                '01',
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function failsWhenAnyRowLacksKey(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("Plucked key 'name' missing in row at position 1");
+
+        (new Plucked(
+            new ListOf(
+                ['id' => 1, 'name' => 'Alice'],
+                ['id' => 2],
+            ),
+            'name',
+        ))->value();
+    }
+
+    #[Test]
+    public function iteratorYieldsSameSequenceAsValue(): void
+    {
+        $plucked = new Plucked(
+            new ListOf(
+                ['v' => 'a'],
+                ['v' => 'b'],
+            ),
+            'v',
+        );
+        $this->assertSame(
+            $plucked->value(),
+            iterator_to_array($plucked),
+        );
+    }
+
+    #[Test]
+    public function countsAsManyAsRowsInSource(): void
+    {
+        $this->assertCount(
+            3,
+            new Plucked(
+                new ListOf(
+                    ['v' => 1],
+                    ['v' => 2],
+                    ['v' => 3],
+                ),
+                'v',
+            ),
+        );
+    }
+
+    #[Test]
+    public function leavesSourceUntouchedAfterReading(): void
+    {
+        $rows = [
+            ['name' => 'Alice'],
+            ['name' => 'Bob'],
+        ];
+        $source = new ListOf(...$rows);
+        $plucked = new Plucked($source, 'name');
+        $plucked->value();
+        iterator_to_array($plucked);
+        $this->assertSame($rows, $source->value());
+    }
+}


### PR DESCRIPTION
- Added a list decorator that exposes one column value from every row in a source list of rows
- Added fail-fast behavior on missing key through RuntimeException in value()
- Updated README with the new List module entry and quick reference row

Closes #98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced column extraction functionality for arrays of rows, enabling efficient data filtering and transformation operations.

* **Documentation**
  * Updated Quick Reference guide and List module documentation to reflect the new column extraction feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->