### PR TITLE
Index Row List Into A Map By Chosen Column

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Objects are immutable, final, and easy to combine.
 | `array_intersect_key($a, $b)` | `new Intersect(new MapOf($a), new MapOf($b))` |
 | `array_combine($k, $v)` | `new Combined(new ListOf(...$k), new ListOf(...$v))` |
 | `array_column($rows, $key)` | `new Plucked(new ListOf(...$rows), $key)` |
+| `array_column($rows, $vk, $ik)` | `new PluckedBy(new ListOf(...$rows), $ik, $vk)` |
 
 ---
 
@@ -92,7 +93,7 @@ FuncWithFallback, Predicate, PredicateOf, Proc, ProcOf, Repeated, StickyFunc
 List_, ListEnvelope, ListOf, Filtered, Joined, Mapped, NoNulls, Plucked, Reversed
 
 ### **Map**
-Map, MapEnvelope, MapOf, BiFiltered, BiMapped, Combined, Diff, Filtered, Intersect, Keys, Mapped, Merged, NoNulls, Values
+Map, MapEnvelope, MapOf, BiFiltered, BiMapped, Combined, Diff, Filtered, Intersect, Keys, Mapped, Merged, NoNulls, PluckedBy, Values
 
 ### **Numeric**
 Number

--- a/src/Map/PluckedBy.php
+++ b/src/Map/PluckedBy.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Map;
+
+use Generator;
+use Override;
+use Primus\List\List_;
+use RuntimeException;
+
+/**
+ * Map of pairs picked from row arrays where the index column supplies keys and the value column supplies values.
+ *
+ * Example:
+ *     $byId = new PluckedBy(
+ *         new ListOf(
+ *             ['id' => 1, 'name' => 'Alice'],
+ *             ['id' => 2, 'name' => 'Bob'],
+ *         ),
+ *         'id',
+ *         'name',
+ *     );
+ *     // [1 => 'Alice', 2 => 'Bob']
+ *
+ * @template V
+ * @implements Map<array-key, V>
+ * @since 0.3
+ */
+final readonly class PluckedBy implements Map
+{
+    /**
+     * Ctor.
+     *
+     * @param List_<array<array-key, mixed>> $origin Source list of row arrays.
+     * @param array-key $index Row column supplying pair keys.
+     * @param array-key $column Row column supplying pair values.
+     */
+    public function __construct(
+        private List_ $origin,
+        private int|string $index,
+        private int|string $column,
+    ) {}
+
+    #[Override]
+    public function value(): array
+    {
+        /** @var array<array-key, V> $pairs */
+        $pairs = [];
+
+        foreach ($this->origin->value() as $position => $row) {
+            if (!array_key_exists($this->index, $row)) {
+                throw new RuntimeException(sprintf(
+                    'PluckedBy index key %s missing in row at position %s',
+                    var_export($this->index, true),
+                    var_export($position, true),
+                ));
+            }
+
+            if (!array_key_exists($this->column, $row)) {
+                throw new RuntimeException(sprintf(
+                    'PluckedBy value key %s missing in row at position %s',
+                    var_export($this->column, true),
+                    var_export($position, true),
+                ));
+            }
+
+            $key = $row[$this->index];
+
+            if (!is_int($key) && !is_string($key)) {
+                throw new RuntimeException(sprintf(
+                    'PluckedBy index value at position %s is %s, expected int or string',
+                    var_export($position, true),
+                    get_debug_type($key),
+                ));
+            }
+
+            /** @var V $value */
+            $value = $row[$this->column];
+
+            $pairs[$key] = $value;
+        }
+
+        return $pairs;
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return count($this->value());
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->value();
+    }
+}

--- a/tests/Map/PluckedByTest.php
+++ b/tests/Map/PluckedByTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Map;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\List\ListOf;
+use Primus\Map\PluckedBy;
+use RuntimeException;
+
+final class PluckedByTest extends TestCase
+{
+    #[Test]
+    public function exposesEmptyResultForEmptySource(): void
+    {
+        $this->assertSame(
+            [],
+            (new PluckedBy(new ListOf(), 'id', 'name'))->value(),
+        );
+    }
+
+    #[Test]
+    public function indexesRowsByIndexColumnValueOfNameColumn(): void
+    {
+        $this->assertSame(
+            [1 => 'Alice', 2 => 'Bob'],
+            (new PluckedBy(
+                new ListOf(
+                    ['id' => 1, 'name' => 'Alice'],
+                    ['id' => 2, 'name' => 'Bob'],
+                ),
+                'id',
+                'name',
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesRowOrderInResult(): void
+    {
+        $this->assertSame(
+            ['z' => 'first', 'a' => 'second'],
+            (new PluckedBy(
+                new ListOf(
+                    ['k' => 'z', 'v' => 'first'],
+                    ['k' => 'a', 'v' => 'second'],
+                ),
+                'k',
+                'v',
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function distinguishesNumericStringIndexFromIntegerIndex(): void
+    {
+        $this->assertSame(
+            [1 => 'one', '01' => 'leadingZero'],
+            (new PluckedBy(
+                new ListOf(
+                    ['k' => 1, 'v' => 'one'],
+                    ['k' => '01', 'v' => 'leadingZero'],
+                ),
+                'k',
+                'v',
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesNullValueInValueColumn(): void
+    {
+        $this->assertSame(
+            [1 => null, 2 => 'present'],
+            (new PluckedBy(
+                new ListOf(
+                    ['id' => 1, 'name' => null],
+                    ['id' => 2, 'name' => 'present'],
+                ),
+                'id',
+                'name',
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function laterDuplicateIndexOverwritesEarlier(): void
+    {
+        $this->assertSame(
+            [1 => 'second'],
+            (new PluckedBy(
+                new ListOf(
+                    ['id' => 1, 'name' => 'first'],
+                    ['id' => 1, 'name' => 'second'],
+                ),
+                'id',
+                'name',
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function failsWhenAnyRowLacksIndexKey(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("PluckedBy index key 'id' missing in row at position 1");
+
+        (new PluckedBy(
+            new ListOf(
+                ['id' => 1, 'name' => 'Alice'],
+                ['name' => 'Bob'],
+            ),
+            'id',
+            'name',
+        ))->value();
+    }
+
+    #[Test]
+    public function failsWhenAnyRowLacksValueKey(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("PluckedBy value key 'name' missing in row at position 0");
+
+        (new PluckedBy(
+            new ListOf(
+                ['id' => 1],
+            ),
+            'id',
+            'name',
+        ))->value();
+    }
+
+    #[Test]
+    public function failsWhenIndexValueIsNotArrayKey(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('PluckedBy index value at position 0 is array, expected int or string');
+
+        (new PluckedBy(
+            new ListOf(
+                ['id' => ['nested'], 'name' => 'Alice'],
+            ),
+            'id',
+            'name',
+        ))->value();
+    }
+
+    #[Test]
+    public function iteratorYieldsSameSequenceAsValue(): void
+    {
+        $plucked = new PluckedBy(
+            new ListOf(
+                ['id' => 1, 'name' => 'Alice'],
+                ['id' => 2, 'name' => 'Bob'],
+            ),
+            'id',
+            'name',
+        );
+        $this->assertSame(
+            $plucked->value(),
+            iterator_to_array($plucked),
+        );
+    }
+
+    #[Test]
+    public function countsAsManyAsRowsInSourceWithUniqueIndexes(): void
+    {
+        $this->assertCount(
+            3,
+            new PluckedBy(
+                new ListOf(
+                    ['id' => 1, 'v' => 'a'],
+                    ['id' => 2, 'v' => 'b'],
+                    ['id' => 3, 'v' => 'c'],
+                ),
+                'id',
+                'v',
+            ),
+        );
+    }
+
+    #[Test]
+    public function leavesSourceUntouchedAfterReading(): void
+    {
+        $rows = [
+            ['id' => 1, 'name' => 'Alice'],
+            ['id' => 2, 'name' => 'Bob'],
+        ];
+        $source = new ListOf(...$rows);
+        $plucked = new PluckedBy($source, 'id', 'name');
+        $plucked->value();
+        iterator_to_array($plucked);
+        $this->assertSame($rows, $source->value());
+    }
+}


### PR DESCRIPTION
- Added a map decorator that exposes one row column as keys and another as values
- Added fail-fast behavior on missing columns or non-array-key index values through RuntimeException in value()
- Updated README with the new Map module entry and quick reference row

Closes #100