### PR TITLE
Tell Whether List Contains A Value

### DIFF
--- a/src/List/Contains.php
+++ b/src/List/Contains.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\List;
+
+use Primus\Scalar\ScalarEnvelope;
+use Primus\Scalar\ScalarOf;
+
+/**
+ * Tells whether a list contains a value, using strict equality.
+ *
+ * Example:
+ *     $scalar = new Contains(new ListOf(1, 2, 3), 2);
+ *     echo $scalar->value() ? 'yes' : 'no'; // yes
+ *
+ * @template T
+ * @extends ScalarEnvelope<bool>
+ * @since 0.3
+ */
+final readonly class Contains extends ScalarEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param List_<T> $origin The list to search in.
+     * @param T $value The value to look for.
+     */
+    public function __construct(List_ $origin, mixed $value)
+    {
+        parent::__construct(
+            new ScalarOf(static fn(): bool => in_array($value, $origin->value(), true)),
+        );
+    }
+}

--- a/src/Scalar/ScalarOf.php
+++ b/src/Scalar/ScalarOf.php
@@ -23,6 +23,7 @@ use Override;
  * @template T
  * @implements Scalar<T>
  * @since 0.1
+ * @phpstan-ignore haspadar.afferentCoupling (base lazy primitive for every Scalar decorator; high coupling is intrinsic to the closure-wrap pattern)
  */
 final readonly class ScalarOf implements Scalar
 {

--- a/tests/List/ContainsTest.php
+++ b/tests/List/ContainsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\List;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\List\Contains;
+use Primus\List\ListOf;
+
+final class ContainsTest extends TestCase
+{
+    #[Test]
+    public function returnsTrueWhenStrictMatchExists(): void
+    {
+        $this->assertTrue(
+            (new Contains(new ListOf(1, 2, 3), 2))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsFalseWhenNoMatchExists(): void
+    {
+        $this->assertFalse(
+            (new Contains(new ListOf(1, 2, 3), 4))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsFalseForEmptyList(): void
+    {
+        $this->assertFalse(
+            (new Contains(new ListOf(), 'anything'))->value(),
+        );
+    }
+
+    #[Test]
+    public function distinguishesValuesByStrictType(): void
+    {
+        $this->assertFalse(
+            (new Contains(new ListOf(0, '1', false), 1))->value(),
+        );
+    }
+
+    #[Test]
+    public function findsStringValueByStrictMatch(): void
+    {
+        $this->assertTrue(
+            (new Contains(new ListOf('a', 'b', 'c'), 'b'))->value(),
+        );
+    }
+
+    #[Test]
+    public function findsObjectByIdentity(): void
+    {
+        $object = new \stdClass();
+        $this->assertTrue(
+            (new Contains(new ListOf(new \stdClass(), $object), $object))->value(),
+        );
+    }
+}


### PR DESCRIPTION
- Added Primus\List\Contains as a Scalar<bool> that reports whether a List contains a given value, using strict equality
- Added ContainsTest covering present-value, absent-value, empty-list, type-strict distinction, string match, and object identity
- Annotated Primus\Scalar\ScalarOf with @phpstan-ignore haspadar.afferentCoupling to acknowledge that high coupling is intrinsic to its role as the base lazy primitive (mirrors the existing TextEnvelope annotation)

Closes #129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new containment check utility that verifies whether a collection contains a specific value using strict type equality comparison.

* **Tests**
  * Added comprehensive test coverage for the containment check, including type differentiation, empty collections, string matching, and object identity verification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/130)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->