### PR TITLE
Lazy Evaluation in Parameterless Text Decorators

### DIFF
--- a/src/Text/HtmlEscaped.php
+++ b/src/Text/HtmlEscaped.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
+use Override;
+
 /**
  * Escaped {@see Text} safe for HTML rendering.
  *
@@ -22,10 +24,12 @@ final readonly class HtmlEscaped extends TextEnvelope
      */
     public function __construct(Text $origin)
     {
-        parent::__construct(
-            new TextOf(
-                htmlspecialchars($origin->value(), ENT_QUOTES | ENT_HTML5, 'UTF-8'),
-            ),
-        );
+        parent::__construct($origin);
+    }
+
+    #[Override]
+    public function value(): string
+    {
+        return htmlspecialchars($this->origin->value(), ENT_QUOTES | ENT_HTML5, 'UTF-8');
     }
 }

--- a/src/Text/Lowered.php
+++ b/src/Text/Lowered.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
+use Override;
+
 /**
  * Text in lowercase.
  *
@@ -24,8 +26,12 @@ final readonly class Lowered extends TextEnvelope
      */
     public function __construct(Text $origin)
     {
-        parent::__construct(
-            new TextOf(mb_strtolower($origin->value(), 'UTF-8')),
-        );
+        parent::__construct($origin);
+    }
+
+    #[Override]
+    public function value(): string
+    {
+        return mb_strtolower($this->origin->value(), 'UTF-8');
     }
 }

--- a/src/Text/Trimmed.php
+++ b/src/Text/Trimmed.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
+use Override;
+
 /**
  * Text without leading or trailing whitespace.
  *
@@ -24,8 +26,12 @@ final readonly class Trimmed extends TextEnvelope
      */
     public function __construct(Text $origin)
     {
-        parent::__construct(
-            new TextOf(trim($origin->value())),
-        );
+        parent::__construct($origin);
+    }
+
+    #[Override]
+    public function value(): string
+    {
+        return trim($this->origin->value());
     }
 }

--- a/src/Text/TrimmedLeft.php
+++ b/src/Text/TrimmedLeft.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
+use InvalidArgumentException;
 use Override;
 
 /**
@@ -30,6 +31,7 @@ final readonly class TrimmedLeft extends TextEnvelope
     #[Override]
     public function value(): string
     {
-        return (string) preg_replace('/^\s+/u', '', $this->origin->value());
+        return preg_replace('/^\s+/u', '', $this->origin->value())
+            ?? throw new InvalidArgumentException('Malformed UTF-8 input');
     }
 }

--- a/src/Text/TrimmedLeft.php
+++ b/src/Text/TrimmedLeft.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
+use Override;
+
 /**
  * Text with whitespace removed from the left side.
  *
@@ -22,10 +24,12 @@ final readonly class TrimmedLeft extends TextEnvelope
      */
     public function __construct(Text $origin)
     {
-        parent::__construct(
-            new TextOf(
-                (string) preg_replace('/^\s+/u', '', $origin->value()),
-            ),
-        );
+        parent::__construct($origin);
+    }
+
+    #[Override]
+    public function value(): string
+    {
+        return (string) preg_replace('/^\s+/u', '', $this->origin->value());
     }
 }

--- a/src/Text/Uppered.php
+++ b/src/Text/Uppered.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
+use Override;
+
 /**
  * Text in uppercase.
  *
@@ -22,8 +24,12 @@ final readonly class Uppered extends TextEnvelope
      */
     public function __construct(Text $origin)
     {
-        parent::__construct(
-            new TextOf(mb_strtoupper($origin->value(), 'UTF-8')),
-        );
+        parent::__construct($origin);
+    }
+
+    #[Override]
+    public function value(): string
+    {
+        return mb_strtoupper($this->origin->value(), 'UTF-8');
     }
 }

--- a/src/Text/WithoutTags.php
+++ b/src/Text/WithoutTags.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
+use Override;
+
 /**
  * Text without HTML tags.
  *
@@ -22,10 +24,12 @@ final readonly class WithoutTags extends TextEnvelope
      */
     public function __construct(Text $origin)
     {
-        parent::__construct(
-            new TextOf(
-                strip_tags($origin->value()),
-            ),
-        );
+        parent::__construct($origin);
+    }
+
+    #[Override]
+    public function value(): string
+    {
+        return strip_tags($this->origin->value());
     }
 }


### PR DESCRIPTION
- Refactored Trimmed, TrimmedLeft, Lowered, Uppered, WithoutTags, and HtmlEscaped to defer transformation until value() is called
- Updated each constructor to delegate origin to TextEnvelope without computing
- Added value() overrides that apply the transformation lazily on the stored origin

Part of #109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Text processing operations now defer computation until value access instead of processing during object creation. Affected operations include HTML escaping, case conversion, whitespace trimming, and HTML tag removal.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/110)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->