### PR TITLE
Pick The Largest Number Across Operands

### DIFF
--- a/src/Number/MaxOf.php
+++ b/src/Number/MaxOf.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Number;
+
+use Override;
+use UnderflowException;
+
+/**
+ * Largest of one or more Number operands.
+ *
+ * Each accessor compares the corresponding projection of every operand
+ * and returns the maximum. An empty operand list rejects access.
+ *
+ * Example:
+ *     $max = new MaxOf(new NumberOf(3), new NumberOf(-1), new NumberOf(2));
+ *     $max->asInt(); // 3
+ *
+ * @since 0.3
+ */
+final readonly class MaxOf implements Number
+{
+    /** @var array<array-key, Number> */
+    private array $operands;
+
+    /**
+     * Ctor.
+     *
+     * @param Number ...$operands The numbers to compare.
+     */
+    public function __construct(Number ...$operands)
+    {
+        $this->operands = $operands;
+    }
+
+    #[Override]
+    public function asInt(): int
+    {
+        if ($this->operands === []) {
+            throw new UnderflowException('Cannot compute maximum of empty operand list');
+        }
+
+        return max(array_map(static fn(Number $n): int => $n->asInt(), $this->operands));
+    }
+
+    #[Override]
+    public function asFloat(): float
+    {
+        if ($this->operands === []) {
+            throw new UnderflowException('Cannot compute maximum of empty operand list');
+        }
+
+        return max(array_map(static fn(Number $n): float => $n->asFloat(), $this->operands));
+    }
+}

--- a/tests/Number/MaxOfTest.php
+++ b/tests/Number/MaxOfTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Number;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Number\MaxOf;
+use Primus\Number\NumberOf;
+use UnderflowException;
+
+final class MaxOfTest extends TestCase
+{
+    #[Test]
+    public function returnsLargestIntegerOperand(): void
+    {
+        $this->assertSame(
+            3,
+            (new MaxOf(new NumberOf(3), new NumberOf(-1), new NumberOf(2)))->asInt(),
+        );
+    }
+
+    #[Test]
+    public function returnsLargestFloatOperand(): void
+    {
+        $this->assertSame(
+            2.5,
+            (new MaxOf(new NumberOf(0.5), new NumberOf(2.5), new NumberOf(1.5)))->asFloat(),
+        );
+    }
+
+    #[Test]
+    public function singleOperandIsItsOwnMaximumAsFloat(): void
+    {
+        $this->assertSame(42.0, (new MaxOf(new NumberOf(42)))->asFloat());
+    }
+
+    #[Test]
+    public function singleOperandIsItsOwnMaximumAsInt(): void
+    {
+        $this->assertSame(42, (new MaxOf(new NumberOf(42)))->asInt());
+    }
+
+    #[Test]
+    public function picksMaximumAcrossMixedSigns(): void
+    {
+        $this->assertSame(
+            10,
+            (new MaxOf(new NumberOf(0), new NumberOf(-10), new NumberOf(10)))->asInt(),
+        );
+    }
+
+    #[Test]
+    public function intProjectionTruncatesFloatBeforeCompare(): void
+    {
+        $this->assertSame(
+            1,
+            (new MaxOf(new NumberOf(0.9), new NumberOf(1.5)))->asInt(),
+        );
+    }
+
+    #[Test]
+    public function emptyOperandsRejectIntAccess(): void
+    {
+        $this->expectException(UnderflowException::class);
+
+        (new MaxOf())->asInt();
+    }
+
+    #[Test]
+    public function emptyOperandsRejectFloatAccess(): void
+    {
+        $this->expectException(UnderflowException::class);
+
+        (new MaxOf())->asFloat();
+    }
+}


### PR DESCRIPTION
- Added Primus\Number\MaxOf as a variadic maximum decorator that returns the largest float and int projection across operands
- Added MaxOfTest covering integer maximum, float maximum, single-operand identity on both accessors, mixed-sign comparison, int projection that truncates floats before comparing, and UnderflowException for empty operands

Closes #152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for finding the maximum value from multiple numbers, with automatic conversion between integer and floating-point representations.
  * Includes error handling when operating on empty number sets.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/153)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->