### PR TITLE
Introduce Time Primitive Over DateTimeImmutable

### DIFF
--- a/src/Time/Iso.php
+++ b/src/Time/Iso.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Time;
+
+use Override;
+use Primus\Text\Text;
+
+/**
+ * ISO-8601 textual representation of a Time.
+ *
+ * Formatting follows PHP DateTimeImmutable's `c` format (ISO-8601 with
+ * timezone offset). The Time is resolved on each value() call.
+ *
+ * Example:
+ *     $iso = new Iso(new TimeOf('2026-05-12T10:00:00Z'));
+ *     $iso->value(); // "2026-05-12T10:00:00+00:00"
+ */
+final readonly class Iso implements Text
+{
+    /**
+     * Ctor.
+     *
+     * @param Time $origin The time to format.
+     */
+    public function __construct(private Time $origin) {}
+
+    #[Override]
+    public function value(): string
+    {
+        return $this->origin->value()->format('c');
+    }
+}

--- a/src/Time/Now.php
+++ b/src/Time/Now.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Time;
+
+use DateTimeImmutable;
+use Override;
+
+/**
+ * The moment the value() accessor is called.
+ *
+ * Each call captures a fresh instant; the object holds no fixed time.
+ *
+ * Example:
+ *     $now = new Now();
+ *     $now->value(); // current DateTimeImmutable
+ */
+final readonly class Now implements Time
+{
+    #[Override]
+    public function value(): DateTimeImmutable
+    {
+        return new DateTimeImmutable();
+    }
+}

--- a/src/Time/Time.php
+++ b/src/Time/Time.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Time;
+
+use DateTimeImmutable;
+
+/**
+ * Represents a moment in time as an immutable PHP DateTimeImmutable.
+ */
+interface Time
+{
+    /**
+     * Returns the moment this Time represents.
+     */
+    public function value(): DateTimeImmutable;
+}

--- a/src/Time/TimeOf.php
+++ b/src/Time/TimeOf.php
@@ -23,13 +23,13 @@ final readonly class TimeOf implements Time
     /**
      * Ctor.
      *
-     * @param string $iso The textual moment in any format accepted by DateTimeImmutable.
+     * @param string $datetime The textual moment in any format accepted by DateTimeImmutable.
      */
-    public function __construct(private string $iso) {}
+    public function __construct(private string $datetime) {}
 
     #[Override]
     public function value(): DateTimeImmutable
     {
-        return new DateTimeImmutable($this->iso);
+        return new DateTimeImmutable($this->datetime);
     }
 }

--- a/src/Time/TimeOf.php
+++ b/src/Time/TimeOf.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Time;
+
+use DateTimeImmutable;
+use Override;
+
+/**
+ * Time parsed from a textual representation on access.
+ *
+ * The string is interpreted by PHP's DateTimeImmutable constructor,
+ * which accepts ISO-8601, RFC-3339, "now", "tomorrow", and other
+ * relative formats. Parsing happens at each value() call.
+ *
+ * Example:
+ *     $t = new TimeOf('2026-05-12T10:00:00Z');
+ *     $t->value(); // DateTimeImmutable @ 2026-05-12 10:00:00 UTC
+ */
+final readonly class TimeOf implements Time
+{
+    /**
+     * Ctor.
+     *
+     * @param string $iso The textual moment in any format accepted by DateTimeImmutable.
+     */
+    public function __construct(private string $iso) {}
+
+    #[Override]
+    public function value(): DateTimeImmutable
+    {
+        return new DateTimeImmutable($this->iso);
+    }
+}

--- a/tests/Time/IsoTest.php
+++ b/tests/Time/IsoTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Time;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Time\Iso;
+use Primus\Time\TimeOf;
+
+final class IsoTest extends TestCase
+{
+    #[Test]
+    public function formatsUtcMomentWithOffset(): void
+    {
+        $this->assertSame(
+            '2026-05-12T10:00:00+00:00',
+            (new Iso(new TimeOf('2026-05-12T10:00:00Z')))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesOffsetFromInput(): void
+    {
+        $this->assertSame(
+            '2026-05-12T13:00:00+03:00',
+            (new Iso(new TimeOf('2026-05-12T13:00:00+03:00')))->value(),
+        );
+    }
+
+    #[Test]
+    public function formatsDateOnlyAsMidnightWithSystemOffset(): void
+    {
+        $iso = (new Iso(new TimeOf('2026-05-12')))->value();
+
+        $this->assertStringStartsWith('2026-05-12T00:00:00', $iso);
+    }
+}

--- a/tests/Time/NowTest.php
+++ b/tests/Time/NowTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Time;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Time\Now;
+
+final class NowTest extends TestCase
+{
+    #[Test]
+    public function returnsRecentMoment(): void
+    {
+        $before = time();
+        $now = (new Now())->value()->getTimestamp();
+        $after = time();
+
+        $this->assertGreaterThanOrEqual($before, $now);
+        $this->assertLessThanOrEqual($after, $now);
+    }
+
+    #[Test]
+    public function repeatedCallsCaptureDistinctReads(): void
+    {
+        $now = new Now();
+        $first = $now->value();
+        usleep(2000);
+        $second = $now->value();
+
+        $this->assertGreaterThanOrEqual($first, $second);
+    }
+}

--- a/tests/Time/TimeOfTest.php
+++ b/tests/Time/TimeOfTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Time;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Time\TimeOf;
+
+final class TimeOfTest extends TestCase
+{
+    #[Test]
+    public function parsesIsoDateTime(): void
+    {
+        $this->assertSame(
+            '2026-05-12T10:00:00+00:00',
+            (new TimeOf('2026-05-12T10:00:00Z'))->value()->format('c'),
+        );
+    }
+
+    #[Test]
+    public function parsesDateOnlyAsMidnight(): void
+    {
+        $this->assertSame(
+            '2026-05-12 00:00:00',
+            (new TimeOf('2026-05-12'))->value()->format('Y-m-d H:i:s'),
+        );
+    }
+
+    #[Test]
+    public function repeatedCallsReturnEqualValues(): void
+    {
+        $time = new TimeOf('2026-05-12T10:00:00Z');
+
+        $this->assertEquals($time->value(), $time->value());
+    }
+}


### PR DESCRIPTION
- Added Primus\Time\Time interface with a single value() accessor returning DateTimeImmutable
- Added Primus\Time\TimeOf as a string-source that parses on each accessor call via DateTimeImmutable's native parser
- Added Primus\Time\Now that returns the current moment captured at each accessor call
- Added Primus\Time\Iso as a Text view that formats any Time using ISO-8601 with offset
- Added TimeOfTest, NowTest, IsoTest covering parse, midnight default, repeated reads, monotonic Now, UTC offset, custom offset

Closes #156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added time handling: ISO-8601 formatting, a provider for the current moment, and parsing of ISO/formatted date strings.

* **Tests**
  * Added comprehensive tests verifying ISO formatting, current-time behavior, parsing of date-only inputs, and consistency of repeated reads.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/157)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->