### PR TITLE
Partition List Into Fixed-Size Chunks

### DIFF
--- a/src/List/Chunks.php
+++ b/src/List/Chunks.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\List;
+
+use Generator;
+use Override;
+
+/**
+ * List of fixed-size sub-lists carved from an origin list.
+ *
+ * Elements of the origin are grouped into consecutive chunks of the
+ * configured size. The last chunk holds the remainder when the origin
+ * size is not a multiple of the configured size.
+ *
+ * Example:
+ *     $list = new Chunks(new ListOf(1, 2, 3, 4, 5), 2);
+ *     foreach ($list as $chunk) {
+ *         echo '[' . implode(',', $chunk->value()) . ']';
+ *     }
+ *     // [1,2][3,4][5]
+ *
+ * @template T
+ * @implements List_<List_<T>>
+ * @since 0.3
+ */
+final readonly class Chunks implements List_
+{
+    /**
+     * Ctor.
+     *
+     * @param List_<T> $origin The list to partition.
+     * @param positive-int $size The size of each chunk; the last chunk may be smaller.
+     */
+    public function __construct(private List_ $origin, private int $size) {}
+
+    #[Override]
+    public function value(): array
+    {
+        return array_map(
+            static fn(array $chunk): List_ => new ListOf(...$chunk),
+            array_chunk($this->origin->value(), $this->size),
+        );
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return count($this->value());
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->value();
+    }
+}

--- a/tests/List/ChunksTest.php
+++ b/tests/List/ChunksTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\List;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\List\Chunks;
+use Primus\List\ListOf;
+use Primus\List\List_;
+use ValueError;
+
+final class ChunksTest extends TestCase
+{
+    #[Test]
+    public function splitsListIntoChunksOfGivenSize(): void
+    {
+        $chunks = (new Chunks(new ListOf(1, 2, 3, 4, 5, 6), 2))->value();
+
+        $this->assertSame(
+            [[1, 2], [3, 4], [5, 6]],
+            array_map(static fn(List_ $chunk): array => $chunk->value(), $chunks),
+        );
+    }
+
+    #[Test]
+    public function lastChunkHoldsRemainderWhenSizeDoesNotDivideLength(): void
+    {
+        $chunks = (new Chunks(new ListOf(1, 2, 3, 4, 5), 2))->value();
+
+        $this->assertSame(
+            [2, 2, 1],
+            array_map(static fn(List_ $chunk): int => count($chunk), $chunks),
+        );
+    }
+
+    #[Test]
+    public function preservesElementOrderAcrossChunks(): void
+    {
+        $chunks = (new Chunks(new ListOf('a', 'b', 'c', 'd'), 3))->value();
+
+        $this->assertSame(
+            ['a', 'b', 'c', 'd'],
+            array_merge(...array_map(static fn(List_ $chunk): array => $chunk->value(), $chunks)),
+        );
+    }
+
+    #[Test]
+    public function emptyOriginProducesEmptyResult(): void
+    {
+        $this->assertSame(
+            [],
+            (new Chunks(new ListOf(), 3))->value(),
+        );
+    }
+
+    #[Test]
+    public function eachChunkHasSequentialKeysStartingAtZero(): void
+    {
+        $chunks = (new Chunks(new ListOf(1, 2, 3, 4), 2))->value();
+
+        foreach ($chunks as $chunk) {
+            $this->assertSame([0, 1], array_keys($chunk->value()));
+        }
+    }
+
+    #[Test]
+    public function resultHasSequentialKeysStartingAtZero(): void
+    {
+        $this->assertSame(
+            [0, 1, 2],
+            array_keys((new Chunks(new ListOf(1, 2, 3, 4, 5), 2))->value()),
+        );
+    }
+
+    #[Test]
+    public function zeroSizeRejectsValueAccess(): void
+    {
+        $this->expectException(ValueError::class);
+
+        (new Chunks(new ListOf(1, 2, 3), 0))->value();
+    }
+
+    #[Test]
+    public function negativeSizeRejectsValueAccess(): void
+    {
+        $this->expectException(ValueError::class);
+
+        (new Chunks(new ListOf(1, 2, 3), -1))->value();
+    }
+
+    #[Test]
+    public function iteratesYieldingTheChunks(): void
+    {
+        $collected = [];
+        foreach (new Chunks(new ListOf(1, 2, 3, 4), 2) as $chunk) {
+            $collected[] = $chunk->value();
+        }
+        $this->assertSame([[1, 2], [3, 4]], $collected);
+    }
+
+    #[Test]
+    public function reportsCountOfChunks(): void
+    {
+        $this->assertCount(3, new Chunks(new ListOf(1, 2, 3, 4, 5), 2));
+    }
+}


### PR DESCRIPTION
- Added Primus\List\Chunks that groups an origin list into consecutive sub-lists of a configured positive size, with the last chunk holding the remainder
- Added ChunksTest covering exact partitioning, remainder behaviour, order preservation across chunks, empty origin, sequential keys both inside and across chunks, rejected non-positive size at value() time, iteration, and count

Closes #127

Notes:
- Chunk size validation is delegated to PHP's native `array_chunk()`, which throws `ValueError` for sizes ≤ 0 at value() time, because the project rule `haspadar.constructorInit` forbids control flow in constructors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for partitioning lists into fixed-size chunks, enabling easier batch processing and grouped data handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/128)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->