### PR TITLE
Route Simple Text Decorators Through Mapped

### DIFF
--- a/src/Func/Func.php
+++ b/src/Func/Func.php
@@ -8,7 +8,7 @@ namespace Primus\Func;
  * Function from I to O.
  *
  * @template I
- * @template O
+ * @template-covariant O
  * @since 0.3
  */
 interface Func

--- a/src/Text/HtmlEscaped.php
+++ b/src/Text/HtmlEscaped.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
-use Override;
+use Primus\Func\FuncOf;
 
 /**
  * Escaped {@see Text} safe for HTML rendering.
@@ -24,12 +24,11 @@ final readonly class HtmlEscaped extends TextEnvelope
      */
     public function __construct(Text $origin)
     {
-        parent::__construct($origin);
-    }
-
-    #[Override]
-    public function value(): string
-    {
-        return htmlspecialchars($this->origin->value(), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        parent::__construct(
+            new Mapped(
+                $origin,
+                new FuncOf(static fn(string $s): string => htmlspecialchars($s, ENT_QUOTES | ENT_HTML5, 'UTF-8')),
+            ),
+        );
     }
 }

--- a/src/Text/Lowered.php
+++ b/src/Text/Lowered.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
-use Override;
+use Primus\Func\FuncOf;
 
 /**
  * Text in lowercase.
@@ -26,12 +26,11 @@ final readonly class Lowered extends TextEnvelope
      */
     public function __construct(Text $origin)
     {
-        parent::__construct($origin);
-    }
-
-    #[Override]
-    public function value(): string
-    {
-        return mb_strtolower($this->origin->value(), 'UTF-8');
+        parent::__construct(
+            new Mapped(
+                $origin,
+                new FuncOf(static fn(string $s): string => mb_strtolower($s, 'UTF-8')),
+            ),
+        );
     }
 }

--- a/src/Text/Trimmed.php
+++ b/src/Text/Trimmed.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
-use Override;
+use Primus\Func\FuncOf;
 
 /**
  * Text without leading or trailing whitespace.
@@ -26,12 +26,11 @@ final readonly class Trimmed extends TextEnvelope
      */
     public function __construct(Text $origin)
     {
-        parent::__construct($origin);
-    }
-
-    #[Override]
-    public function value(): string
-    {
-        return trim($this->origin->value());
+        parent::__construct(
+            new Mapped(
+                $origin,
+                new FuncOf(static fn(string $s): string => trim($s)),
+            ),
+        );
     }
 }

--- a/src/Text/TrimmedLeft.php
+++ b/src/Text/TrimmedLeft.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Primus\Text;
 
 use InvalidArgumentException;
-use Override;
+use Primus\Func\FuncOf;
 
 /**
  * Text with whitespace removed from the left side.
@@ -25,13 +25,12 @@ final readonly class TrimmedLeft extends TextEnvelope
      */
     public function __construct(Text $origin)
     {
-        parent::__construct($origin);
-    }
-
-    #[Override]
-    public function value(): string
-    {
-        return preg_replace('/^\s+/u', '', $this->origin->value())
-            ?? throw new InvalidArgumentException('Malformed UTF-8 input');
+        parent::__construct(
+            new Mapped(
+                $origin,
+                new FuncOf(static fn(string $s): string => preg_replace('/^\s+/u', '', $s)
+                    ?? throw new InvalidArgumentException('Malformed UTF-8 input')),
+            ),
+        );
     }
 }

--- a/src/Text/TrimmedRight.php
+++ b/src/Text/TrimmedRight.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Primus\Text;
 
 use InvalidArgumentException;
-use Primus\Scalar\ScalarOf;
+use Primus\Func\FuncOf;
 
 /**
  * Text with whitespace removed from the right side.
@@ -26,11 +26,10 @@ final readonly class TrimmedRight extends TextEnvelope
     public function __construct(Text $origin)
     {
         parent::__construct(
-            new TextOfScalar(
-                new ScalarOf(
-                    static fn(): string => preg_replace('/\s+$/u', '', $origin->value())
-                        ?? throw new InvalidArgumentException('Malformed UTF-8 input'),
-                ),
+            new Mapped(
+                $origin,
+                new FuncOf(static fn(string $s): string => preg_replace('/\s+$/u', '', $s)
+                    ?? throw new InvalidArgumentException('Malformed UTF-8 input')),
             ),
         );
     }

--- a/src/Text/Uppered.php
+++ b/src/Text/Uppered.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
-use Override;
+use Primus\Func\FuncOf;
 
 /**
  * Text in uppercase.
@@ -24,12 +24,11 @@ final readonly class Uppered extends TextEnvelope
      */
     public function __construct(Text $origin)
     {
-        parent::__construct($origin);
-    }
-
-    #[Override]
-    public function value(): string
-    {
-        return mb_strtoupper($this->origin->value(), 'UTF-8');
+        parent::__construct(
+            new Mapped(
+                $origin,
+                new FuncOf(static fn(string $s): string => mb_strtoupper($s, 'UTF-8')),
+            ),
+        );
     }
 }

--- a/src/Text/WithoutTags.php
+++ b/src/Text/WithoutTags.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
-use Override;
+use Primus\Func\FuncOf;
 
 /**
  * Text without HTML tags.
@@ -24,12 +24,11 @@ final readonly class WithoutTags extends TextEnvelope
      */
     public function __construct(Text $origin)
     {
-        parent::__construct($origin);
-    }
-
-    #[Override]
-    public function value(): string
-    {
-        return strip_tags($this->origin->value());
+        parent::__construct(
+            new Mapped(
+                $origin,
+                new FuncOf(static fn(string $s): string => strip_tags($s)),
+            ),
+        );
     }
 }


### PR DESCRIPTION
- Refactored seven Text decorators (Trimmed, Lowered, Uppered, TrimmedLeft, TrimmedRight, WithoutTags, HtmlEscaped) to delegate transformation through Mapped instead of overriding value()
- Updated Func to be covariant on its output type so narrowed function return types satisfy Func<string, string>

Part of #111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Text transformation classes (`HtmlEscaped`, `Lowered`, `Trimmed`, `TrimmedLeft`, `TrimmedRight`, `Uppered`, `WithoutTags`) now apply transformations through a unified mapping pipeline during construction instead of on value retrieval. Behavior remains unchanged.

* **Chores**
  * Updated type annotations in the `Func` interface for improved static analysis.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/113)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->