### PR TITLE
Average Numbers For Composable Mean Decorator

### DIFF
--- a/src/Number/AvgOf.php
+++ b/src/Number/AvgOf.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Number;
+
+use Override;
+
+/**
+ * Arithmetic mean of one or more Number operands.
+ *
+ * The float accessor sums operand float projections and divides by the
+ * operand count. The int accessor truncates the resulting mean toward
+ * zero. An empty operand list surfaces PHP's native DivisionByZeroError
+ * at accessor time.
+ *
+ * Example:
+ *     $avg = new AvgOf(new NumberOf(1), new NumberOf(2), new NumberOf(6));
+ *     $avg->asFloat(); // 3.0
+ *     $avg->asInt(); // 3
+ *
+ * @since 0.3
+ */
+final readonly class AvgOf implements Number
+{
+    /** @var array<array-key, Number> */
+    private array $operands;
+
+    /**
+     * Ctor.
+     *
+     * @param Number ...$operands The numbers to average.
+     */
+    public function __construct(Number ...$operands)
+    {
+        $this->operands = $operands;
+    }
+
+    #[Override]
+    public function asInt(): int
+    {
+        return (int) $this->asFloat();
+    }
+
+    #[Override]
+    public function asFloat(): float
+    {
+        $total = (float) 0;
+
+        foreach ($this->operands as $operand) {
+            $total += $operand->asFloat();
+        }
+
+        return $total / (float) count($this->operands);
+    }
+}

--- a/tests/Number/AvgOfTest.php
+++ b/tests/Number/AvgOfTest.php
@@ -21,7 +21,7 @@ final class AvgOfTest extends TestCase
     #[Test]
     public function averagesMixedIntegerAndFloat(): void
     {
-        $this->assertSame(2.5, (new AvgOf(new NumberOf(2), new NumberOf(3)))->asFloat());
+        $this->assertSame(2.25, (new AvgOf(new NumberOf(2), new NumberOf(2.5)))->asFloat());
     }
 
     #[Test]
@@ -31,9 +31,15 @@ final class AvgOfTest extends TestCase
     }
 
     #[Test]
-    public function singleOperandIsItsOwnAverage(): void
+    public function singleOperandIsItsOwnAverageAsFloat(): void
     {
         $this->assertSame(7.0, (new AvgOf(new NumberOf(7)))->asFloat());
+    }
+
+    #[Test]
+    public function singleOperandIsItsOwnAverageAsInt(): void
+    {
+        $this->assertSame(7, (new AvgOf(new NumberOf(7)))->asInt());
     }
 
     #[Test]

--- a/tests/Number/AvgOfTest.php
+++ b/tests/Number/AvgOfTest.php
@@ -25,9 +25,15 @@ final class AvgOfTest extends TestCase
     }
 
     #[Test]
-    public function truncatesFractionalAverageOnIntAccessor(): void
+    public function truncatesPositiveFractionalAverageOnIntAccessor(): void
     {
         $this->assertSame(2, (new AvgOf(new NumberOf(1), new NumberOf(2), new NumberOf(4)))->asInt());
+    }
+
+    #[Test]
+    public function truncatesNegativeFractionalAverageTowardZeroOnIntAccessor(): void
+    {
+        $this->assertSame(-2, (new AvgOf(new NumberOf(-1), new NumberOf(-2), new NumberOf(-4)))->asInt());
     }
 
     #[Test]

--- a/tests/Number/AvgOfTest.php
+++ b/tests/Number/AvgOfTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Number;
+
+use DivisionByZeroError;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Number\AvgOf;
+use Primus\Number\NumberOf;
+
+final class AvgOfTest extends TestCase
+{
+    #[Test]
+    public function averagesThreeIntegers(): void
+    {
+        $this->assertSame(3.0, (new AvgOf(new NumberOf(1), new NumberOf(2), new NumberOf(6)))->asFloat());
+    }
+
+    #[Test]
+    public function averagesMixedIntegerAndFloat(): void
+    {
+        $this->assertSame(2.5, (new AvgOf(new NumberOf(2), new NumberOf(3)))->asFloat());
+    }
+
+    #[Test]
+    public function truncatesFractionalAverageOnIntAccessor(): void
+    {
+        $this->assertSame(2, (new AvgOf(new NumberOf(1), new NumberOf(2), new NumberOf(4)))->asInt());
+    }
+
+    #[Test]
+    public function singleOperandIsItsOwnAverage(): void
+    {
+        $this->assertSame(7.0, (new AvgOf(new NumberOf(7)))->asFloat());
+    }
+
+    #[Test]
+    public function averagesAcrossNegativeAndPositive(): void
+    {
+        $this->assertSame(0.0, (new AvgOf(new NumberOf(-5), new NumberOf(5)))->asFloat());
+    }
+
+    #[Test]
+    public function emptyOperandsRejectFloatAccessWithDivisionByZero(): void
+    {
+        $this->expectException(DivisionByZeroError::class);
+
+        (new AvgOf())->asFloat();
+    }
+
+    #[Test]
+    public function emptyOperandsRejectIntAccessWithDivisionByZero(): void
+    {
+        $this->expectException(DivisionByZeroError::class);
+
+        (new AvgOf())->asInt();
+    }
+}


### PR DESCRIPTION
- Added Primus\Number\AvgOf as a variadic arithmetic-mean decorator that sums float projections and divides by operand count
- Added AvgOfTest covering integer mean, mixed int/float, fractional truncation on int accessor, single-operand identity, sign cancellation, and DivisionByZeroError on empty operands

Closes #150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added arithmetic mean calculation for numeric values; supports multiple operands (ints/floats). Integer accessor returns truncated result; empty input triggers division-by-zero.

* **Tests**
  * Added tests for multi-value and single-value averages, mixed types, negative/positive values, truncation toward zero, and division-by-zero behavior on empty input.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/151)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->