### PR TITLE
Tighten Joined Constructor To Array And Defer Joining

### DIFF
--- a/src/Text/Joined.php
+++ b/src/Text/Joined.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
+use Primus\Scalar\ScalarOf;
+
 /**
  * Text joined from multiple Text parts with a separator.
  *
@@ -19,19 +21,19 @@ final readonly class Joined extends TextEnvelope
      * Ctor.
      *
      * @param string $separator The glue inserted between parts.
-     * @param iterable<Text> $parts The texts to join.
+     * @param list<Text> $parts The texts to join.
      */
-    public function __construct(string $separator, iterable $parts)
+    public function __construct(string $separator, array $parts)
     {
         parent::__construct(
-            new TextOf(
-                implode(
+            new TextOfScalar(
+                new ScalarOf(static fn(): string => implode(
                     $separator,
                     array_map(
                         static fn(Text $t): string => $t->value(),
-                        is_array($parts) ? $parts : iterator_to_array($parts, false),
+                        $parts,
                     ),
-                ),
+                )),
             ),
         );
     }

--- a/tests/Text/JoinedTest.php
+++ b/tests/Text/JoinedTest.php
@@ -70,4 +70,24 @@ final class JoinedTest extends TestCase
 
         self::assertSame(0, $calls);
     }
+
+    #[Test]
+    public function resolvesEachPartWhenJoinedValueIsCalled(): void
+    {
+        $calls = 0;
+        $part = new class ($calls) implements Text {
+            public function __construct(private int &$calls) {}
+
+            public function value(): string
+            {
+                $this->calls++;
+
+                return 'x';
+            }
+        };
+        $joined = new Joined(',', [$part, $part]);
+        $joined->value();
+
+        self::assertSame(2, $calls);
+    }
 }

--- a/tests/Text/JoinedTest.php
+++ b/tests/Text/JoinedTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Primus\Tests\Text;
 
-use Generator;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Primus\Tests\Constraint\HasTextValue;
 use Primus\Text\Joined;
+use Primus\Text\Text;
 use Primus\Text\TextOf;
 
 /**
@@ -44,7 +44,7 @@ final class JoinedTest extends TestCase
     }
 
     #[Test]
-    public function joinsEmptyIterable(): void
+    public function joinsEmptyArray(): void
     {
         self::assertThat(
             new Joined(', ', []),
@@ -53,29 +53,21 @@ final class JoinedTest extends TestCase
     }
 
     #[Test]
-    public function joinsIteratorIgnoresKeys(): void
+    public function defersValueResolutionUntilJoinedValueIsCalled(): void
     {
-        self::assertThat(
-            new Joined('-', (function (): Generator {
-                yield 'x' => new TextOf('A');
-                yield 'y' => new TextOf('B');
-            })()),
-            new HasTextValue('A-B')
-        );
-    }
+        $calls = 0;
+        $part = new class ($calls) implements Text {
+            public function __construct(private int &$calls) {}
 
-    #[Test]
-    public function joinsIteratorWithDuplicateKeys(): void
-    {
-        self::assertThat(
-            new Joined(
-                ',',
-                (function (): Generator {
-                    yield 0 => new TextOf('first');
-                    yield 0 => new TextOf('second');
-                })()
-            ),
-            new HasTextValue('first,second')
-        );
+            public function value(): string
+            {
+                $this->calls++;
+
+                return 'x';
+            }
+        };
+        new Joined(',', [$part, $part]); // NOSONAR — instantiation is the subject under test for the lazy contract
+
+        self::assertSame(0, $calls);
     }
 }


### PR DESCRIPTION
- Refactored Joined to wrap the joining computation inside a ScalarOf so the implode runs only when value() is called
- Replaced the iterable parts parameter with array<Text> to remove the eager iterator_to_array drain in the constructor
- Updated tests to drop iterator scenarios that no longer apply and added a regression test for deferred origin resolution

Closes #111

**Breaking changes:**
- `Joined::__construct` no longer accepts `iterable<Text>`; callers must pass an `array<Text>`. Code that passes a `Generator` or `Iterator` now fails with `TypeError` and must materialise the source via `iterator_to_array($g, false)` before constructing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * The `Joined` class constructor now requires arrays instead of iterables as input.

* **Tests**
  * Updated test coverage to validate empty array handling and lazy value resolution behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/116)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->