### PR TITLE
Hash Bytes Through Md5 And Sha256 Decorators

### DIFF
--- a/src/Bytes/Md5.php
+++ b/src/Bytes/Md5.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Bytes;
+
+use Override;
+
+/**
+ * Raw 16-byte MD5 digest of an origin Bytes.
+ *
+ * Compose with {@see HexEncoded} for the canonical hexadecimal form.
+ *
+ * Example:
+ *     $hex = new HexEncoded(new Md5(new BytesOf('hello')));
+ *     $hex->value(); // "5d41402abc4b2a76b9719d911017c592"
+ */
+final readonly class Md5 implements Bytes
+{
+    /**
+     * Ctor.
+     *
+     * @param Bytes $origin The bytes to hash.
+     */
+    public function __construct(private Bytes $origin) {}
+
+    #[Override]
+    public function value(): string
+    {
+        return hash('md5', $this->origin->value(), true);
+    }
+}

--- a/src/Bytes/Sha256.php
+++ b/src/Bytes/Sha256.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Bytes;
+
+use Override;
+
+/**
+ * Raw 32-byte SHA-256 digest of an origin Bytes.
+ *
+ * Compose with {@see HexEncoded} for the canonical hexadecimal form.
+ *
+ * Example:
+ *     $hex = new HexEncoded(new Sha256(new BytesOf('hello')));
+ *     $hex->value(); // "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+ */
+final readonly class Sha256 implements Bytes
+{
+    /**
+     * Ctor.
+     *
+     * @param Bytes $origin The bytes to hash.
+     */
+    public function __construct(private Bytes $origin) {}
+
+    #[Override]
+    public function value(): string
+    {
+        return hash('sha256', $this->origin->value(), true);
+    }
+}

--- a/tests/Bytes/Md5Test.php
+++ b/tests/Bytes/Md5Test.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Bytes;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Bytes\BytesOf;
+use Primus\Bytes\HexEncoded;
+use Primus\Bytes\Md5;
+
+final class Md5Test extends TestCase
+{
+    #[Test]
+    public function digestOfAsciiMatchesKnownHex(): void
+    {
+        $this->assertSame(
+            '5d41402abc4b2a76b9719d911017c592',
+            (new HexEncoded(new Md5(new BytesOf('hello'))))->value(),
+        );
+    }
+
+    #[Test]
+    public function digestOfEmptyMatchesKnownHex(): void
+    {
+        $this->assertSame(
+            'd41d8cd98f00b204e9800998ecf8427e',
+            (new HexEncoded(new Md5(new BytesOf(''))))->value(),
+        );
+    }
+
+    #[Test]
+    public function rawDigestIsSixteenBytes(): void
+    {
+        $this->assertSame(16, strlen((new Md5(new BytesOf('hello')))->value()));
+    }
+
+    #[Test]
+    public function repeatedCallsReturnSameDigest(): void
+    {
+        $md5 = new Md5(new BytesOf('hello'));
+
+        $this->assertSame($md5->value(), $md5->value());
+    }
+}

--- a/tests/Bytes/Sha256Test.php
+++ b/tests/Bytes/Sha256Test.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Bytes;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Bytes\BytesOf;
+use Primus\Bytes\HexEncoded;
+use Primus\Bytes\Sha256;
+
+final class Sha256Test extends TestCase
+{
+    #[Test]
+    public function digestOfAsciiMatchesKnownHex(): void
+    {
+        $this->assertSame(
+            '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
+            (new HexEncoded(new Sha256(new BytesOf('hello'))))->value(),
+        );
+    }
+
+    #[Test]
+    public function digestOfEmptyMatchesKnownHex(): void
+    {
+        $this->assertSame(
+            'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+            (new HexEncoded(new Sha256(new BytesOf(''))))->value(),
+        );
+    }
+
+    #[Test]
+    public function rawDigestIsThirtyTwoBytes(): void
+    {
+        $this->assertSame(32, strlen((new Sha256(new BytesOf('hello')))->value()));
+    }
+
+    #[Test]
+    public function repeatedCallsReturnSameDigest(): void
+    {
+        $sha = new Sha256(new BytesOf('hello'));
+
+        $this->assertSame($sha->value(), $sha->value());
+    }
+}


### PR DESCRIPTION
- Added Primus\Bytes\Md5 that exposes the raw 16-byte MD5 digest of an origin Bytes
- Added Primus\Bytes\Sha256 that exposes the raw 32-byte SHA-256 digest of an origin Bytes
- Added Md5Test and Sha256Test covering known-hex digests (composed via HexEncoded), empty input, raw byte length, and repeated-call stability

Closes #160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MD5 cryptographic hash computation for message digest generation
  * Added SHA-256 cryptographic hash computation for message digest generation
  * Both implementations deliver consistent, reliable cryptographic output

* **Tests**
  * Comprehensive test coverage added for MD5 and SHA-256, verifying digest accuracy and consistency of repeated operations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/161)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->