### PR TITLE
Mark Primus Runtime Failures With A Dedicated Exception Type

### DIFF
--- a/src/Func/Repeated.php
+++ b/src/Func/Repeated.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Primus\Func;
 
 use Override;
-use RuntimeException;
+use Primus\RuntimeException;
 
 /**
  * Func applied multiple times sequentially.

--- a/src/List/NoNulls.php
+++ b/src/List/NoNulls.php
@@ -6,7 +6,7 @@ namespace Primus\List;
 
 use Generator;
 use Override;
-use RuntimeException;
+use Primus\RuntimeException;
 
 /**
  * List that forbids null values.

--- a/src/List/Plucked.php
+++ b/src/List/Plucked.php
@@ -6,7 +6,7 @@ namespace Primus\List;
 
 use Generator;
 use Override;
-use RuntimeException;
+use Primus\RuntimeException;
 
 /**
  * List of values picked at a single key from every row of a source list of rows.

--- a/src/Map/Combined.php
+++ b/src/Map/Combined.php
@@ -7,7 +7,7 @@ namespace Primus\Map;
 use Generator;
 use Override;
 use Primus\List\List_;
-use RuntimeException;
+use Primus\RuntimeException;
 
 /**
  * Map built from two parallel lists used as keys and values.

--- a/src/Map/NoNulls.php
+++ b/src/Map/NoNulls.php
@@ -6,7 +6,7 @@ namespace Primus\Map;
 
 use Generator;
 use Override;
-use RuntimeException;
+use Primus\RuntimeException;
 
 /**
  * Map that forbids null values.

--- a/src/Map/PluckedBy.php
+++ b/src/Map/PluckedBy.php
@@ -7,7 +7,7 @@ namespace Primus\Map;
 use Generator;
 use Override;
 use Primus\List\List_;
-use RuntimeException;
+use Primus\RuntimeException;
 
 /**
  * Map of pairs picked from row arrays where the index column supplies keys and the value column supplies values.

--- a/src/RuntimeException.php
+++ b/src/RuntimeException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus;
+
+use RuntimeException as BaseRuntimeException;
+
+/**
+ * Marker exception thrown by Primus decorators when a runtime contract is broken.
+ *
+ * Every Primus runtime failure uses this single type so that consumers can
+ * distinguish primus-originated failures from unrelated runtime exceptions
+ * via a single catch clause. No per-failure subclasses are introduced.
+ *
+ * @since 0.3
+ */
+final class RuntimeException extends BaseRuntimeException {}


### PR DESCRIPTION
- Added a single project-level Primus runtime exception class extending the standard runtime exception
- Refactored every existing runtime-failure throw site to use the project-level type instead of the bare standard one

Closes #103