### PR TITLE
Drop Redundant Envelope-Forwarding Constructors

### DIFF
--- a/src/List/Reversed.php
+++ b/src/List/Reversed.php
@@ -23,16 +23,6 @@ use Override;
  */
 final readonly class Reversed extends ListEnvelope
 {
-    /**
-     * Ctor.
-     *
-     * @param List_<T> $origin The list to reverse.
-     */
-    public function __construct(List_ $origin)
-    {
-        parent::__construct($origin);
-    }
-
     #[Override]
     public function value(): array
     {

--- a/src/List/Unique.php
+++ b/src/List/Unique.php
@@ -27,16 +27,6 @@ use Override;
  */
 final readonly class Unique extends ListEnvelope
 {
-    /**
-     * Ctor.
-     *
-     * @param List_<T> $origin The list to deduplicate.
-     */
-    public function __construct(List_ $origin)
-    {
-        parent::__construct($origin);
-    }
-
     #[Override]
     public function value(): array
     {

--- a/src/Map/NoNulls.php
+++ b/src/Map/NoNulls.php
@@ -21,16 +21,6 @@ use Primus\RuntimeException;
  */
 final readonly class NoNulls extends MapEnvelope
 {
-    /**
-     * Ctor.
-     *
-     * @param Map<K, V> $origin The map whose null values should be rejected.
-     */
-    public function __construct(Map $origin)
-    {
-        parent::__construct($origin);
-    }
-
     #[Override]
     public function value(): array
     {

--- a/src/Map/Unique.php
+++ b/src/Map/Unique.php
@@ -29,16 +29,6 @@ use Override;
  */
 final readonly class Unique extends MapEnvelope
 {
-    /**
-     * Ctor.
-     *
-     * @param Map<K, V> $origin The map to deduplicate.
-     */
-    public function __construct(Map $origin)
-    {
-        parent::__construct($origin);
-    }
-
     #[Override]
     public function value(): array
     {


### PR DESCRIPTION
- Removed redundant constructors from Reversed, List/Unique, Map/NoNulls, and Map/Unique where the body only forwarded the origin to the parent envelope constructor with an identical signature
- Existing tests continue to pass unchanged; public construction API is preserved through implicit parent constructor inheritance

Closes #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure optimizations to improve maintainability and consistency across collection handling components.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/142)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->