### PR TITLE
Deduplicate List By Strict Equality

### DIFF
--- a/src/List/Unique.php
+++ b/src/List/Unique.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\List;
+
+use Generator;
+use Override;
+
+/**
+ * List with duplicate values removed using strict equality.
+ *
+ * Only the first occurrence of each distinct value is kept; subsequent
+ * occurrences are dropped. Values are compared with `===`, so `0` and
+ * `'0'` are treated as different.
+ *
+ * Example:
+ *     $list = new Unique(new ListOf(1, 2, 1, 3, 2));
+ *     foreach ($list as $value) {
+ *         echo $value;
+ *     }
+ *     // 123
+ *
+ * @template T
+ * @extends ListEnvelope<T>
+ * @since 0.3
+ */
+final readonly class Unique extends ListEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param List_<T> $origin The list to deduplicate.
+     */
+    public function __construct(List_ $origin)
+    {
+        parent::__construct($origin);
+    }
+
+    #[Override]
+    public function value(): array
+    {
+        $seen = [];
+
+        foreach ($this->origin->value() as $item) {
+            if (!in_array($item, $seen, true)) {
+                $seen[] = $item;
+            }
+        }
+
+        return $seen;
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return count($this->value());
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->value();
+    }
+}

--- a/tests/List/UniqueTest.php
+++ b/tests/List/UniqueTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Primus\Tests\List;
 
+use Generator;
+use LogicException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Primus\List\ListOf;
+use Primus\List\List_;
 use Primus\List\Unique;
 
 final class UniqueTest extends TestCase
@@ -79,5 +82,30 @@ final class UniqueTest extends TestCase
     public function reportsCountOfDistinctValues(): void
     {
         $this->assertCount(3, new Unique(new ListOf(1, 1, 2, 3, 3, 2)));
+    }
+
+    #[Test]
+    public function defersOriginValueResolutionUntilValueIsCalled(): void
+    {
+        $origin = new class () implements List_ {
+            public function value(): array
+            {
+                throw new LogicException('value() must not be called by Unique constructor');
+            }
+
+            public function count(): int
+            {
+                return 0;
+            }
+
+            public function getIterator(): Generator
+            {
+                yield from [];
+            }
+        };
+
+        new Unique($origin); // NOSONAR — instantiation is the subject under test for the lazy contract
+
+        $this->expectNotToPerformAssertions();
     }
 }

--- a/tests/List/UniqueTest.php
+++ b/tests/List/UniqueTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\List;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\List\ListOf;
+use Primus\List\Unique;
+
+final class UniqueTest extends TestCase
+{
+    #[Test]
+    public function dropsRepeatedValuesKeepingFirstOccurrence(): void
+    {
+        $this->assertSame(
+            [1, 2, 3],
+            (new Unique(new ListOf(1, 2, 1, 3, 2, 1)))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesRelativeOrderOfFirstOccurrences(): void
+    {
+        $this->assertSame(
+            ['c', 'a', 'b'],
+            (new Unique(new ListOf('c', 'a', 'c', 'b', 'a')))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsSequentialKeysStartingAtZero(): void
+    {
+        $this->assertSame(
+            [0, 1, 2],
+            array_keys((new Unique(new ListOf('x', 'y', 'x', 'z')))->value()),
+        );
+    }
+
+    #[Test]
+    public function distinguishesValuesByStrictType(): void
+    {
+        $this->assertSame(
+            [0, '0', false],
+            (new Unique(new ListOf(0, '0', false, 0, '0', false)))->value(),
+        );
+    }
+
+    #[Test]
+    public function leavesEmptyListEmpty(): void
+    {
+        $this->assertSame(
+            [],
+            (new Unique(new ListOf()))->value(),
+        );
+    }
+
+    #[Test]
+    public function leavesAlreadyUniqueListUnchanged(): void
+    {
+        $this->assertSame(
+            [1, 2, 3, 4],
+            (new Unique(new ListOf(1, 2, 3, 4)))->value(),
+        );
+    }
+
+    #[Test]
+    public function iteratesYieldingDeduplicatedValues(): void
+    {
+        $collected = [];
+        foreach (new Unique(new ListOf(1, 1, 2, 2, 3)) as $value) {
+            $collected[] = $value;
+        }
+        $this->assertSame([1, 2, 3], $collected);
+    }
+
+    #[Test]
+    public function reportsCountOfDistinctValues(): void
+    {
+        $this->assertCount(3, new Unique(new ListOf(1, 1, 2, 3, 3, 2)));
+    }
+}


### PR DESCRIPTION
- Added Primus\List\Unique that retains only the first strict-equal occurrence of each value from an origin list
- Added UniqueTest covering deduplication, order preservation, sequential keys from zero, type-strict distinction (0 vs '0' vs false), empty input, already unique input, iteration, and count

Closes #123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new list wrapper that automatically deduplicates values while preserving the order of first occurrences and maintaining strict type differentiation.

* **Tests**
  * Added comprehensive test coverage for the deduplicated list functionality, including edge cases and various value types.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/124)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->