### PR TITLE
Raise PR Size Limit From 250 To 500 Lines

### DIFF
--- a/.github/workflows/sheriff.yml
+++ b/.github/workflows/sheriff.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: maidsafe/pr_size_checker@948bfb3e96d93fbeeef4e207375163e8dae5665e
         with:
-          max_lines_changed: 250
+          max_lines_changed: 500
 
 
   # ============================================================

--- a/.sheriff.yaml
+++ b/.sheriff.yaml
@@ -5,3 +5,4 @@ override:
     phpmetrics.coupling.max_afferent: 17
     phpunit.testsuites.unit: ["../../tests"]
     phpunit.testsuites.integration: []
+    ci.pr.max_lines_changed: 500


### PR DESCRIPTION
- Updated PR size hard gate from 250 to 500 lines to accommodate tooling overhead in feature PRs
- Updated generated sheriff workflow to reflect the new limit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request size validation configuration thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->