### PR TITLE
Drop @since Tags From PHPDoc

### DIFF
--- a/src/Func/BiFunc.php
+++ b/src/Func/BiFunc.php
@@ -10,7 +10,6 @@ namespace Primus\Func;
  * @template X
  * @template Y
  * @template Z
- * @since 0.3
  */
 interface BiFunc
 {

--- a/src/Func/BiFuncOf.php
+++ b/src/Func/BiFuncOf.php
@@ -14,7 +14,6 @@ use Override;
  * @template Y
  * @template Z
  * @implements BiFunc<X, Y, Z>
- * @since 0.3
  */
 final readonly class BiFuncOf implements BiFunc
 {

--- a/src/Func/BiProc.php
+++ b/src/Func/BiProc.php
@@ -9,7 +9,6 @@ namespace Primus\Func;
  *
  * @template X
  * @template Y
- * @since 0.3
  */
 interface BiProc
 {

--- a/src/Func/BiProcOf.php
+++ b/src/Func/BiProcOf.php
@@ -13,7 +13,6 @@ use Override;
  * @template X
  * @template Y
  * @implements BiProc<X, Y>
- * @since 0.3
  */
 final readonly class BiProcOf implements BiProc
 {

--- a/src/Func/Func.php
+++ b/src/Func/Func.php
@@ -9,7 +9,6 @@ namespace Primus\Func;
  *
  * @template I
  * @template-covariant O
- * @since 0.3
  */
 interface Func
 {

--- a/src/Func/FuncEnvelope.php
+++ b/src/Func/FuncEnvelope.php
@@ -18,7 +18,6 @@ use Override;
  * @template I
  * @template O
  * @implements Func<I, O>
- * @since 0.3
  */
 abstract readonly class FuncEnvelope implements Func
 {

--- a/src/Func/FuncOf.php
+++ b/src/Func/FuncOf.php
@@ -13,7 +13,6 @@ use Override;
  * @template I
  * @template O
  * @implements Func<I, O>
- * @since 0.3
  */
 final readonly class FuncOf implements Func
 {

--- a/src/Func/FuncWithFallback.php
+++ b/src/Func/FuncWithFallback.php
@@ -12,7 +12,6 @@ use Throwable;
  * @template I
  * @template O
  * @extends FuncEnvelope<I, O>
- * @since 0.3
  */
 final readonly class FuncWithFallback extends FuncEnvelope
 {

--- a/src/Func/Predicate.php
+++ b/src/Func/Predicate.php
@@ -9,6 +9,5 @@ namespace Primus\Func;
  *
  * @template X
  * @extends Func<X, bool>
- * @since 0.3
  */
 interface Predicate extends Func {}

--- a/src/Func/PredicateOf.php
+++ b/src/Func/PredicateOf.php
@@ -12,7 +12,6 @@ use Override;
  *
  * @template X
  * @implements Predicate<X>
- * @since 0.3
  */
 final readonly class PredicateOf implements Predicate
 {

--- a/src/Func/Proc.php
+++ b/src/Func/Proc.php
@@ -8,7 +8,6 @@ namespace Primus\Func;
  * Procedure from X with no result.
  *
  * @template X
- * @since 0.3
  */
 interface Proc
 {

--- a/src/Func/ProcOf.php
+++ b/src/Func/ProcOf.php
@@ -12,7 +12,6 @@ use Override;
  *
  * @template X
  * @implements Proc<X>
- * @since 0.3
  */
 final readonly class ProcOf implements Proc
 {

--- a/src/Func/Repeated.php
+++ b/src/Func/Repeated.php
@@ -19,7 +19,6 @@ use Primus\RuntimeException;
  *
  * @template T
  * @implements Func<T, T>
- * @since 0.3
  */
 final readonly class Repeated implements Func
 {

--- a/src/Func/StickyFunc.php
+++ b/src/Func/StickyFunc.php
@@ -20,7 +20,6 @@ use Override;
  * @template X
  * @template Y
  * @implements Func<X, Y>
- * @since 0.3
  */
 final class StickyFunc implements Func
 {

--- a/src/List/Chunks.php
+++ b/src/List/Chunks.php
@@ -23,7 +23,6 @@ use Override;
  *
  * @template T
  * @implements List_<List_<T>>
- * @since 0.3
  */
 final readonly class Chunks implements List_
 {

--- a/src/List/Contains.php
+++ b/src/List/Contains.php
@@ -16,7 +16,6 @@ use Primus\Scalar\ScalarOf;
  *
  * @template T
  * @extends ScalarEnvelope<bool>
- * @since 0.3
  */
 final readonly class Contains extends ScalarEnvelope
 {

--- a/src/List/Difference.php
+++ b/src/List/Difference.php
@@ -26,7 +26,6 @@ use Override;
  *
  * @template T
  * @implements List_<T>
- * @since 0.3
  */
 final readonly class Difference implements List_
 {

--- a/src/List/Filtered.php
+++ b/src/List/Filtered.php
@@ -22,7 +22,6 @@ use Primus\Func\Predicate;
  *
  * @template T
  * @extends ListEnvelope<T>
- * @since 0.3
  */
 final readonly class Filtered extends ListEnvelope
 {

--- a/src/List/IndexOf.php
+++ b/src/List/IndexOf.php
@@ -17,7 +17,6 @@ use Primus\Scalar\ScalarOf;
  *
  * @template T
  * @extends ScalarEnvelope<int>
- * @since 0.3
  */
 final readonly class IndexOf extends ScalarEnvelope
 {

--- a/src/List/Intersection.php
+++ b/src/List/Intersection.php
@@ -26,7 +26,6 @@ use Override;
  *
  * @template T
  * @implements List_<T>
- * @since 0.3
  */
 final readonly class Intersection implements List_
 {

--- a/src/List/Joined.php
+++ b/src/List/Joined.php
@@ -21,7 +21,6 @@ use Override;
  *
  * @template T
  * @implements List_<T>
- * @since 0.3
  */
 final readonly class Joined implements List_
 {

--- a/src/List/ListEnvelope.php
+++ b/src/List/ListEnvelope.php
@@ -12,7 +12,6 @@ use Override;
  *
  * @template T
  * @implements List_<T>
- * @since 0.3
  */
 abstract readonly class ListEnvelope implements List_
 {

--- a/src/List/ListOf.php
+++ b/src/List/ListOf.php
@@ -16,7 +16,6 @@ use Override;
  *
  * @template T
  * @implements List_<T>
- * @since 0.3
  */
 final readonly class ListOf implements List_
 {

--- a/src/List/List_.php
+++ b/src/List/List_.php
@@ -14,7 +14,6 @@ use IteratorAggregate;
  *
  * @template T
  * @extends IteratorAggregate<array-key, T>
- * @since 0.3
  */
 interface List_ extends Countable, IteratorAggregate
 {

--- a/src/List/Mapped.php
+++ b/src/List/Mapped.php
@@ -24,7 +24,6 @@ use Primus\Func\Func;
  * @template X
  * @template Y
  * @implements List_<Y>
- * @since 0.3
  */
 final readonly class Mapped implements List_
 {

--- a/src/List/NoNulls.php
+++ b/src/List/NoNulls.php
@@ -16,7 +16,6 @@ use Primus\RuntimeException;
  *
  * @template T
  * @extends ListEnvelope<T>
- * @since 0.3
  */
 final readonly class NoNulls extends ListEnvelope
 {

--- a/src/List/Plucked.php
+++ b/src/List/Plucked.php
@@ -23,7 +23,6 @@ use Primus\RuntimeException;
  *
  * @template V
  * @implements List_<V>
- * @since 0.3
  */
 final readonly class Plucked implements List_
 {

--- a/src/List/Range.php
+++ b/src/List/Range.php
@@ -23,7 +23,6 @@ use Override;
  *     // 1357
  *
  * @implements List_<int>
- * @since 0.3
  */
 final readonly class Range implements List_
 {

--- a/src/List/Reversed.php
+++ b/src/List/Reversed.php
@@ -19,7 +19,6 @@ use Override;
  *
  * @template T
  * @extends ListEnvelope<T>
- * @since 0.3
  */
 final readonly class Reversed extends ListEnvelope
 {

--- a/src/List/Sliced.php
+++ b/src/List/Sliced.php
@@ -24,7 +24,6 @@ use Override;
  *
  * @template T
  * @extends ListEnvelope<T>
- * @since 0.3
  */
 final readonly class Sliced extends ListEnvelope
 {

--- a/src/List/Sorted.php
+++ b/src/List/Sorted.php
@@ -19,7 +19,6 @@ use Override;
  *
  * @template T
  * @extends ListEnvelope<T>
- * @since 0.3
  */
 final readonly class Sorted extends ListEnvelope
 {

--- a/src/List/SortedBy.php
+++ b/src/List/SortedBy.php
@@ -25,7 +25,6 @@ use Primus\Func\BiFunc;
  *
  * @template T
  * @extends ListEnvelope<T>
- * @since 0.3
  */
 final readonly class SortedBy extends ListEnvelope
 {

--- a/src/List/Unique.php
+++ b/src/List/Unique.php
@@ -23,7 +23,6 @@ use Override;
  *
  * @template T
  * @extends ListEnvelope<T>
- * @since 0.3
  */
 final readonly class Unique extends ListEnvelope
 {

--- a/src/Map/BiFiltered.php
+++ b/src/Map/BiFiltered.php
@@ -24,7 +24,6 @@ use Primus\Func\BiFunc;
  * @template K of array-key
  * @template V
  * @extends MapEnvelope<K, V>
- * @since 0.7
  */
 final readonly class BiFiltered extends MapEnvelope
 {

--- a/src/Map/BiMapped.php
+++ b/src/Map/BiMapped.php
@@ -25,7 +25,6 @@ use Primus\Func\BiFunc;
  * @template V
  * @template W
  * @implements Map<K, W>
- * @since 0.7
  */
 final readonly class BiMapped implements Map
 {

--- a/src/Map/Combined.php
+++ b/src/Map/Combined.php
@@ -24,7 +24,6 @@ use Primus\RuntimeException;
  *
  * @template V
  * @implements Map<array-key, V>
- * @since 0.3
  */
 final readonly class Combined implements Map
 {

--- a/src/Map/Diff.php
+++ b/src/Map/Diff.php
@@ -21,7 +21,6 @@ use Override;
  * @template K of array-key
  * @template V
  * @implements Map<K, V>
- * @since 0.3
  */
 final readonly class Diff implements Map
 {

--- a/src/Map/DiffAssoc.php
+++ b/src/Map/DiffAssoc.php
@@ -28,7 +28,6 @@ use Override;
  * @template K of array-key
  * @template V
  * @implements Map<K, V>
- * @since 0.3
  */
 final readonly class DiffAssoc implements Map
 {

--- a/src/Map/Filtered.php
+++ b/src/Map/Filtered.php
@@ -24,7 +24,6 @@ use Primus\Func\Predicate;
  * @template K of array-key
  * @template V
  * @extends MapEnvelope<K, V>
- * @since 0.3
  */
 final readonly class Filtered extends MapEnvelope
 {

--- a/src/Map/Intersect.php
+++ b/src/Map/Intersect.php
@@ -21,7 +21,6 @@ use Override;
  * @template K of array-key
  * @template V
  * @implements Map<K, V>
- * @since 0.3
  */
 final readonly class Intersect implements Map
 {

--- a/src/Map/IntersectAssoc.php
+++ b/src/Map/IntersectAssoc.php
@@ -28,7 +28,6 @@ use Override;
  * @template K of array-key
  * @template V
  * @implements Map<K, V>
- * @since 0.3
  */
 final readonly class IntersectAssoc implements Map
 {

--- a/src/Map/Keys.php
+++ b/src/Map/Keys.php
@@ -18,7 +18,6 @@ use Primus\List\List_;
  * @template K of array-key
  * @template V
  * @implements List_<K>
- * @since 0.3
  */
 final readonly class Keys implements List_
 {

--- a/src/Map/Map.php
+++ b/src/Map/Map.php
@@ -15,7 +15,6 @@ use IteratorAggregate;
  * @template K of array-key
  * @template V
  * @extends IteratorAggregate<K, V>
- * @since 0.3
  */
 interface Map extends Countable, IteratorAggregate
 {

--- a/src/Map/MapEnvelope.php
+++ b/src/Map/MapEnvelope.php
@@ -13,7 +13,6 @@ use Override;
  * @template K of array-key
  * @template V
  * @implements Map<K, V>
- * @since 0.3
  */
 abstract readonly class MapEnvelope implements Map
 {

--- a/src/Map/MapOf.php
+++ b/src/Map/MapOf.php
@@ -17,7 +17,6 @@ use Override;
  * @template K of array-key
  * @template V
  * @implements Map<K, V>
- * @since 0.3
  */
 final readonly class MapOf implements Map
 {

--- a/src/Map/Mapped.php
+++ b/src/Map/Mapped.php
@@ -25,7 +25,6 @@ use Primus\Func\Func;
  * @template V
  * @template W
  * @implements Map<K, W>
- * @since 0.3
  */
 final readonly class Mapped implements Map
 {

--- a/src/Map/Merged.php
+++ b/src/Map/Merged.php
@@ -20,7 +20,6 @@ use Override;
  * @template K of array-key
  * @template V
  * @implements Map<K, V>
- * @since 0.3
  */
 final readonly class Merged implements Map
 {

--- a/src/Map/NoNulls.php
+++ b/src/Map/NoNulls.php
@@ -17,7 +17,6 @@ use Primus\RuntimeException;
  * @template K of array-key
  * @template V
  * @extends MapEnvelope<K, V>
- * @since 0.3
  */
 final readonly class NoNulls extends MapEnvelope
 {

--- a/src/Map/PluckedBy.php
+++ b/src/Map/PluckedBy.php
@@ -25,7 +25,6 @@ use Primus\RuntimeException;
  *
  * @template V
  * @implements Map<array-key, V>
- * @since 0.3
  */
 final readonly class PluckedBy implements Map
 {

--- a/src/Map/Sliced.php
+++ b/src/Map/Sliced.php
@@ -25,7 +25,6 @@ use Override;
  * @template K of array-key
  * @template V
  * @extends MapEnvelope<K, V>
- * @since 0.3
  */
 final readonly class Sliced extends MapEnvelope
 {

--- a/src/Map/Unique.php
+++ b/src/Map/Unique.php
@@ -25,7 +25,6 @@ use Override;
  * @template K of array-key
  * @template V
  * @extends MapEnvelope<K, V>
- * @since 0.3
  */
 final readonly class Unique extends MapEnvelope
 {

--- a/src/Map/Values.php
+++ b/src/Map/Values.php
@@ -18,7 +18,6 @@ use Primus\List\List_;
  * @template K of array-key
  * @template V
  * @implements List_<V>
- * @since 0.3
  */
 final readonly class Values implements List_
 {

--- a/src/Number/AvgOf.php
+++ b/src/Number/AvgOf.php
@@ -18,8 +18,6 @@ use Override;
  *     $avg = new AvgOf(new NumberOf(1), new NumberOf(2), new NumberOf(6));
  *     $avg->asFloat(); // 3.0
  *     $avg->asInt(); // 3
- *
- * @since 0.3
  */
 final readonly class AvgOf implements Number
 {

--- a/src/Number/DivOf.php
+++ b/src/Number/DivOf.php
@@ -18,8 +18,6 @@ use Override;
  *     $q = new DivOf(new NumberOf(7), new NumberOf(2));
  *     $q->asFloat(); // 3.5
  *     $q->asInt(); // 3
- *
- * @since 0.3
  */
 final readonly class DivOf implements Number
 {

--- a/src/Number/MaxOf.php
+++ b/src/Number/MaxOf.php
@@ -16,8 +16,6 @@ use UnderflowException;
  * Example:
  *     $max = new MaxOf(new NumberOf(3), new NumberOf(-1), new NumberOf(2));
  *     $max->asInt(); // 3
- *
- * @since 0.3
  */
 final readonly class MaxOf implements Number
 {

--- a/src/Number/MinOf.php
+++ b/src/Number/MinOf.php
@@ -16,8 +16,6 @@ use UnderflowException;
  * Example:
  *     $min = new MinOf(new NumberOf(3), new NumberOf(-1), new NumberOf(2));
  *     $min->asInt(); // -1
- *
- * @since 0.3
  */
 final readonly class MinOf implements Number
 {

--- a/src/Number/MultOf.php
+++ b/src/Number/MultOf.php
@@ -17,8 +17,6 @@ use Override;
  *     $product = new MultOf(new NumberOf(2), new NumberOf(2.5));
  *     $product->asInt(); // 5
  *     $product->asFloat(); // 5.0
- *
- * @since 0.3
  */
 final readonly class MultOf implements Number
 {

--- a/src/Number/Number.php
+++ b/src/Number/Number.php
@@ -9,8 +9,6 @@ namespace Primus\Number;
  *
  * Truncation toward zero on the int accessor follows native PHP `(int)` cast
  * semantics; the float accessor preserves the source magnitude.
- *
- * @since 0.3
  */
 interface Number
 {

--- a/src/Number/NumberOf.php
+++ b/src/Number/NumberOf.php
@@ -13,8 +13,6 @@ use Override;
  *     $n = new NumberOf(3.7);
  *     $n->asInt(); // 3 (truncate)
  *     $n->asFloat(); // 3.7
- *
- * @since 0.3
  */
 final readonly class NumberOf implements Number
 {

--- a/src/Number/NumberOfScalar.php
+++ b/src/Number/NumberOfScalar.php
@@ -17,8 +17,6 @@ use Primus\Scalar\Scalar;
  *     $n = new NumberOfScalar(new ScalarOf(static fn(): float => 2.7));
  *     $n->asInt(); // 2
  *     $n->asFloat(); // 2.7
- *
- * @since 0.3
  */
 final readonly class NumberOfScalar implements Number
 {

--- a/src/Number/NumberOfText.php
+++ b/src/Number/NumberOfText.php
@@ -17,8 +17,6 @@ use Primus\Text\Text;
  *     $n = new NumberOfText(new TextOf('3.14'));
  *     $n->asInt(); // 3
  *     $n->asFloat(); // 3.14
- *
- * @since 0.3
  */
 final readonly class NumberOfText implements Number
 {

--- a/src/Number/SumOf.php
+++ b/src/Number/SumOf.php
@@ -16,8 +16,6 @@ use Override;
  *     $sum = new SumOf(new NumberOf(1), new NumberOf(2.5));
  *     $sum->asInt(); // 3 (truncate)
  *     $sum->asFloat(); // 3.5
- *
- * @since 0.3
  */
 final readonly class SumOf implements Number
 {

--- a/src/RuntimeException.php
+++ b/src/RuntimeException.php
@@ -12,7 +12,5 @@ use RuntimeException as BaseRuntimeException;
  * Every Primus runtime failure uses this single type so that consumers can
  * distinguish primus-originated failures from unrelated runtime exceptions
  * via a single catch clause. No per-failure subclasses are introduced.
- *
- * @since 0.3
  */
 final class RuntimeException extends BaseRuntimeException {}

--- a/src/Scalar/And_.php
+++ b/src/Scalar/And_.php
@@ -16,7 +16,6 @@ use InvalidArgumentException;
  *     echo $and->value(); // false
  *
  * @extends ScalarEnvelope<bool>
- * @since 0.2
  */
 final readonly class And_ extends ScalarEnvelope
 {

--- a/src/Scalar/Between.php
+++ b/src/Scalar/Between.php
@@ -17,7 +17,6 @@ namespace Primus\Scalar;
  *
  * @template T of int|float|string
  * @extends ScalarEnvelope<bool>
- * @since 0.2
  */
 final readonly class Between extends ScalarEnvelope
 {

--- a/src/Scalar/Constant.php
+++ b/src/Scalar/Constant.php
@@ -19,7 +19,6 @@ use Override;
  *
  * @template T
  * @implements Scalar<T>
- * @since 0.2
  */
 final readonly class Constant implements Scalar
 {

--- a/src/Scalar/EqualTo.php
+++ b/src/Scalar/EqualTo.php
@@ -16,7 +16,6 @@ namespace Primus\Scalar;
  *
  * @template T
  * @extends ScalarEnvelope<bool>
- * @since 0.2
  */
 final readonly class EqualTo extends ScalarEnvelope
 {

--- a/src/Scalar/GreaterThan.php
+++ b/src/Scalar/GreaterThan.php
@@ -16,7 +16,6 @@ namespace Primus\Scalar;
  *
  * @template T of int|float|string
  * @extends ScalarEnvelope<bool>
- * @since 0.2
  */
 final readonly class GreaterThan extends ScalarEnvelope
 {

--- a/src/Scalar/LessThan.php
+++ b/src/Scalar/LessThan.php
@@ -16,7 +16,6 @@ namespace Primus\Scalar;
  *
  * @template T of int|float|string
  * @extends ScalarEnvelope<bool>
- * @since 0.2
  */
 final readonly class LessThan extends ScalarEnvelope
 {

--- a/src/Scalar/Not.php
+++ b/src/Scalar/Not.php
@@ -12,7 +12,6 @@ namespace Primus\Scalar;
  *     echo $scalar->value(); // true
  *
  * @extends ScalarEnvelope<bool>
- * @since 0.2
  */
 final readonly class Not extends ScalarEnvelope
 {

--- a/src/Scalar/Or_.php
+++ b/src/Scalar/Or_.php
@@ -12,7 +12,6 @@ use InvalidArgumentException;
  * Returns true if at least one provided scalar evaluates to true.
  *
  * @extends ScalarEnvelope<bool>
- * @since 0.2
  */
 final readonly class Or_ extends ScalarEnvelope
 {

--- a/src/Scalar/Scalar.php
+++ b/src/Scalar/Scalar.php
@@ -11,7 +11,6 @@ namespace Primus\Scalar;
  * Used as a base abstraction for all primitive-like types (Text, Number, etc).
  *
  * @template-covariant T
- * @since 0.1
  */
 interface Scalar
 {

--- a/src/Scalar/ScalarEnvelope.php
+++ b/src/Scalar/ScalarEnvelope.php
@@ -14,7 +14,6 @@ use Override;
  *
  * @template T
  * @implements Scalar<T>
- * @since 0.1
  */
 abstract readonly class ScalarEnvelope implements Scalar
 {

--- a/src/Scalar/ScalarOf.php
+++ b/src/Scalar/ScalarOf.php
@@ -22,7 +22,6 @@ use Override;
  *
  * @template T
  * @implements Scalar<T>
- * @since 0.1
  * @phpstan-ignore haspadar.afferentCoupling (base lazy primitive for every Scalar decorator; high coupling is intrinsic to the closure-wrap pattern)
  */
 final readonly class ScalarOf implements Scalar

--- a/src/Scalar/Sticky.php
+++ b/src/Scalar/Sticky.php
@@ -22,7 +22,6 @@ use Override;
  *
  * @template T
  * @implements Scalar<T>
- * @since 0.2
  */
 final class Sticky implements Scalar
 {

--- a/src/Scalar/Ternary.php
+++ b/src/Scalar/Ternary.php
@@ -20,7 +20,6 @@ namespace Primus\Scalar;
  *
  * @template T
  * @extends ScalarEnvelope<T>
- * @since 0.2
  */
 final readonly class Ternary extends ScalarEnvelope
 {

--- a/src/Scalar/Xor_.php
+++ b/src/Scalar/Xor_.php
@@ -19,7 +19,6 @@ use InvalidArgumentException;
  *     echo $scalar->value(); // true
  *
  * @extends ScalarEnvelope<bool>
- * @since 0.2
  */
 final readonly class Xor_ extends ScalarEnvelope
 {

--- a/src/Text/Abbreviated.php
+++ b/src/Text/Abbreviated.php
@@ -15,8 +15,6 @@ use Primus\Scalar\ScalarOf;
  * Example:
  *     $text = new Abbreviated(new TextOf('Hello, world!'), 8);
  *     echo $text->value(); // 'Hello, w…'
- *
- * @since 0.1
  */
 final readonly class Abbreviated extends TextEnvelope
 {

--- a/src/Text/Capitalized.php
+++ b/src/Text/Capitalized.php
@@ -13,8 +13,6 @@ namespace Primus\Text;
  * Example:
  *     $text = new Capitalized(new TextOf('hello'));
  *     echo $text->value(); // 'Hello'
- *
- * @since 0.2
  */
 final readonly class Capitalized extends TextEnvelope
 {

--- a/src/Text/HtmlEscaped.php
+++ b/src/Text/HtmlEscaped.php
@@ -12,8 +12,6 @@ use Primus\Func\FuncOf;
  * Example:
  *     $text = new HtmlEscaped(new TextOf('<b>"A & B"</b>'));
  *     echo $text->value(); // &lt;b&gt;&quot;A &amp; B&quot;&lt;/b&gt;
- *
- * @since 0.2
  */
 final readonly class HtmlEscaped extends TextEnvelope
 {

--- a/src/Text/IsEmpty.php
+++ b/src/Text/IsEmpty.php
@@ -18,7 +18,6 @@ use Primus\Scalar\ScalarOf;
  *     echo $empty->value(); // true
  *
  * @extends ScalarEnvelope<bool>
- * @since 0.3
  */
 final readonly class IsEmpty extends ScalarEnvelope
 {

--- a/src/Text/Joined.php
+++ b/src/Text/Joined.php
@@ -12,8 +12,6 @@ use Primus\Scalar\ScalarOf;
  * Example:
  *     $text = new Joined(', ', [new TextOf('a'), new TextOf('b'), new TextOf('c')]);
  *     echo $text->value(); // 'a, b, c'
- *
- * @since 0.2
  */
 final readonly class Joined extends TextEnvelope
 {

--- a/src/Text/LeftPadded.php
+++ b/src/Text/LeftPadded.php
@@ -15,8 +15,6 @@ use Primus\Func\FuncOf;
  * Example:
  *     $text = new LeftPadded(new TextOf('foo'), 6, '.');
  *     echo $text->value(); // '...foo'
- *
- * @since 0.2
  */
 final readonly class LeftPadded extends TextEnvelope
 {

--- a/src/Text/Lowered.php
+++ b/src/Text/Lowered.php
@@ -14,8 +14,6 @@ use Primus\Func\FuncOf;
  * Example:
  *     $text = new Lowered(new TextOf('CAFÉ & TÜRKİYE'));
  *     echo $text->value(); // 'café & türkiye'
- *
- * @since 0.1
  */
 final readonly class Lowered extends TextEnvelope
 {

--- a/src/Text/Mapped.php
+++ b/src/Text/Mapped.php
@@ -16,8 +16,6 @@ use Primus\Func\Func;
  *         new FuncOf(strtoupper(...)),
  *     );
  *     echo $text->value(); // 'HELLO'
- *
- * @since 0.3
  */
 final readonly class Mapped extends TextEnvelope
 {

--- a/src/Text/Normalized.php
+++ b/src/Text/Normalized.php
@@ -16,8 +16,6 @@ use Primus\Scalar\ScalarOf;
  * Example:
  *     $text = new Normalized(new TextOf(" Hello \n\t world "));
  *     echo $text->value(); // 'Hello world'
- *
- * @since 0.2
  */
 final readonly class Normalized extends TextEnvelope
 {

--- a/src/Text/RandomText.php
+++ b/src/Text/RandomText.php
@@ -16,8 +16,6 @@ use Primus\Scalar\Sticky;
  * Example:
  *     $text = new RandomText(8);
  *     echo $text->value(); // e.g. 'aZ8mKp2Q'
- *
- * @since 0.2
  */
 final readonly class RandomText extends TextEnvelope
 {

--- a/src/Text/Repeated.php
+++ b/src/Text/Repeated.php
@@ -12,8 +12,6 @@ use Primus\Func\FuncOf;
  * Example:
  *     $text = new Repeated(new TextOf('xo'), 3);
  *     echo $text->value(); // 'xoxoxo'
- *
- * @since 0.2
  */
 final readonly class Repeated extends TextEnvelope
 {

--- a/src/Text/Replaced.php
+++ b/src/Text/Replaced.php
@@ -18,8 +18,6 @@ use Primus\Func\FuncOf;
  *         ['', '', 'and']
  *     );
  *     echo $text->value(); // 'Hello and bye'
- *
- * @since 0.2
  */
 final readonly class Replaced extends TextEnvelope
 {

--- a/src/Text/RightPadded.php
+++ b/src/Text/RightPadded.php
@@ -14,8 +14,6 @@ use Primus\Func\FuncOf;
  * Example:
  *     $text = new RightPadded(new TextOf('foo'), 6, '.');
  *     echo $text->value(); // 'foo...'
- *
- * @since 0.1
  */
 final readonly class RightPadded extends TextEnvelope
 {

--- a/src/Text/Split.php
+++ b/src/Text/Split.php
@@ -19,7 +19,6 @@ use Primus\Scalar\Scalar;
  *     }
  *
  * @implements Scalar<iterable<Text>>
- * @since 0.2
  */
 final readonly class Split implements Scalar
 {

--- a/src/Text/Sub.php
+++ b/src/Text/Sub.php
@@ -15,8 +15,6 @@ use Primus\Func\FuncOf;
  * Example:
  *     $text = new Sub(new TextOf('hello world'), 0, 5);
  *     echo $text->value(); // 'hello'
- *
- * @since 0.1
  */
 final readonly class Sub extends TextEnvelope
 {

--- a/src/Text/Trimmed.php
+++ b/src/Text/Trimmed.php
@@ -14,8 +14,6 @@ use Primus\Func\FuncOf;
  * Example:
  *     $text = new Trimmed(new TextOf(' hello '));
  *     echo $text->value(); // 'hello'
- *
- * @since 0.1
  */
 final readonly class Trimmed extends TextEnvelope
 {

--- a/src/Text/TrimmedLeft.php
+++ b/src/Text/TrimmedLeft.php
@@ -13,8 +13,6 @@ use Primus\Func\FuncOf;
  * Example:
  *     $text = new TrimmedLeft(new TextOf(" hello "));
  *     echo $text->value(); // 'hello '
- *
- * @since 0.2
  */
 final readonly class TrimmedLeft extends TextEnvelope
 {

--- a/src/Text/TrimmedRight.php
+++ b/src/Text/TrimmedRight.php
@@ -13,8 +13,6 @@ use Primus\Func\FuncOf;
  * Example:
  *     $text = new TrimmedRight(new TextOf(" hello "));
  *     echo $text->value(); // ' hello'
- *
- * @since 0.2
  */
 final readonly class TrimmedRight extends TextEnvelope
 {

--- a/tests/Constraint/AppliesBiFuncTo.php
+++ b/tests/Constraint/AppliesBiFuncTo.php
@@ -17,7 +17,6 @@ use Primus\Func\BiFunc;
  *     new AppliesBiFuncTo([3, 4], 7)
  * );
  *
- * @since 0.5
  */
 final class AppliesBiFuncTo extends Constraint
 {

--- a/tests/Constraint/AppliesFuncTo.php
+++ b/tests/Constraint/AppliesFuncTo.php
@@ -17,7 +17,6 @@ use Primus\Func\Func;
  *     new AppliesFuncTo(3, new EqualsValue(6))
  * );
  *
- * @since 0.5
  */
 final class AppliesFuncTo extends Constraint
 {

--- a/tests/Constraint/EqualsValue.php
+++ b/tests/Constraint/EqualsValue.php
@@ -12,7 +12,6 @@ use PHPUnit\Framework\Constraint\Constraint;
  * Example:
  * self::assertThat($actual, new EqualsValue($expected));
  *
- * @since 0.5
  */
 final class EqualsValue extends Constraint
 {

--- a/tests/Constraint/ExecBiProcTo.php
+++ b/tests/Constraint/ExecBiProcTo.php
@@ -17,7 +17,6 @@ use Primus\Func\BiProc;
  *     new BiProcOf(...)
  * );
  *
- * @since 0.5
  */
 final class ExecBiProcTo extends Constraint
 {

--- a/tests/Constraint/HasCallCount.php
+++ b/tests/Constraint/HasCallCount.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\Constraint\Constraint;
 
 /**
 *
-* @since 0.3
 */
 final class HasCallCount extends Constraint
 {

--- a/tests/Constraint/HasIteratorValues.php
+++ b/tests/Constraint/HasIteratorValues.php
@@ -27,7 +27,6 @@ use RuntimeException;
  * Expected: [10,20]
  * But was:  [10]
  *
- * @since 0.5
  */
 final class HasIteratorValues extends Constraint
 {

--- a/tests/Constraint/HasKey.php
+++ b/tests/Constraint/HasKey.php
@@ -23,7 +23,6 @@ use PHPUnit\Framework\Constraint\Constraint;
  * Failed asserting that iterator has key 2
  * But key was: 1
  *
- * @since 0.5
  */
 final class HasKey extends Constraint
 {

--- a/tests/Constraint/HasKeyValuePairs.php
+++ b/tests/Constraint/HasKeyValuePairs.php
@@ -41,7 +41,6 @@ use Traversable;
  *   1 => 4,
  * )
  *
- * @since 0.5
  */
 final class HasKeyValuePairs extends Constraint
 {

--- a/tests/Constraint/HasScalarBoolValue.php
+++ b/tests/Constraint/HasScalarBoolValue.php
@@ -13,7 +13,6 @@ use Primus\Scalar\Scalar;
  * Example:
  * self::assertThat(new True_(), new HasBoolValue(true));
  *
- * @since 0.2
  */
 final class HasScalarBoolValue extends Constraint
 {

--- a/tests/Constraint/HasScalarValue.php
+++ b/tests/Constraint/HasScalarValue.php
@@ -12,7 +12,6 @@ use Primus\Scalar\Scalar;
  *
  * Supports int, float, string, and bool.
  *
- * @since 0.2
  */
 final class HasScalarValue extends Constraint
 {

--- a/tests/Constraint/HasScalarValues.php
+++ b/tests/Constraint/HasScalarValues.php
@@ -10,7 +10,6 @@ use PHPUnit\Framework\Constraint\Constraint;
  * Asserts that an iterable of scalar values (int, float, string, bool)
  * has the expected values.
  *
- * @since 0.2
  */
 final class HasScalarValues extends Constraint
 {

--- a/tests/Constraint/HasSize.php
+++ b/tests/Constraint/HasSize.php
@@ -19,7 +19,6 @@ use Primus\Text\Text;
  * Expected length: 5
  * But was:         3
  *
- * @since 0.2
  */
 final class HasSize extends Constraint
 {

--- a/tests/Constraint/HasTextValue.php
+++ b/tests/Constraint/HasTextValue.php
@@ -13,7 +13,6 @@ use Primus\Text\Text;
  * Example:
  * self::assertThat(new TextOf('foo'), new HasTextValue('foo'));
  *
- * @since 0.2
  */
 final class HasTextValue extends Constraint
 {

--- a/tests/Constraint/HasTextValues.php
+++ b/tests/Constraint/HasTextValues.php
@@ -21,7 +21,6 @@ use Primus\Text\Text;
  * Expected: ["a","b"]
  * But was:  ["a","c"]
  *
- * @since 0.2
  */
 final class HasTextValues extends Constraint
 {

--- a/tests/Constraint/MatchesPattern.php
+++ b/tests/Constraint/MatchesPattern.php
@@ -22,7 +22,6 @@ use Primus\Text\Text;
  * Expected pattern: /^foo$/
  * But was:          'bar'
  *
- * @since 0.2
  */
 final class MatchesPattern extends Constraint
 {

--- a/tests/Constraint/ThrowsClosure.php
+++ b/tests/Constraint/ThrowsClosure.php
@@ -17,7 +17,6 @@ use Throwable;
  *     new ThrowsClosure(\RuntimeException::class)
  * );
  *
- * @since 0.5
  */
 final class ThrowsClosure extends Constraint
 {

--- a/tests/Constraint/ThrowsValue.php
+++ b/tests/Constraint/ThrowsValue.php
@@ -16,7 +16,6 @@ use Throwable;
  *     new ThrowsValue(\RuntimeException::class)
  * );
  *
- * @since 0.2
  */
 final class ThrowsValue extends Constraint
 {

--- a/tests/CountCalls.php
+++ b/tests/CountCalls.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Primus\Tests;
 
 /**
- * @since 0.3
  */
 final class CountCalls
 {

--- a/tests/Func/BiFuncOfTest.php
+++ b/tests/Func/BiFuncOfTest.php
@@ -10,7 +10,6 @@ use Primus\Func\BiFuncOf;
 use Primus\Tests\Constraint\AppliesBiFuncTo;
 
 /**
- * @since 0.3
  */
 final class BiFuncOfTest extends TestCase
 {

--- a/tests/Func/BiProcOfTest.php
+++ b/tests/Func/BiProcOfTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
 use Primus\Func\BiProcOf;
 
 /**
- * @since 0.3
  */
 final class BiProcOfTest extends TestCase
 {

--- a/tests/Func/FuncOfTest.php
+++ b/tests/Func/FuncOfTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
 use Primus\Func\FuncOf;
 
 /**
- * @since 0.3
  */
 final class FuncOfTest extends TestCase
 {

--- a/tests/Func/FuncWithFallbackTest.php
+++ b/tests/Func/FuncWithFallbackTest.php
@@ -13,7 +13,6 @@ use Primus\Tests\Constraint\EqualsValue;
 use RuntimeException;
 
 /**
- * @since 0.3
  */
 final class FuncWithFallbackTest extends TestCase
 {

--- a/tests/Func/PredicateOfTest.php
+++ b/tests/Func/PredicateOfTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
 use Primus\Func\PredicateOf;
 
 /**
- * @since 0.3
  */
 final class PredicateOfTest extends TestCase
 {

--- a/tests/Func/ProcOfTest.php
+++ b/tests/Func/ProcOfTest.php
@@ -11,7 +11,6 @@ use Primus\Tests\Constraint\HasCallCount;
 use Primus\Tests\CountCalls;
 
 /**
- * @since 0.3
  */
 final class ProcOfTest extends TestCase
 {

--- a/tests/Func/RepeatedTest.php
+++ b/tests/Func/RepeatedTest.php
@@ -11,7 +11,6 @@ use Primus\Func\Repeated;
 use Primus\Tests\Constraint\ThrowsClosure;
 
 /**
- * @since 0.3
  */
 final class RepeatedTest extends TestCase
 {

--- a/tests/Func/StickyFuncTest.php
+++ b/tests/Func/StickyFuncTest.php
@@ -13,7 +13,6 @@ use Primus\Tests\Constraint\HasCallCount;
 use Primus\Tests\CountCalls;
 
 /**
- * @since 0.3
  */
 final class StickyFuncTest extends TestCase
 {

--- a/tests/Scalar/And_Test.php
+++ b/tests/Scalar/And_Test.php
@@ -13,7 +13,6 @@ use Primus\Tests\Constraint\HasScalarBoolValue;
 use Primus\Tests\Constraint\ThrowsValue;
 
 /**
- * @since 0.2
  */
 final class And_Test extends TestCase
 {

--- a/tests/Scalar/BetweenTest.php
+++ b/tests/Scalar/BetweenTest.php
@@ -11,7 +11,6 @@ use Primus\Scalar\ScalarOf;
 use Primus\Tests\Constraint\HasScalarBoolValue;
 
 /**
- * @since 0.2
  */
 final class BetweenTest extends TestCase
 {

--- a/tests/Scalar/ConstantTest.php
+++ b/tests/Scalar/ConstantTest.php
@@ -10,7 +10,6 @@ use Primus\Scalar\Constant;
 use Primus\Tests\Constraint\HasScalarValue;
 
 /**
- * @since 0.2
  */
 final class ConstantTest extends TestCase
 {

--- a/tests/Scalar/EqualToTest.php
+++ b/tests/Scalar/EqualToTest.php
@@ -11,7 +11,6 @@ use Primus\Scalar\ScalarOf;
 use Primus\Tests\Constraint\HasScalarBoolValue;
 
 /**
- * @since 0.2
  */
 final class EqualToTest extends TestCase
 {

--- a/tests/Scalar/GreaterThanTest.php
+++ b/tests/Scalar/GreaterThanTest.php
@@ -11,7 +11,6 @@ use Primus\Scalar\ScalarOf;
 use Primus\Tests\Constraint\HasScalarBoolValue;
 
 /**
- * @since 0.2
  */
 final class GreaterThanTest extends TestCase
 {

--- a/tests/Scalar/LessThanTest.php
+++ b/tests/Scalar/LessThanTest.php
@@ -11,7 +11,6 @@ use Primus\Scalar\ScalarOf;
 use Primus\Tests\Constraint\HasScalarBoolValue;
 
 /**
- * @since 0.2
  */
 final class LessThanTest extends TestCase
 {

--- a/tests/Scalar/NotTest.php
+++ b/tests/Scalar/NotTest.php
@@ -11,7 +11,6 @@ use Primus\Scalar\ScalarOf;
 use Primus\Tests\Constraint\HasScalarBoolValue;
 
 /**
- * @since 0.2
  */
 final class NotTest extends TestCase
 {

--- a/tests/Scalar/Or_Test.php
+++ b/tests/Scalar/Or_Test.php
@@ -13,7 +13,6 @@ use Primus\Tests\Constraint\HasScalarBoolValue;
 use Primus\Tests\Constraint\ThrowsValue;
 
 /**
- * @since 0.2
  */
 final class Or_Test extends TestCase
 {

--- a/tests/Scalar/ScalarOfTest.php
+++ b/tests/Scalar/ScalarOfTest.php
@@ -12,7 +12,6 @@ use Primus\Tests\Constraint\HasScalarValue;
 use Primus\Tests\CountCalls;
 
 /**
- * @since 0.2
  */
 final class ScalarOfTest extends TestCase
 {

--- a/tests/Scalar/StickyTest.php
+++ b/tests/Scalar/StickyTest.php
@@ -11,7 +11,6 @@ use Primus\Scalar\Sticky;
 use Primus\Tests\Constraint\HasScalarValue;
 
 /**
- * @since 0.2
  */
 final class StickyTest extends TestCase
 {

--- a/tests/Scalar/TernaryTest.php
+++ b/tests/Scalar/TernaryTest.php
@@ -12,7 +12,6 @@ use Primus\Scalar\Ternary;
 use Primus\Tests\Constraint\HasScalarValue;
 
 /**
- * @since 0.2
  */
 final class TernaryTest extends TestCase
 {

--- a/tests/Scalar/Xor_Test.php
+++ b/tests/Scalar/Xor_Test.php
@@ -13,7 +13,6 @@ use Primus\Tests\Constraint\HasScalarBoolValue;
 use Primus\Tests\Constraint\ThrowsValue;
 
 /**
- * @since 0.2
  */
 final class Xor_Test extends TestCase
 {

--- a/tests/Text/AbbreviatedTest.php
+++ b/tests/Text/AbbreviatedTest.php
@@ -11,7 +11,6 @@ use Primus\Text\Abbreviated;
 use Primus\Text\TextOf;
 
 /**
- * @since 0.2
  */
 final class AbbreviatedTest extends TestCase
 {

--- a/tests/Text/CapitalizedTest.php
+++ b/tests/Text/CapitalizedTest.php
@@ -11,7 +11,6 @@ use Primus\Text\Capitalized;
 use Primus\Text\TextOf;
 
 /**
- * @since 0.2
  */
 final class CapitalizedTest extends TestCase
 {

--- a/tests/Text/HtmlEscapedTest.php
+++ b/tests/Text/HtmlEscapedTest.php
@@ -11,7 +11,6 @@ use Primus\Text\HtmlEscaped;
 use Primus\Text\TextOf;
 
 /**
- * @since 0.2
  */
 final class HtmlEscapedTest extends TestCase
 {

--- a/tests/Text/JoinedTest.php
+++ b/tests/Text/JoinedTest.php
@@ -12,7 +12,6 @@ use Primus\Text\Text;
 use Primus\Text\TextOf;
 
 /**
- * @since 0.2
  */
 final class JoinedTest extends TestCase
 {

--- a/tests/Text/LeftPaddedTest.php
+++ b/tests/Text/LeftPaddedTest.php
@@ -11,7 +11,6 @@ use Primus\Text\LeftPadded;
 use Primus\Text\TextOf;
 
 /**
- * @since 0.2
  */
 final class LeftPaddedTest extends TestCase
 {

--- a/tests/Text/LengthOfTextTest.php
+++ b/tests/Text/LengthOfTextTest.php
@@ -10,7 +10,6 @@ use Primus\Tests\Constraint\HasSize;
 use Primus\Text\TextOf;
 
 /**
- * @since 0.2
  */
 final class LengthOfTextTest extends TestCase
 {

--- a/tests/Text/LoweredTest.php
+++ b/tests/Text/LoweredTest.php
@@ -11,7 +11,6 @@ use Primus\Text\Lowered;
 use Primus\Text\TextOf;
 
 /**
- * @since 0.2
  */
 final class LoweredTest extends TestCase
 {

--- a/tests/Text/MappedTest.php
+++ b/tests/Text/MappedTest.php
@@ -12,7 +12,6 @@ use Primus\Text\Mapped;
 use Primus\Text\TextOf;
 
 /**
- * @since 0.3
  */
 final class MappedTest extends TestCase
 {

--- a/tests/Text/NormalizedTest.php
+++ b/tests/Text/NormalizedTest.php
@@ -13,7 +13,6 @@ use Primus\Text\Normalized;
 use Primus\Text\TextOf;
 
 /**
- * @since 0.2
  */
 final class NormalizedTest extends TestCase
 {

--- a/tests/Text/RandomTextTest.php
+++ b/tests/Text/RandomTextTest.php
@@ -11,7 +11,6 @@ use Primus\Tests\Constraint\MatchesPattern;
 use Primus\Text\RandomText;
 
 /**
- * @since 0.2
  */
 final class RandomTextTest extends TestCase
 {

--- a/tests/Text/RepeatedTest.php
+++ b/tests/Text/RepeatedTest.php
@@ -11,7 +11,6 @@ use Primus\Text\Repeated;
 use Primus\Text\TextOf;
 
 /**
- * @since 0.2
  */
 final class RepeatedTest extends TestCase
 {

--- a/tests/Text/ReplacedTest.php
+++ b/tests/Text/ReplacedTest.php
@@ -11,7 +11,6 @@ use Primus\Text\Replaced;
 use Primus\Text\TextOf;
 
 /**
- * @since 0.2
  */
 final class ReplacedTest extends TestCase
 {

--- a/tests/Text/RightPaddedTest.php
+++ b/tests/Text/RightPaddedTest.php
@@ -11,7 +11,6 @@ use Primus\Text\RightPadded;
 use Primus\Text\TextOf;
 
 /**
- * @since 0.2
  */
 final class RightPaddedTest extends TestCase
 {

--- a/tests/Text/SplitTest.php
+++ b/tests/Text/SplitTest.php
@@ -11,7 +11,6 @@ use Primus\Text\Split;
 use Primus\Text\TextOf;
 
 /**
- * @since 0.2
  */
 final class SplitTest extends TestCase
 {

--- a/tests/Text/SubTest.php
+++ b/tests/Text/SubTest.php
@@ -11,7 +11,6 @@ use Primus\Text\Sub;
 use Primus\Text\TextOf;
 
 /**
- * @since 0.2
  */
 final class SubTest extends TestCase
 {

--- a/tests/Text/TextOfScalarTest.php
+++ b/tests/Text/TextOfScalarTest.php
@@ -11,7 +11,6 @@ use Primus\Tests\Constraint\HasTextValue;
 use Primus\Text\TextOfScalar;
 
 /**
- * @since 0.2
  */
 final class TextOfScalarTest extends TestCase
 {

--- a/tests/Text/TextOfTest.php
+++ b/tests/Text/TextOfTest.php
@@ -10,7 +10,6 @@ use Primus\Tests\Constraint\HasTextValue;
 use Primus\Text\TextOf;
 
 /**
- * @since 0.2
  */
 final class TextOfTest extends TestCase
 {

--- a/tests/Text/TrimmedLeftTest.php
+++ b/tests/Text/TrimmedLeftTest.php
@@ -11,7 +11,6 @@ use Primus\Text\TextOf;
 use Primus\Text\TrimmedLeft;
 
 /**
- * @since 0.2
  */
 final class TrimmedLeftTest extends TestCase
 {

--- a/tests/Text/TrimmedRightTest.php
+++ b/tests/Text/TrimmedRightTest.php
@@ -13,7 +13,6 @@ use Primus\Text\TextOf;
 use Primus\Text\TrimmedRight;
 
 /**
- * @since 0.2
  */
 final class TrimmedRightTest extends TestCase
 {

--- a/tests/Text/TrimmedTest.php
+++ b/tests/Text/TrimmedTest.php
@@ -11,7 +11,6 @@ use Primus\Text\TextOf;
 use Primus\Text\Trimmed;
 
 /**
- * @since 0.2
  */
 final class TrimmedTest extends TestCase
 {

--- a/tests/Text/UpperedTest.php
+++ b/tests/Text/UpperedTest.php
@@ -11,7 +11,6 @@ use Primus\Text\TextOf;
 use Primus\Text\Uppered;
 
 /**
- * @since 0.2
  */
 final class UpperedTest extends TestCase
 {

--- a/tests/Text/WithoutTagsTest.php
+++ b/tests/Text/WithoutTagsTest.php
@@ -11,7 +11,6 @@ use Primus\Text\TextOf;
 use Primus\Text\WithoutTags;
 
 /**
- * @since 0.2
  */
 final class WithoutTagsTest extends TestCase
 {


### PR DESCRIPTION
- Removed every `@since` line from PHPDoc across src/ and tests/ — 155 files, 182 deletions
- Other PHPDoc content (summaries, @param, @template, @phpstan-ignore, etc.) is preserved
- phpcs/phpcbf cleaned up the empty trailing lines left behind in the docblocks
- Existing tests pass without modification

Closes #154