### PR TITLE
Generate Integer Arithmetic Range As List Source

### DIFF
--- a/src/List/Range.php
+++ b/src/List/Range.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\List;
+
+use Generator;
+use Override;
+
+/**
+ * Finite arithmetic sequence of integers between two endpoints.
+ *
+ * The direction is determined by the relation between start and end:
+ * an ascending sequence when start <= end, descending when start > end.
+ * The step is always positive; it is the absolute distance between
+ * consecutive elements.
+ *
+ * Example:
+ *     $list = new Range(1, 7, 2);
+ *     foreach ($list as $value) {
+ *         echo $value;
+ *     }
+ *     // 1357
+ *
+ * @implements List_<int>
+ * @since 0.3
+ */
+final readonly class Range implements List_
+{
+    /**
+     * Ctor.
+     *
+     * @param int $start The first value of the sequence.
+     * @param int $end The last reachable value not crossing the endpoint.
+     * @param int $step The positive distance between consecutive values.
+     */
+    public function __construct(private int $start, private int $end, private int $step = 1) {}
+
+    #[Override]
+    public function value(): array
+    {
+        return range($this->start, $this->end, $this->step);
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return count($this->value());
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->value();
+    }
+}

--- a/tests/List/RangeTest.php
+++ b/tests/List/RangeTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\List;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\List\Range;
+use ValueError;
+
+final class RangeTest extends TestCase
+{
+    #[Test]
+    public function startEqualToEndProducesSingleElementList(): void
+    {
+        $this->assertSame(
+            [5],
+            (new Range(5, 5))->value(),
+        );
+    }
+
+    #[Test]
+    public function ascendingSequenceWalksFromStartToEndByStep(): void
+    {
+        $this->assertSame(
+            [1, 3, 5, 7],
+            (new Range(1, 7, 2))->value(),
+        );
+    }
+
+    #[Test]
+    public function descendingSequenceWalksFromStartToEndByStep(): void
+    {
+        $this->assertSame(
+            [7, 5, 3, 1],
+            (new Range(7, 1, 2))->value(),
+        );
+    }
+
+    #[Test]
+    public function firstElementIsTheStart(): void
+    {
+        $this->assertSame(
+            10,
+            (new Range(10, 30, 3))->value()[0],
+        );
+    }
+
+    #[Test]
+    public function stopsBeforeOvershootingEnd(): void
+    {
+        $this->assertSame(
+            [1, 4, 7],
+            (new Range(1, 8, 3))->value(),
+        );
+    }
+
+    #[Test]
+    public function defaultStepIsOne(): void
+    {
+        $this->assertSame(
+            [1, 2, 3, 4, 5],
+            (new Range(1, 5))->value(),
+        );
+    }
+
+    #[Test]
+    public function zeroStepRejectsValueAccess(): void
+    {
+        $this->expectException(ValueError::class);
+
+        (new Range(1, 5, 0))->value();
+    }
+
+    #[Test]
+    public function negativeStepRejectsValueAccess(): void
+    {
+        $this->expectException(ValueError::class);
+
+        (new Range(1, 5, -2))->value();
+    }
+
+    #[Test]
+    public function iteratesYieldingTheSequence(): void
+    {
+        $collected = [];
+        foreach (new Range(1, 4) as $value) {
+            $collected[] = $value;
+        }
+        $this->assertSame([1, 2, 3, 4], $collected);
+    }
+
+    #[Test]
+    public function countMatchesSequenceLength(): void
+    {
+        $this->assertCount(4, new Range(1, 7, 2));
+    }
+}


### PR DESCRIPTION
- Added Primus\List\Range that produces a finite arithmetic sequence of integers between start and end with a positive step
- Added RangeTest covering single-element, ascending, descending, default step, no overshoot, iteration, count, and rejected non-positive step on value access

Closes #121

Notes:
- Issue condition "non-positive step rejects construction" was implemented as "rejects on value()" instead, because the project rule `haspadar.constructorInit` forbids control flow in constructors. Validation is delegated to PHP's native `range()`, which throws `ValueError` for zero or negative step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Range` implementation for generating immutable integer arithmetic sequences with configurable start, end, and step values.

* **Tests**
  * Added test coverage for Range functionality including sequence generation, iteration, counting, and parameter validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/122)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->