### PR TITLE
Slice List By Offset And Length

### DIFF
--- a/src/List/Sliced.php
+++ b/src/List/Sliced.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\List;
+
+use Generator;
+use Override;
+
+/**
+ * List exposing a contiguous slice of an origin list.
+ *
+ * Offsets and lengths follow {@see array_slice()} semantics without
+ * preserving keys: negative offset counts from the end, omitted length
+ * extends to the end, negative length stops that many positions before
+ * the end.
+ *
+ * Example:
+ *     $list = new Sliced(new ListOf(1, 2, 3, 4, 5), 1, 3);
+ *     foreach ($list as $value) {
+ *         echo $value;
+ *     }
+ *     // 234
+ *
+ * @template T
+ * @extends ListEnvelope<T>
+ * @since 0.3
+ */
+final readonly class Sliced extends ListEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param List_<T> $origin The list to slice.
+     * @param int $offset The starting position; negative counts from the end.
+     * @param int $length The maximum number of elements; defaults to extending to the end.
+     */
+    public function __construct(
+        List_ $origin,
+        private int $offset,
+        private int $length = PHP_INT_MAX,
+    ) {
+        parent::__construct($origin);
+    }
+
+    #[Override]
+    public function value(): array
+    {
+        return array_slice($this->origin->value(), $this->offset, $this->length);
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->value();
+    }
+}

--- a/tests/List/SlicedTest.php
+++ b/tests/List/SlicedTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\List;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\List\ListOf;
+use Primus\List\Sliced;
+
+final class SlicedTest extends TestCase
+{
+    #[Test]
+    public function takesElementsFromGivenOffsetWithLength(): void
+    {
+        $this->assertSame(
+            [2, 3, 4],
+            (new Sliced(new ListOf(1, 2, 3, 4, 5), 1, 3))->value(),
+        );
+    }
+
+    #[Test]
+    public function negativeOffsetCountsFromTheEnd(): void
+    {
+        $this->assertSame(
+            [4, 5],
+            (new Sliced(new ListOf(1, 2, 3, 4, 5), -2))->value(),
+        );
+    }
+
+    #[Test]
+    public function omittedLengthExtendsToTheEnd(): void
+    {
+        $this->assertSame(
+            [3, 4, 5],
+            (new Sliced(new ListOf(1, 2, 3, 4, 5), 2))->value(),
+        );
+    }
+
+    #[Test]
+    public function negativeLengthStopsBeforeTheEnd(): void
+    {
+        $this->assertSame(
+            [2, 3],
+            (new Sliced(new ListOf(1, 2, 3, 4, 5), 1, -2))->value(),
+        );
+    }
+
+    #[Test]
+    public function offsetBeyondEndProducesEmptyList(): void
+    {
+        $this->assertSame(
+            [],
+            (new Sliced(new ListOf(1, 2, 3), 10))->value(),
+        );
+    }
+
+    #[Test]
+    public function nonPositiveLengthProducesEmptyList(): void
+    {
+        $this->assertSame(
+            [],
+            (new Sliced(new ListOf(1, 2, 3), 0, 0))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsSequentialKeysStartingAtZero(): void
+    {
+        $this->assertSame(
+            [0, 1, 2],
+            array_keys((new Sliced(new ListOf('a', 'b', 'c', 'd'), 1, 3))->value()),
+        );
+    }
+
+    #[Test]
+    public function iteratesYieldingSlicedElements(): void
+    {
+        $collected = [];
+        foreach (new Sliced(new ListOf(1, 2, 3, 4, 5), 1, 2) as $value) {
+            $collected[] = $value;
+        }
+        $this->assertSame([2, 3], $collected);
+    }
+}


### PR DESCRIPTION
- Added Primus\List\Sliced that exposes a contiguous slice of an origin list using array_slice semantics without preserving keys
- Added SlicedTest covering positive and negative offsets, omitted and negative length, beyond-end offset, non-positive length, sequential keys, and iteration

Closes #117