### PR TITLE
Defer RandomText Generation Until First value() Call

### DIFF
--- a/src/Text/RandomText.php
+++ b/src/Text/RandomText.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Primus\Text;
 
 use Primus\Scalar\ScalarOf;
+use Primus\Scalar\Sticky;
 
 /**
  * Randomly generated {@see Text}.
@@ -31,22 +32,24 @@ final readonly class RandomText extends TextEnvelope
         string $alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
     ) {
         parent::__construct(
-            new TextOf(
-                (new ScalarOf(
-                    static function () use ($length, $alphabet): string {
-                        $source = $alphabet !== ''
-                            ? $alphabet
-                            : 'a';
-                        $size = mb_strlen($source, 'UTF-8');
-                        $chars = [];
+            new TextOfScalar(
+                new Sticky(
+                    new ScalarOf(
+                        static function () use ($length, $alphabet): string {
+                            $source = $alphabet !== ''
+                                ? $alphabet
+                                : 'a';
+                            $size = mb_strlen($source, 'UTF-8');
+                            $chars = [];
 
-                        for ($i = 0; $i < max(0, $length); $i++) {
-                            $chars[] = mb_substr($source, random_int(0, $size - 1), 1, 'UTF-8');
-                        }
+                            for ($i = 0; $i < max(0, $length); $i++) {
+                                $chars[] = mb_substr($source, random_int(0, $size - 1), 1, 'UTF-8');
+                            }
 
-                        return implode('', $chars);
-                    },
-                ))->value(),
+                            return implode('', $chars);
+                        },
+                    ),
+                ),
             ),
         );
     }

--- a/tests/Text/RandomTextTest.php
+++ b/tests/Text/RandomTextTest.php
@@ -77,4 +77,12 @@ final class RandomTextTest extends TestCase
             new MatchesPattern('/^[a]+$/')
         );
     }
+
+    #[Test]
+    public function returnsTheSameValueOnRepeatedCalls(): void
+    {
+        $text = new RandomText(16);
+
+        self::assertSame($text->value(), $text->value());
+    }
 }


### PR DESCRIPTION
- Refactored RandomText to defer character generation until value() is called instead of running random_int() inside the constructor
- Wrapped the generator scalar in Sticky so repeated value() calls return the same string and preserve immutable semantics
- Added a regression test that verifies repeated value() returns the same string

Part of #111