### PR TITLE
Slice Map By Offset And Length Keeping Keys

### DIFF
--- a/src/Map/Sliced.php
+++ b/src/Map/Sliced.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Map;
+
+use Generator;
+use Override;
+
+/**
+ * Map exposing a contiguous slice of an origin map while preserving keys.
+ *
+ * Offsets and lengths follow {@see array_slice()} semantics with
+ * preserve_keys=true: negative offset counts from the end, omitted length
+ * extends to the end, negative length stops that many positions before
+ * the end.
+ *
+ * Example:
+ *     $map = new Sliced(new MapOf(['a' => 1, 'b' => 2, 'c' => 3]), 1);
+ *     foreach ($map as $key => $value) {
+ *         echo "$key=$value ";
+ *     }
+ *     // b=2 c=3
+ *
+ * @template K of array-key
+ * @template V
+ * @extends MapEnvelope<K, V>
+ * @since 0.3
+ */
+final readonly class Sliced extends MapEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Map<K, V> $origin The map to slice.
+     * @param int $offset The starting position; negative counts from the end.
+     * @param int $length The maximum number of entries; defaults to extending to the end.
+     */
+    public function __construct(
+        Map $origin,
+        private int $offset,
+        private int $length = PHP_INT_MAX,
+    ) {
+        parent::__construct($origin);
+    }
+
+    #[Override]
+    public function value(): array
+    {
+        return array_slice($this->origin->value(), $this->offset, $this->length, true);
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return count($this->value());
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->value();
+    }
+}

--- a/tests/Map/SlicedTest.php
+++ b/tests/Map/SlicedTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Map;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Map\MapOf;
+use Primus\Map\Sliced;
+
+final class SlicedTest extends TestCase
+{
+    #[Test]
+    public function takesEntriesFromGivenOffsetWithLength(): void
+    {
+        $this->assertSame(
+            ['b' => 2, 'c' => 3],
+            (new Sliced(new MapOf(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4]), 1, 2))->value(),
+        );
+    }
+
+    #[Test]
+    public function negativeOffsetCountsFromTheEnd(): void
+    {
+        $this->assertSame(
+            ['c' => 3, 'd' => 4],
+            (new Sliced(new MapOf(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4]), -2))->value(),
+        );
+    }
+
+    #[Test]
+    public function omittedLengthExtendsToTheEnd(): void
+    {
+        $this->assertSame(
+            ['c' => 3, 'd' => 4],
+            (new Sliced(new MapOf(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4]), 2))->value(),
+        );
+    }
+
+    #[Test]
+    public function negativeLengthStopsBeforeTheEnd(): void
+    {
+        $this->assertSame(
+            ['b' => 2, 'c' => 3],
+            (new Sliced(new MapOf(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4]), 1, -1))->value(),
+        );
+    }
+
+    #[Test]
+    public function offsetBeyondEndProducesEmptyMap(): void
+    {
+        $this->assertSame(
+            [],
+            (new Sliced(new MapOf(['a' => 1, 'b' => 2]), 10))->value(),
+        );
+    }
+
+    #[Test]
+    public function nonPositiveLengthProducesEmptyMap(): void
+    {
+        $this->assertSame(
+            [],
+            (new Sliced(new MapOf(['a' => 1, 'b' => 2]), 0, 0))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesOriginalKeys(): void
+    {
+        $this->assertSame(
+            ['b', 'c'],
+            array_keys((new Sliced(new MapOf(['a' => 1, 'b' => 2, 'c' => 3]), 1))->value()),
+        );
+    }
+
+    #[Test]
+    public function iteratesYieldingSlicedEntriesWithKeys(): void
+    {
+        $collected = [];
+        foreach (new Sliced(new MapOf(['a' => 1, 'b' => 2, 'c' => 3]), 1, 1) as $key => $value) {
+            $collected[$key] = $value;
+        }
+        $this->assertSame(['b' => 2], $collected);
+    }
+}

--- a/tests/Map/SlicedTest.php
+++ b/tests/Map/SlicedTest.php
@@ -83,4 +83,13 @@ final class SlicedTest extends TestCase
         }
         $this->assertSame(['b' => 2], $collected);
     }
+
+    #[Test]
+    public function reportsCountOfSlicedEntries(): void
+    {
+        $this->assertCount(
+            2,
+            new Sliced(new MapOf(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4]), 1, 2),
+        );
+    }
 }


### PR DESCRIPTION
- Added Primus\Map\Sliced that exposes a contiguous slice of an origin map using array_slice with preserve_keys
- Added SlicedTest covering positive and negative offsets, omitted and negative length, beyond-end offset, non-positive length, key preservation, and iteration with keys

Closes #119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to extract contiguous slices from maps while preserving original keys. Supports positive/negative offsets and optional length parameters.

* **Tests**
  * Added comprehensive test coverage for slicing functionality, including edge cases and key preservation behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/120)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->