### PR TITLE
Subtract Map Pairs By Strict Key Plus Value

### DIFF
--- a/src/Map/DiffAssoc.php
+++ b/src/Map/DiffAssoc.php
@@ -49,14 +49,17 @@ final readonly class DiffAssoc implements Map
     #[Override]
     public function value(): array
     {
+        $excludedValues = array_map(
+            static fn(Map $source): array => $source->value(),
+            $this->excluded,
+        );
+
         $kept = [];
 
         foreach ($this->first->value() as $key => $value) {
             $matched = false;
 
-            foreach ($this->excluded as $source) {
-                $other = $source->value();
-
+            foreach ($excludedValues as $other) {
                 if (array_key_exists($key, $other) && $other[$key] === $value) {
                     $matched = true;
 

--- a/src/Map/DiffAssoc.php
+++ b/src/Map/DiffAssoc.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Map;
+
+use Generator;
+use Override;
+
+/**
+ * Map of pairs from the first origin whose key/value combinations are absent from all other origins.
+ *
+ * Values are compared with strict equality (`===`), so `0` and `'0'`
+ * are treated as different. Keys are compared by exact match. Only
+ * pairs where another origin holds the same key with a strict-equal
+ * value are dropped; same key with a different value is kept.
+ *
+ * Example:
+ *     $map = new DiffAssoc(
+ *         new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+ *         new MapOf(['a' => 1, 'b' => 99]),
+ *     );
+ *     foreach ($map as $key => $value) {
+ *         echo "$key=$value ";
+ *     }
+ *     // b=2 c=3
+ *
+ * @template K of array-key
+ * @template V
+ * @implements Map<K, V>
+ * @since 0.3
+ */
+final readonly class DiffAssoc implements Map
+{
+    /** @var array<array-key, Map<K, V>> */
+    private array $excluded;
+
+    /**
+     * Ctor.
+     *
+     * @param Map<K, V> $first The map to draw pairs from.
+     * @param Map<K, V> ...$excluded Maps whose key/value pairs remove matches from the first.
+     */
+    public function __construct(private Map $first, Map ...$excluded)
+    {
+        $this->excluded = $excluded;
+    }
+
+    #[Override]
+    public function value(): array
+    {
+        $kept = [];
+
+        foreach ($this->first->value() as $key => $value) {
+            $matched = false;
+
+            foreach ($this->excluded as $source) {
+                $other = $source->value();
+
+                if (array_key_exists($key, $other) && $other[$key] === $value) {
+                    $matched = true;
+
+                    break;
+                }
+            }
+
+            if (!$matched) {
+                $kept[$key] = $value;
+            }
+        }
+
+        return $kept;
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return count($this->value());
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->value();
+    }
+}

--- a/tests/Map/DiffAssocTest.php
+++ b/tests/Map/DiffAssocTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Map;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Map\DiffAssoc;
+use Primus\Map\MapOf;
+
+final class DiffAssocTest extends TestCase
+{
+    #[Test]
+    public function dropsPairsWithSameKeyAndStrictlyEqualValue(): void
+    {
+        $this->assertSame(
+            ['c' => 3],
+            (new DiffAssoc(
+                new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+                new MapOf(['a' => 1, 'b' => 2]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function keepsPairsWithSameKeyButDifferentValue(): void
+    {
+        $this->assertSame(
+            ['b' => 2, 'c' => 3],
+            (new DiffAssoc(
+                new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+                new MapOf(['a' => 1, 'b' => 99]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function subtractsAcrossMultipleSources(): void
+    {
+        $this->assertSame(
+            ['c' => 3],
+            (new DiffAssoc(
+                new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+                new MapOf(['a' => 1]),
+                new MapOf(['b' => 2]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function distinguishesValuesByStrictType(): void
+    {
+        $this->assertSame(
+            ['a' => 0],
+            (new DiffAssoc(
+                new MapOf(['a' => 0]),
+                new MapOf(['a' => '0']),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesOriginalKeysOfKeptPairs(): void
+    {
+        $this->assertSame(
+            ['b', 'c'],
+            array_keys((new DiffAssoc(
+                new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+                new MapOf(['a' => 1]),
+            ))->value()),
+        );
+    }
+
+    #[Test]
+    public function preservesRelativeOrderOfKeptPairs(): void
+    {
+        $this->assertSame(
+            ['c' => 3, 'a' => 1, 'b' => 2],
+            (new DiffAssoc(
+                new MapOf(['c' => 3, 'x' => 9, 'a' => 1, 'y' => 8, 'b' => 2]),
+                new MapOf(['x' => 9, 'y' => 8]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function emptyFirstOriginProducesEmptyResult(): void
+    {
+        $this->assertSame(
+            [],
+            (new DiffAssoc(
+                new MapOf([]),
+                new MapOf(['a' => 1]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function withoutOtherMapsKeepsAllPairs(): void
+    {
+        $this->assertSame(
+            ['a' => 1, 'b' => 2],
+            (new DiffAssoc(new MapOf(['a' => 1, 'b' => 2])))->value(),
+        );
+    }
+
+    #[Test]
+    public function iteratesYieldingKeptPairsWithKeys(): void
+    {
+        $collected = [];
+        foreach (new DiffAssoc(
+            new MapOf(['a' => 1, 'b' => 2]),
+            new MapOf(['a' => 1]),
+        ) as $key => $value) {
+            $collected[$key] = $value;
+        }
+        $this->assertSame(['b' => 2], $collected);
+    }
+
+    #[Test]
+    public function reportsCountOfKeptPairs(): void
+    {
+        $this->assertCount(
+            2,
+            new DiffAssoc(
+                new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+                new MapOf(['a' => 1]),
+            ),
+        );
+    }
+}


### PR DESCRIPTION
- Added Primus\Map\DiffAssoc that retains pairs of the first origin map whose key/value combinations do not appear in any of the other origin maps
- Added DiffAssocTest covering same-key-and-value drop, same-key-different-value keep, multi-source subtraction, type-strict value distinction, key preservation, order preservation, empty first origin, no-exclusion identity, iteration with keys, and count

Closes #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new map operation for comparing maps and identifying differences. Returns key-value pairs from the primary map that don't match entries in other maps through strict equality comparison.

* **Tests**
  * Added comprehensive test coverage validating the operation across multiple sources, edge cases, and strict type comparisons.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/138)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->