### PR TITLE
Introduce Bytes Primitive With Base64 And Hex Codecs

### DIFF
--- a/src/Bytes/Base64Decoded.php
+++ b/src/Bytes/Base64Decoded.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Bytes;
+
+use InvalidArgumentException;
+use Override;
+use Primus\Text\Text;
+
+/**
+ * Raw bytes decoded from a Base64-encoded Text.
+ *
+ * Strict decoding is used: any character outside the Base64 alphabet
+ * rejects access with InvalidArgumentException.
+ *
+ * Example:
+ *     $bytes = new Base64Decoded(new TextOf("aGVsbG8="));
+ *     $bytes->value(); // "hello"
+ */
+final readonly class Base64Decoded implements Bytes
+{
+    /**
+     * Ctor.
+     *
+     * @param Text $origin The Base64 text to decode.
+     */
+    public function __construct(private Text $origin) {}
+
+    #[Override]
+    public function value(): string
+    {
+        $decoded = base64_decode($this->origin->value(), true);
+
+        return is_string($decoded)
+            ? $decoded
+            : throw new InvalidArgumentException('Invalid Base64 input');
+    }
+}

--- a/src/Bytes/Base64Encoded.php
+++ b/src/Bytes/Base64Encoded.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Bytes;
+
+use Override;
+use Primus\Text\Text;
+
+/**
+ * Canonical Base64 textual representation of Bytes.
+ *
+ * Example:
+ *     $text = new Base64Encoded(new BytesOf("hello"));
+ *     $text->value(); // "aGVsbG8="
+ */
+final readonly class Base64Encoded implements Text
+{
+    /**
+     * Ctor.
+     *
+     * @param Bytes $origin The bytes to encode.
+     */
+    public function __construct(private Bytes $origin) {}
+
+    #[Override]
+    public function value(): string
+    {
+        return base64_encode($this->origin->value());
+    }
+}

--- a/src/Bytes/Bytes.php
+++ b/src/Bytes/Bytes.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Bytes;
+
+/**
+ * Represents a sequence of raw binary bytes.
+ *
+ * In PHP, a binary byte sequence is just a string; the contract makes
+ * the binary intent explicit and composable.
+ */
+interface Bytes
+{
+    /**
+     * Returns the raw binary byte sequence.
+     */
+    public function value(): string;
+}

--- a/src/Bytes/BytesOf.php
+++ b/src/Bytes/BytesOf.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Bytes;
+
+use Override;
+
+/**
+ * Bytes wrapping a raw binary string.
+ *
+ * Example:
+ *     $b = new BytesOf("hello");
+ *     $b->value(); // "hello"
+ */
+final readonly class BytesOf implements Bytes
+{
+    /**
+     * Ctor.
+     *
+     * @param string $value The raw binary byte sequence.
+     */
+    public function __construct(private string $value) {}
+
+    #[Override]
+    public function value(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Bytes/HexDecoded.php
+++ b/src/Bytes/HexDecoded.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Bytes;
+
+use InvalidArgumentException;
+use Override;
+use Primus\Text\Text;
+
+/**
+ * Raw bytes decoded from hexadecimal Text.
+ *
+ * Input must contain only hexadecimal characters in pairs; an odd
+ * length or any non-hex character rejects access with
+ * InvalidArgumentException.
+ *
+ * Example:
+ *     $bytes = new HexDecoded(new TextOf("6869"));
+ *     $bytes->value(); // "hi"
+ */
+final readonly class HexDecoded implements Bytes
+{
+    /**
+     * Ctor.
+     *
+     * @param Text $origin The hexadecimal text to decode.
+     */
+    public function __construct(private Text $origin) {}
+
+    #[Override]
+    public function value(): string
+    {
+        $decoded = @hex2bin($this->origin->value());
+
+        return is_string($decoded)
+            ? $decoded
+            : throw new InvalidArgumentException('Invalid hexadecimal input');
+    }
+}

--- a/src/Bytes/HexEncoded.php
+++ b/src/Bytes/HexEncoded.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Bytes;
+
+use Override;
+use Primus\Text\Text;
+
+/**
+ * Lowercase hexadecimal representation of Bytes.
+ *
+ * Each byte becomes two hex digits; the result has even length.
+ *
+ * Example:
+ *     $text = new HexEncoded(new BytesOf("hi"));
+ *     $text->value(); // "6869"
+ */
+final readonly class HexEncoded implements Text
+{
+    /**
+     * Ctor.
+     *
+     * @param Bytes $origin The bytes to encode.
+     */
+    public function __construct(private Bytes $origin) {}
+
+    #[Override]
+    public function value(): string
+    {
+        return bin2hex($this->origin->value());
+    }
+}

--- a/tests/Bytes/Base64Test.php
+++ b/tests/Bytes/Base64Test.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Bytes;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Bytes\Base64Decoded;
+use Primus\Bytes\Base64Encoded;
+use Primus\Bytes\BytesOf;
+use Primus\Text\TextOf;
+
+final class Base64Test extends TestCase
+{
+    #[Test]
+    public function encodesAsciiToCanonicalBase64(): void
+    {
+        $this->assertSame('aGVsbG8=', (new Base64Encoded(new BytesOf('hello')))->value());
+    }
+
+    #[Test]
+    public function encodesEmptyBytesToEmptyString(): void
+    {
+        $this->assertSame('', (new Base64Encoded(new BytesOf('')))->value());
+    }
+
+    #[Test]
+    public function decodesBase64BackToOriginal(): void
+    {
+        $this->assertSame('hello', (new Base64Decoded(new TextOf('aGVsbG8=')))->value());
+    }
+
+    #[Test]
+    public function decodesEmptyStringToEmptyBytes(): void
+    {
+        $this->assertSame('', (new Base64Decoded(new TextOf('')))->value());
+    }
+
+    #[Test]
+    public function roundTripPreservesBinaryBytesWithNulls(): void
+    {
+        $bytes = "\x00\x01\xff\xfe";
+        $this->assertSame(
+            $bytes,
+            (new Base64Decoded(new TextOf((new Base64Encoded(new BytesOf($bytes)))->value())))->value(),
+        );
+    }
+
+    #[Test]
+    public function rejectsInvalidBase64Input(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new Base64Decoded(new TextOf('not_valid!!!')))->value();
+    }
+}

--- a/tests/Bytes/BytesOfTest.php
+++ b/tests/Bytes/BytesOfTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Bytes;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Bytes\BytesOf;
+
+final class BytesOfTest extends TestCase
+{
+    #[Test]
+    public function returnsWrappedStringUnchanged(): void
+    {
+        $this->assertSame('hello', (new BytesOf('hello'))->value());
+    }
+
+    #[Test]
+    public function returnsEmptyStringUnchanged(): void
+    {
+        $this->assertSame('', (new BytesOf(''))->value());
+    }
+
+    #[Test]
+    public function preservesBinaryBytesWithNulls(): void
+    {
+        $this->assertSame("\x00\x01\xff", (new BytesOf("\x00\x01\xff"))->value());
+    }
+}

--- a/tests/Bytes/HexTest.php
+++ b/tests/Bytes/HexTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Bytes;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Bytes\BytesOf;
+use Primus\Bytes\HexDecoded;
+use Primus\Bytes\HexEncoded;
+use Primus\Text\TextOf;
+
+final class HexTest extends TestCase
+{
+    #[Test]
+    public function encodesAsciiToLowercaseHex(): void
+    {
+        $this->assertSame('6869', (new HexEncoded(new BytesOf('hi')))->value());
+    }
+
+    #[Test]
+    public function encodesEmptyBytesToEmptyString(): void
+    {
+        $this->assertSame('', (new HexEncoded(new BytesOf('')))->value());
+    }
+
+    #[Test]
+    public function encodesBinaryBytesIncludingHighRange(): void
+    {
+        $this->assertSame('00ff', (new HexEncoded(new BytesOf("\x00\xff")))->value());
+    }
+
+    #[Test]
+    public function decodesHexBackToOriginal(): void
+    {
+        $this->assertSame('hi', (new HexDecoded(new TextOf('6869')))->value());
+    }
+
+    #[Test]
+    public function decodesEmptyStringToEmptyBytes(): void
+    {
+        $this->assertSame('', (new HexDecoded(new TextOf('')))->value());
+    }
+
+    #[Test]
+    public function roundTripPreservesBinaryBytesWithNulls(): void
+    {
+        $bytes = "\x00\x01\xff\xfe";
+        $this->assertSame(
+            $bytes,
+            (new HexDecoded(new TextOf((new HexEncoded(new BytesOf($bytes)))->value())))->value(),
+        );
+    }
+
+    #[Test]
+    public function rejectsOddLengthHexInput(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new HexDecoded(new TextOf('abc')))->value();
+    }
+
+    #[Test]
+    public function rejectsNonHexCharacters(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new HexDecoded(new TextOf('zz')))->value();
+    }
+}


### PR DESCRIPTION
- Added Primus\Bytes\Bytes interface with a single value() accessor returning a raw binary string
- Added BytesOf wrapping a raw string unchanged
- Added Base64Encoded (Bytes → Text) and Base64Decoded (Text → Bytes) with strict decoding that rejects invalid input
- Added HexEncoded (Bytes → Text, lowercase) and HexDecoded (Text → Bytes) with rejection for odd length or non-hex characters
- Added BytesOfTest, Base64Test, HexTest covering ASCII, empty input, binary bytes with nulls, round-trip identity, and invalid-input rejection

Closes #158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added binary data representation and manipulation capabilities
  * Base64 encoding/decoding with strict validation for converting between binary data and ASCII-safe text format
  * Hexadecimal encoding/decoding with validation for converting between binary data and hex string representation
  * Handles edge cases including empty data and binary content with null bytes

* **Tests**
  * Added comprehensive test coverage for all encoding and decoding operations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/159)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->