### PR TITLE
Deduplicate Map By Strict Equality Preserving Keys

### DIFF
--- a/src/Map/Unique.php
+++ b/src/Map/Unique.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Map;
+
+use Generator;
+use Override;
+
+/**
+ * Map with duplicate values removed using strict equality, keys preserved.
+ *
+ * Only the first occurrence of each distinct value is kept; subsequent
+ * entries with the same value are dropped. Values are compared with
+ * `===`, so `0` and `'0'` are treated as different. The kept entries
+ * retain their original keys from the origin map.
+ *
+ * Example:
+ *     $map = new Unique(new MapOf(['a' => 1, 'b' => 2, 'c' => 1]));
+ *     foreach ($map as $key => $value) {
+ *         echo "$key=$value ";
+ *     }
+ *     // a=1 b=2
+ *
+ * @template K of array-key
+ * @template V
+ * @extends MapEnvelope<K, V>
+ * @since 0.3
+ */
+final readonly class Unique extends MapEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Map<K, V> $origin The map to deduplicate.
+     */
+    public function __construct(Map $origin)
+    {
+        parent::__construct($origin);
+    }
+
+    #[Override]
+    public function value(): array
+    {
+        $seen = [];
+        $kept = [];
+
+        foreach ($this->origin->value() as $key => $item) {
+            if (!in_array($item, $seen, true)) {
+                $seen[] = $item;
+                $kept[$key] = $item;
+            }
+        }
+
+        return $kept;
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return count($this->value());
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->value();
+    }
+}

--- a/tests/Map/UniqueTest.php
+++ b/tests/Map/UniqueTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Map;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Map\MapOf;
+use Primus\Map\Unique;
+
+final class UniqueTest extends TestCase
+{
+    #[Test]
+    public function dropsRepeatedValuesKeepingFirstEntry(): void
+    {
+        $this->assertSame(
+            ['a' => 1, 'b' => 2, 'd' => 3],
+            (new Unique(new MapOf(['a' => 1, 'b' => 2, 'c' => 1, 'd' => 3, 'e' => 2])))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesOriginalKeysOfKeptEntries(): void
+    {
+        $this->assertSame(
+            ['x', 'y'],
+            array_keys((new Unique(new MapOf(['x' => 'a', 'y' => 'b', 'z' => 'a'])))->value()),
+        );
+    }
+
+    #[Test]
+    public function preservesRelativeOrderOfFirstOccurrences(): void
+    {
+        $this->assertSame(
+            ['c' => 1, 'a' => 2, 'b' => 3],
+            (new Unique(new MapOf(['c' => 1, 'a' => 2, 'd' => 1, 'b' => 3, 'e' => 2])))->value(),
+        );
+    }
+
+    #[Test]
+    public function distinguishesValuesByStrictType(): void
+    {
+        $this->assertSame(
+            ['a' => 0, 'b' => '0', 'c' => false],
+            (new Unique(new MapOf(['a' => 0, 'b' => '0', 'c' => false, 'd' => 0])))->value(),
+        );
+    }
+
+    #[Test]
+    public function leavesEmptyMapEmpty(): void
+    {
+        $this->assertSame(
+            [],
+            (new Unique(new MapOf([])))->value(),
+        );
+    }
+
+    #[Test]
+    public function leavesAlreadyUniqueMapUnchanged(): void
+    {
+        $this->assertSame(
+            ['a' => 1, 'b' => 2, 'c' => 3],
+            (new Unique(new MapOf(['a' => 1, 'b' => 2, 'c' => 3])))->value(),
+        );
+    }
+
+    #[Test]
+    public function iteratesYieldingDeduplicatedEntriesWithKeys(): void
+    {
+        $collected = [];
+        foreach (new Unique(new MapOf(['a' => 1, 'b' => 1, 'c' => 2])) as $key => $value) {
+            $collected[$key] = $value;
+        }
+        $this->assertSame(['a' => 1, 'c' => 2], $collected);
+    }
+
+    #[Test]
+    public function reportsCountOfDistinctValues(): void
+    {
+        $this->assertCount(2, new Unique(new MapOf(['a' => 1, 'b' => 1, 'c' => 2])));
+    }
+}


### PR DESCRIPTION
- Added Primus\Map\Unique that retains only the first strict-equal occurrence of each value from an origin map while keeping the original keys of the kept entries
- Added UniqueTest covering deduplication, key preservation, order preservation, type-strict distinction, empty input, already unique input, iteration with keys, and count

Closes #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new map feature that deduplicates values using strict equality while preserving original keys for first occurrences.

* **Tests**
  * Added comprehensive test coverage for map deduplication, validating behavior with repeated values, key preservation, order handling, type distinction, and iteration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/126)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->