### PR TITLE
Intersect List Values By Strict Equality

### DIFF
--- a/src/List/Intersection.php
+++ b/src/List/Intersection.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\List;
+
+use Generator;
+use Override;
+
+/**
+ * List of values from the first origin present in every other origin.
+ *
+ * Values are compared with strict equality (`===`), so `0` and `'0'`
+ * are treated as different. Order and duplicates of the first origin
+ * are preserved for kept values; keys are renumbered from zero.
+ *
+ * Example:
+ *     $list = new Intersection(
+ *         new ListOf(1, 2, 3, 4),
+ *         new ListOf(2, 3, 5),
+ *     );
+ *     foreach ($list as $value) {
+ *         echo $value;
+ *     }
+ *     // 23
+ *
+ * @template T
+ * @implements List_<T>
+ * @since 0.3
+ */
+final readonly class Intersection implements List_
+{
+    /** @var array<array-key, List_<T>> */
+    private array $others;
+
+    /**
+     * Ctor.
+     *
+     * @param List_<T> $first The list to draw values from.
+     * @param List_<T> ...$others Lists whose values must contain a strict-equal copy.
+     */
+    public function __construct(private List_ $first, List_ ...$others)
+    {
+        $this->others = $others;
+    }
+
+    #[Override]
+    public function value(): array
+    {
+        $required = array_map(
+            static fn(List_ $source): array => $source->value(),
+            $this->others,
+        );
+
+        $kept = [];
+
+        foreach ($this->first->value() as $item) {
+            foreach ($required as $values) {
+                if (!in_array($item, $values, true)) {
+                    continue 2;
+                }
+            }
+
+            $kept[] = $item;
+        }
+
+        return $kept;
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return count($this->value());
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->value();
+    }
+}

--- a/tests/List/IntersectionTest.php
+++ b/tests/List/IntersectionTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\List;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\List\Intersection;
+use Primus\List\ListOf;
+
+final class IntersectionTest extends TestCase
+{
+    #[Test]
+    public function keepsValuesPresentInOtherList(): void
+    {
+        $this->assertSame(
+            [2, 3],
+            (new Intersection(
+                new ListOf(1, 2, 3, 4),
+                new ListOf(2, 3, 5),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function requiresPresenceInEveryOtherSource(): void
+    {
+        $this->assertSame(
+            [3, 5],
+            (new Intersection(
+                new ListOf(1, 2, 3, 4, 5),
+                new ListOf(2, 3, 5),
+                new ListOf(3, 4, 5),
+                new ListOf(1, 3, 5),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function dropsValueMissingInAnyOtherSource(): void
+    {
+        $this->assertSame(
+            [2],
+            (new Intersection(
+                new ListOf(1, 2, 3),
+                new ListOf(1, 2, 3),
+                new ListOf(2),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function distinguishesValuesByStrictType(): void
+    {
+        $this->assertSame(
+            [0],
+            (new Intersection(
+                new ListOf(0, '0', false),
+                new ListOf(0),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesDuplicatesOfKeptValues(): void
+    {
+        $this->assertSame(
+            ['a', 'a', 'c'],
+            (new Intersection(
+                new ListOf('a', 'b', 'a', 'c'),
+                new ListOf('a', 'c'),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesRelativeOrderOfKeptValues(): void
+    {
+        $this->assertSame(
+            ['c', 'a', 'b'],
+            (new Intersection(
+                new ListOf('c', 'x', 'a', 'y', 'b'),
+                new ListOf('a', 'b', 'c'),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsSequentialKeysStartingAtZero(): void
+    {
+        $this->assertSame(
+            [0, 1],
+            array_keys((new Intersection(
+                new ListOf('a', 'b', 'c'),
+                new ListOf('a', 'c'),
+            ))->value()),
+        );
+    }
+
+    #[Test]
+    public function emptyFirstOriginProducesEmptyResult(): void
+    {
+        $this->assertSame(
+            [],
+            (new Intersection(
+                new ListOf(),
+                new ListOf(1, 2, 3),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function withoutOtherListsReturnsFirstOriginAsIs(): void
+    {
+        $this->assertSame(
+            [1, 2, 3],
+            (new Intersection(new ListOf(1, 2, 3)))->value(),
+        );
+    }
+
+    #[Test]
+    public function iteratesYieldingKeptValues(): void
+    {
+        $collected = [];
+        foreach (new Intersection(new ListOf(1, 2, 3), new ListOf(2, 3)) as $value) {
+            $collected[] = $value;
+        }
+        $this->assertSame([2, 3], $collected);
+    }
+
+    #[Test]
+    public function reportsCountOfKeptValues(): void
+    {
+        $this->assertCount(
+            2,
+            new Intersection(new ListOf(1, 2, 3), new ListOf(2, 3, 4)),
+        );
+    }
+}


### PR DESCRIPTION
- Added Primus\List\Intersection that retains values of the first origin list whose strict-equal copies appear in every one of the other origin lists
- Added IntersectionTest covering single-source intersection, multi-source intersection, dropped-missing values, type-strict distinction, duplicate preservation, order preservation, sequential keys from zero, empty first origin, no-other-sources identity, iteration, and count

Closes #135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced list intersection that returns values from the first list that are present in all other provided lists using strict type comparison. The result preserves the original order and any duplicate values while reindexing keys sequentially starting from zero.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/136)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->