### PR TITLE
Tell Position Of A Value In A List

### DIFF
--- a/src/List/IndexOf.php
+++ b/src/List/IndexOf.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\List;
+
+use OutOfBoundsException;
+use Primus\Scalar\ScalarEnvelope;
+use Primus\Scalar\ScalarOf;
+
+/**
+ * Tells the position of the first strict-equal occurrence of a value in a list.
+ *
+ * Example:
+ *     $scalar = new IndexOf(new ListOf('a', 'b', 'c'), 'b');
+ *     echo $scalar->value(); // 1
+ *
+ * @template T
+ * @extends ScalarEnvelope<int>
+ * @since 0.3
+ */
+final readonly class IndexOf extends ScalarEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param List_<T> $origin The list to search in.
+     * @param T $value The value to locate.
+     */
+    public function __construct(List_ $origin, mixed $value)
+    {
+        parent::__construct(
+            new ScalarOf(static function () use ($origin, $value): int {
+                $index = 0;
+
+                foreach ($origin->value() as $item) {
+                    if ($item === $value) {
+                        return $index;
+                    }
+
+                    $index++;
+                }
+
+                throw new OutOfBoundsException('Value not found in list');
+            }),
+        );
+    }
+}

--- a/tests/List/IndexOfTest.php
+++ b/tests/List/IndexOfTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\List;
+
+use OutOfBoundsException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\List\IndexOf;
+use Primus\List\ListOf;
+
+final class IndexOfTest extends TestCase
+{
+    #[Test]
+    public function returnsZeroBasedIndexOfStrictMatch(): void
+    {
+        $this->assertSame(
+            1,
+            (new IndexOf(new ListOf('a', 'b', 'c'), 'b'))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsFirstOccurrenceWhenValueRepeats(): void
+    {
+        $this->assertSame(
+            1,
+            (new IndexOf(new ListOf('x', 'y', 'y', 'y'), 'y'))->value(),
+        );
+    }
+
+    #[Test]
+    public function distinguishesValuesByStrictType(): void
+    {
+        $this->expectException(OutOfBoundsException::class);
+
+        (new IndexOf(new ListOf('0', false, null), 0))->value();
+    }
+
+    #[Test]
+    public function rejectsValueAccessForAbsentValue(): void
+    {
+        $this->expectException(OutOfBoundsException::class);
+
+        (new IndexOf(new ListOf(1, 2, 3), 99))->value();
+    }
+
+    #[Test]
+    public function rejectsValueAccessForEmptyList(): void
+    {
+        $this->expectException(OutOfBoundsException::class);
+
+        (new IndexOf(new ListOf(), 'anything'))->value();
+    }
+
+    #[Test]
+    public function findsValueAtPositionZero(): void
+    {
+        $this->assertSame(
+            0,
+            (new IndexOf(new ListOf('start', 'middle', 'end'), 'start'))->value(),
+        );
+    }
+}


### PR DESCRIPTION
- Added Primus\List\IndexOf as a Scalar<int> that returns the zero-based position of the first strict-equal occurrence of a value in a list
- Added IndexOfTest covering present-value, first-occurrence selection, type-strict distinction, absent-value rejection, empty-list rejection, and zero-position match
- Rejects access through value() with OutOfBoundsException when the value is absent

Closes #131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functionality to search within lists and retrieve the zero-based index position of matching values.
  * Returns the first occurrence when multiple matches exist.
  * Appropriately handles cases when values are absent or lists are empty.

* **Tests**
  * Added comprehensive test coverage for list search functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/132)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->