### PR TITLE
Lift Text Into Number By Parsing On Access

### DIFF
--- a/src/Number/NumberOfText.php
+++ b/src/Number/NumberOfText.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Number;
+
+use Override;
+use Primus\Text\Text;
+
+/**
+ * Number parsed from the textual representation of a Text.
+ *
+ * Parsing follows native PHP `(int)` and `(float)` cast semantics on
+ * the Text's value: leading numeric prefix is read, the rest is dropped.
+ *
+ * Example:
+ *     $n = new NumberOfText(new TextOf('3.14'));
+ *     $n->asInt(); // 3
+ *     $n->asFloat(); // 3.14
+ *
+ * @since 0.3
+ */
+final readonly class NumberOfText implements Number
+{
+    /**
+     * Ctor.
+     *
+     * @param Text $origin The textual source to parse on access.
+     */
+    public function __construct(private Text $origin) {}
+
+    #[Override]
+    public function asInt(): int
+    {
+        return (int) $this->origin->value();
+    }
+
+    #[Override]
+    public function asFloat(): float
+    {
+        return (float) $this->origin->value();
+    }
+}

--- a/tests/Number/NumberOfTextTest.php
+++ b/tests/Number/NumberOfTextTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Number;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Number\NumberOfText;
+use Primus\Text\TextOf;
+
+final class NumberOfTextTest extends TestCase
+{
+    #[Test]
+    public function parsesIntegerString(): void
+    {
+        $this->assertSame(42, (new NumberOfText(new TextOf('42')))->asInt());
+    }
+
+    #[Test]
+    public function parsesFloatString(): void
+    {
+        $this->assertSame(3.14, (new NumberOfText(new TextOf('3.14')))->asFloat());
+    }
+
+    #[Test]
+    public function truncatesParsedFloatTowardZero(): void
+    {
+        $this->assertSame(3, (new NumberOfText(new TextOf('3.7')))->asInt());
+    }
+
+    #[Test]
+    public function parsesNegativeIntegerString(): void
+    {
+        $this->assertSame(-7, (new NumberOfText(new TextOf('-7')))->asInt());
+    }
+
+    #[Test]
+    public function returnsFloatForIntegerString(): void
+    {
+        $this->assertSame(42.0, (new NumberOfText(new TextOf('42')))->asFloat());
+    }
+}

--- a/tests/Number/NumberOfTextTest.php
+++ b/tests/Number/NumberOfTextTest.php
@@ -24,9 +24,15 @@ final class NumberOfTextTest extends TestCase
     }
 
     #[Test]
-    public function truncatesParsedFloatTowardZero(): void
+    public function truncatesParsedPositiveFloatTowardZero(): void
     {
         $this->assertSame(3, (new NumberOfText(new TextOf('3.7')))->asInt());
+    }
+
+    #[Test]
+    public function truncatesParsedNegativeFloatTowardZero(): void
+    {
+        $this->assertSame(-3, (new NumberOfText(new TextOf('-3.7')))->asInt());
     }
 
     #[Test]


### PR DESCRIPTION
- Added Primus\Number\NumberOfText that wraps a Text and parses its value on each accessor call using native PHP `(int)` and `(float)` cast semantics
- Added NumberOfTextTest covering integer parse, float parse, fractional truncation, negative integer, and float-of-integer projection

Closes #143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Text-to-number conversion added: parse textual values to integers or floats.
  * Conversions follow PHP casting semantics; decimal values truncate toward zero for integer results.

* **Tests**
  * Added comprehensive tests covering integer and float parsing, negative values, truncation behavior, and edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/145)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->