### PR TITLE
Subtract List Values By Strict Equality

### DIFF
--- a/src/List/Difference.php
+++ b/src/List/Difference.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\List;
+
+use Generator;
+use Override;
+
+/**
+ * List of values from the first origin absent from all other origins.
+ *
+ * Values are compared with strict equality (`===`), so `0` and `'0'`
+ * are treated as different. Order and duplicates of the first origin
+ * are preserved for kept values; keys are renumbered from zero.
+ *
+ * Example:
+ *     $list = new Difference(
+ *         new ListOf(1, 2, 3, 4),
+ *         new ListOf(2, 4),
+ *     );
+ *     foreach ($list as $value) {
+ *         echo $value;
+ *     }
+ *     // 13
+ *
+ * @template T
+ * @implements List_<T>
+ * @since 0.3
+ */
+final readonly class Difference implements List_
+{
+    /** @var array<array-key, List_<T>> */
+    private array $excluded;
+
+    /**
+     * Ctor.
+     *
+     * @param List_<T> $first The list to draw values from.
+     * @param List_<T> ...$excluded Lists whose values remove matches from the first.
+     */
+    public function __construct(private List_ $first, List_ ...$excluded)
+    {
+        $this->excluded = $excluded;
+    }
+
+    #[Override]
+    public function value(): array
+    {
+        $forbidden = [];
+
+        foreach ($this->excluded as $source) {
+            foreach ($source->value() as $item) {
+                $forbidden[] = $item;
+            }
+        }
+
+        $kept = [];
+
+        foreach ($this->first->value() as $item) {
+            if (!in_array($item, $forbidden, true)) {
+                $kept[] = $item;
+            }
+        }
+
+        return $kept;
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return count($this->value());
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->value();
+    }
+}

--- a/tests/List/DifferenceTest.php
+++ b/tests/List/DifferenceTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\List;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\List\Difference;
+use Primus\List\ListOf;
+
+final class DifferenceTest extends TestCase
+{
+    #[Test]
+    public function keepsValuesAbsentFromOtherList(): void
+    {
+        $this->assertSame(
+            [1, 3],
+            (new Difference(
+                new ListOf(1, 2, 3, 4),
+                new ListOf(2, 4),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function subtractsAcrossMultipleSources(): void
+    {
+        $this->assertSame(
+            [3],
+            (new Difference(
+                new ListOf(1, 2, 3, 4, 5),
+                new ListOf(1, 2),
+                new ListOf(4, 5),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function distinguishesValuesByStrictType(): void
+    {
+        $this->assertSame(
+            [0, '0'],
+            (new Difference(
+                new ListOf(0, '0', 1),
+                new ListOf(1),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesDuplicatesOfKeptValues(): void
+    {
+        $this->assertSame(
+            ['a', 'a', 'c'],
+            (new Difference(
+                new ListOf('a', 'b', 'a', 'c'),
+                new ListOf('b'),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesRelativeOrderOfKeptValues(): void
+    {
+        $this->assertSame(
+            ['c', 'a', 'b'],
+            (new Difference(
+                new ListOf('c', 'x', 'a', 'y', 'b'),
+                new ListOf('x', 'y'),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsSequentialKeysStartingAtZero(): void
+    {
+        $this->assertSame(
+            [0, 1],
+            array_keys((new Difference(
+                new ListOf('a', 'b', 'c'),
+                new ListOf('b'),
+            ))->value()),
+        );
+    }
+
+    #[Test]
+    public function emptyFirstOriginProducesEmptyResult(): void
+    {
+        $this->assertSame(
+            [],
+            (new Difference(
+                new ListOf(),
+                new ListOf(1, 2, 3),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function withoutOtherListsKeepsAllValues(): void
+    {
+        $this->assertSame(
+            [1, 2, 3],
+            (new Difference(new ListOf(1, 2, 3)))->value(),
+        );
+    }
+
+    #[Test]
+    public function iteratesYieldingKeptValues(): void
+    {
+        $collected = [];
+        foreach (new Difference(new ListOf(1, 2, 3), new ListOf(2)) as $value) {
+            $collected[] = $value;
+        }
+        $this->assertSame([1, 3], $collected);
+    }
+
+    #[Test]
+    public function reportsCountOfKeptValues(): void
+    {
+        $this->assertCount(
+            2,
+            new Difference(new ListOf(1, 2, 3), new ListOf(2)),
+        );
+    }
+}


### PR DESCRIPTION
- Added Primus\List\Difference that retains values of the first origin list whose strict-equal copies are absent from any of the other origin lists
- Added DifferenceTest covering single-source subtraction, multi-source subtraction, type-strict distinction, duplicate preservation, order preservation, sequential keys from zero, empty first origin, no-exclusion identity, iteration, and count

Closes #133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new list difference operation that filters a primary list by removing values found in excluded lists, preserving order and duplicates with strict type comparison.

* **Tests**
  * Added comprehensive test coverage for the new list difference functionality, including behavior validation for order preservation, duplicates, and type handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/134)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->