### PR TITLE
Intersect Map Pairs By Strict Key Plus Value

### DIFF
--- a/src/Map/IntersectAssoc.php
+++ b/src/Map/IntersectAssoc.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Map;
+
+use Generator;
+use Override;
+
+/**
+ * Map of pairs from the first origin present in every other origin by key and value.
+ *
+ * Values are compared with strict equality (`===`), so `0` and `'0'`
+ * are treated as different. A pair is kept only when every other
+ * origin holds the same key with a strict-equal value; same key with
+ * a different value drops the pair.
+ *
+ * Example:
+ *     $map = new IntersectAssoc(
+ *         new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+ *         new MapOf(['a' => 1, 'b' => 99, 'c' => 3]),
+ *     );
+ *     foreach ($map as $key => $value) {
+ *         echo "$key=$value ";
+ *     }
+ *     // a=1 c=3
+ *
+ * @template K of array-key
+ * @template V
+ * @implements Map<K, V>
+ * @since 0.3
+ */
+final readonly class IntersectAssoc implements Map
+{
+    /** @var array<array-key, Map<K, V>> */
+    private array $others;
+
+    /**
+     * Ctor.
+     *
+     * @param Map<K, V> $first The map to draw pairs from.
+     * @param Map<K, V> ...$others Maps whose key/value pairs must contain a strict-equal copy.
+     */
+    public function __construct(private Map $first, Map ...$others)
+    {
+        $this->others = $others;
+    }
+
+    #[Override]
+    public function value(): array
+    {
+        $required = array_map(
+            static fn(Map $source): array => $source->value(),
+            $this->others,
+        );
+
+        $kept = [];
+
+        foreach ($this->first->value() as $key => $value) {
+            foreach ($required as $other) {
+                if (!array_key_exists($key, $other) || $other[$key] !== $value) {
+                    continue 2;
+                }
+            }
+
+            $kept[$key] = $value;
+        }
+
+        return $kept;
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return count($this->value());
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->value();
+    }
+}

--- a/tests/Map/IntersectAssocTest.php
+++ b/tests/Map/IntersectAssocTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Map;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Map\IntersectAssoc;
+use Primus\Map\MapOf;
+
+final class IntersectAssocTest extends TestCase
+{
+    #[Test]
+    public function keepsPairsPresentInOtherMap(): void
+    {
+        $this->assertSame(
+            ['a' => 1, 'c' => 3],
+            (new IntersectAssoc(
+                new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+                new MapOf(['a' => 1, 'b' => 99, 'c' => 3]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function requiresPresenceInEveryOtherSource(): void
+    {
+        $this->assertSame(
+            ['c' => 3],
+            (new IntersectAssoc(
+                new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+                new MapOf(['a' => 1, 'c' => 3]),
+                new MapOf(['b' => 2, 'c' => 3]),
+                new MapOf(['c' => 3, 'd' => 4]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function dropsPairWithSameKeyButDifferentValue(): void
+    {
+        $this->assertSame(
+            ['a' => 1],
+            (new IntersectAssoc(
+                new MapOf(['a' => 1, 'b' => 2]),
+                new MapOf(['a' => 1, 'b' => 99]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function dropsPairWhenAnyOtherSourceLacksTheKey(): void
+    {
+        $this->assertSame(
+            ['a' => 1],
+            (new IntersectAssoc(
+                new MapOf(['a' => 1, 'b' => 2]),
+                new MapOf(['a' => 1, 'b' => 2]),
+                new MapOf(['a' => 1]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function distinguishesValuesByStrictType(): void
+    {
+        $this->assertSame(
+            [],
+            (new IntersectAssoc(
+                new MapOf(['a' => 0]),
+                new MapOf(['a' => '0']),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesOriginalKeysOfKeptPairs(): void
+    {
+        $this->assertSame(
+            ['a', 'c'],
+            array_keys((new IntersectAssoc(
+                new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+                new MapOf(['a' => 1, 'c' => 3]),
+            ))->value()),
+        );
+    }
+
+    #[Test]
+    public function preservesRelativeOrderOfKeptPairs(): void
+    {
+        $this->assertSame(
+            ['c' => 3, 'a' => 1, 'b' => 2],
+            (new IntersectAssoc(
+                new MapOf(['c' => 3, 'x' => 9, 'a' => 1, 'y' => 8, 'b' => 2]),
+                new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function emptyFirstOriginProducesEmptyResult(): void
+    {
+        $this->assertSame(
+            [],
+            (new IntersectAssoc(
+                new MapOf([]),
+                new MapOf(['a' => 1]),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function withoutOtherMapsReturnsFirstOriginAsIs(): void
+    {
+        $this->assertSame(
+            ['a' => 1, 'b' => 2],
+            (new IntersectAssoc(new MapOf(['a' => 1, 'b' => 2])))->value(),
+        );
+    }
+
+    #[Test]
+    public function iteratesYieldingKeptPairsWithKeys(): void
+    {
+        $collected = [];
+        foreach (new IntersectAssoc(
+            new MapOf(['a' => 1, 'b' => 2]),
+            new MapOf(['a' => 1, 'b' => 2]),
+        ) as $key => $value) {
+            $collected[$key] = $value;
+        }
+        $this->assertSame(['a' => 1, 'b' => 2], $collected);
+    }
+
+    #[Test]
+    public function reportsCountOfKeptPairs(): void
+    {
+        $this->assertCount(
+            2,
+            new IntersectAssoc(
+                new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
+                new MapOf(['a' => 1, 'b' => 2]),
+            ),
+        );
+    }
+}


### PR DESCRIPTION
- Added Primus\Map\IntersectAssoc that retains pairs of the first origin map whose key/value combinations appear in every one of the other origin maps
- Added IntersectAssocTest covering single-source intersection, multi-source intersection, same-key-different-value drop, missing-key drop, type-strict value distinction, key preservation, order preservation, empty first origin, no-other-sources identity, iteration with keys, and count
- Caches other-map value() results before the outer loop to avoid N×M re-evaluations

Closes #139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `IntersectAssoc` map type that computes the intersection of multiple maps, keeping only entries where keys and values match across all sources using strict comparison.

* **Tests**
  * Added comprehensive test suite for the new map intersection functionality, covering edge cases and type strictness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/140)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->