### PR TITLE
Route Parametric Text Decorators Through Mapped

### DIFF
--- a/src/Text/LeftPadded.php
+++ b/src/Text/LeftPadded.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
+use Primus\Func\FuncOf;
+
 /**
  * Text with left padding.
  *
@@ -28,13 +30,9 @@ final readonly class LeftPadded extends TextEnvelope
     public function __construct(Text $origin, int $length, string $padding)
     {
         parent::__construct(
-            new TextOf(
-                str_pad(
-                    $origin->value(),
-                    $length,
-                    $padding,
-                    STR_PAD_LEFT,
-                ),
+            new Mapped(
+                $origin,
+                new FuncOf(static fn(string $s): string => str_pad($s, $length, $padding, STR_PAD_LEFT)),
             ),
         );
     }

--- a/src/Text/Repeated.php
+++ b/src/Text/Repeated.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
+use Primus\Func\FuncOf;
+
 /**
  * Text repeated multiple times.
  *
@@ -24,8 +26,9 @@ final readonly class Repeated extends TextEnvelope
     public function __construct(Text $origin, int $count)
     {
         parent::__construct(
-            new TextOf(
-                str_repeat($origin->value(), max(0, $count)),
+            new Mapped(
+                $origin,
+                new FuncOf(static fn(string $s): string => str_repeat($s, max(0, $count))),
             ),
         );
     }

--- a/src/Text/Replaced.php
+++ b/src/Text/Replaced.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
+use Primus\Func\FuncOf;
+
 /**
  * Text with replaced substrings.
  *
@@ -31,8 +33,9 @@ final readonly class Replaced extends TextEnvelope
     public function __construct(Text $origin, string|array $search, string|array $replacement)
     {
         parent::__construct(
-            new TextOf(
-                str_replace($search, $replacement, $origin->value()),
+            new Mapped(
+                $origin,
+                new FuncOf(static fn(string $s): string => str_replace($search, $replacement, $s)),
             ),
         );
     }

--- a/src/Text/RightPadded.php
+++ b/src/Text/RightPadded.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
+use Primus\Func\FuncOf;
+
 /**
  * Text with right padding.
  *
@@ -27,12 +29,9 @@ final readonly class RightPadded extends TextEnvelope
     public function __construct(Text $origin, int $length, string $padding)
     {
         parent::__construct(
-            new TextOf(
-                str_pad(
-                    $origin->value(),
-                    $length,
-                    $padding,
-                ),
+            new Mapped(
+                $origin,
+                new FuncOf(static fn(string $s): string => str_pad($s, $length, $padding)),
             ),
         );
     }

--- a/src/Text/Sub.php
+++ b/src/Text/Sub.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
+use Primus\Func\FuncOf;
+
 /**
  * Substring of a {@see Text}.
  *
@@ -28,7 +30,10 @@ final readonly class Sub extends TextEnvelope
     public function __construct(Text $text, int $start, int $length = PHP_INT_MAX)
     {
         parent::__construct(
-            new TextOf(mb_substr($text->value(), $start, $length, 'UTF-8')),
+            new Mapped(
+                $text,
+                new FuncOf(static fn(string $s): string => mb_substr($s, $start, $length, 'UTF-8')),
+            ),
         );
     }
 }


### PR DESCRIPTION
- Refactored Repeated, Sub, LeftPadded, RightPadded, and Replaced to delegate transformation through Mapped instead of computing in the constructor
- Captured each decorator's parameters into the closure passed to Mapped, keeping public signatures intact

Part of #111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved efficiency of text manipulation operations including padding, repetition, replacement, and substring extraction through architectural optimizations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/114)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->