### PR TITLE
Random UUID v4 From Injectable Bytes Source

### DIFF
--- a/src/Bytes/RandomBytes.php
+++ b/src/Bytes/RandomBytes.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Bytes;
+
+use Override;
+
+/**
+ * Cryptographically random bytes of the requested length.
+ *
+ * Each value() call reads fresh entropy from the system CSPRNG, so two
+ * consecutive calls on the same instance return different bytes.
+ *
+ * Example:
+ *     $bytes = new RandomBytes(16);
+ *     $bytes->value(); // 16 unpredictable bytes
+ */
+final readonly class RandomBytes implements Bytes
+{
+    /**
+     * Ctor.
+     *
+     * @param positive-int $length Number of random bytes to produce.
+     */
+    public function __construct(private int $length) {}
+
+    #[Override]
+    public function value(): string
+    {
+        return random_bytes($this->length);
+    }
+}

--- a/src/Bytes/UuidV4.php
+++ b/src/Bytes/UuidV4.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Bytes;
+
+use InvalidArgumentException;
+use Override;
+
+/**
+ * Raw 16-byte UUID version 4 derived from a Bytes random source.
+ *
+ * Reads 16 bytes from the source on each value() call, then forces the
+ * version (byte 6 high nibble = 0x4) and variant (byte 8 high bits = 0b10)
+ * fields per RFC 9562.
+ *
+ * Compose with {@see HexEncoded} for canonical hexadecimal form.
+ *
+ * Example:
+ *     $hex = new HexEncoded(new UuidV4(new RandomBytes(16)));
+ *     $hex->value(); // 32 lowercase hex chars, e.g. "550e8400e29b41d4a716446655440000"
+ */
+final readonly class UuidV4 implements Bytes
+{
+    private const int UUID_LENGTH = 16;
+    private const int VERSION_BYTE = 6;
+    private const int VERSION_MASK = 0x0F;
+    private const int VERSION_4 = 0x40;
+    private const int VARIANT_BYTE = 8;
+    private const int VARIANT_MASK = 0x3F;
+    private const int VARIANT_RFC9562 = 0x80;
+
+    /**
+     * Ctor.
+     *
+     * @param Bytes $source Random byte source providing at least 16 bytes.
+     */
+    public function __construct(private Bytes $source) {}
+
+    #[Override]
+    public function value(): string
+    {
+        $raw = $this->source->value();
+
+        if (strlen($raw) < self::UUID_LENGTH) {
+            throw new InvalidArgumentException('UuidV4 source must provide at least 16 bytes');
+        }
+
+        $bytes = substr($raw, 0, self::UUID_LENGTH);
+        $bytes[self::VERSION_BYTE] = chr((ord($bytes[self::VERSION_BYTE]) & self::VERSION_MASK) | self::VERSION_4);
+        $bytes[self::VARIANT_BYTE] = chr(
+            (ord($bytes[self::VARIANT_BYTE]) & self::VARIANT_MASK) | self::VARIANT_RFC9562,
+        );
+
+        return $bytes;
+    }
+}

--- a/tests/Bytes/RandomBytesTest.php
+++ b/tests/Bytes/RandomBytesTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Bytes;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Bytes\RandomBytes;
+
+final class RandomBytesTest extends TestCase
+{
+    #[Test]
+    public function producesRequestedLength(): void
+    {
+        $this->assertSame(16, strlen((new RandomBytes(16))->value()));
+    }
+
+    #[Test]
+    public function producesAnotherRequestedLength(): void
+    {
+        $this->assertSame(32, strlen((new RandomBytes(32))->value()));
+    }
+
+    #[Test]
+    public function consecutiveCallsDifferOnSameInstance(): void
+    {
+        $bytes = new RandomBytes(16);
+
+        $this->assertNotSame($bytes->value(), $bytes->value());
+    }
+}

--- a/tests/Bytes/UuidV4Test.php
+++ b/tests/Bytes/UuidV4Test.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Bytes;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Bytes\BytesOf;
+use Primus\Bytes\HexEncoded;
+use Primus\Bytes\RandomBytes;
+use Primus\Bytes\UuidV4;
+
+final class UuidV4Test extends TestCase
+{
+    #[Test]
+    public function valueIsSixteenBytes(): void
+    {
+        $this->assertSame(16, strlen((new UuidV4(new RandomBytes(16)))->value()));
+    }
+
+    #[Test]
+    public function versionNibbleIsFour(): void
+    {
+        $bytes = (new UuidV4(new RandomBytes(16)))->value();
+
+        $this->assertSame(0x40, ord($bytes[6]) & 0xF0);
+    }
+
+    #[Test]
+    public function variantBitsAreRfc9562(): void
+    {
+        $bytes = (new UuidV4(new RandomBytes(16)))->value();
+
+        $this->assertSame(0x80, ord($bytes[8]) & 0xC0);
+    }
+
+    #[Test]
+    public function consecutiveCallsRereadSource(): void
+    {
+        $uuid = new UuidV4(new RandomBytes(16));
+
+        $this->assertNotSame($uuid->value(), $uuid->value());
+    }
+
+    #[Test]
+    public function preservesNonVersionVariantBitsFromSource(): void
+    {
+        $source = new BytesOf(str_repeat("\x00", 16));
+
+        $bytes = (new UuidV4($source))->value();
+
+        $this->assertSame("\x00\x00\x00\x00\x00\x00\x40\x00\x80\x00\x00\x00\x00\x00\x00\x00", $bytes);
+    }
+
+    #[Test]
+    public function composesWithHexEncodedToCanonicalForm(): void
+    {
+        $source = new BytesOf(str_repeat("\xff", 16));
+
+        $this->assertSame(
+            'ffffffffffff4fffbfffffffffffffff',
+            (new HexEncoded(new UuidV4($source)))->value(),
+        );
+    }
+
+    #[Test]
+    public function rejectsTooShortSource(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new UuidV4(new BytesOf('short')))->value();
+    }
+}


### PR DESCRIPTION
- Added RandomBytes for cryptographically random byte sequences
- Added UuidV4 producing 16-byte RFC 9562 UUIDs from any Bytes source
- Updated Bytes namespace with composable random-identity primitives

Part of #162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cryptographically secure random bytes generation supporting configurable lengths for flexible security use cases.
  * UUID v4 generation with RFC 9562 compliance, ensuring proper version and variant bits for standards-compliant universally unique identifiers.

* **Tests**
  * Comprehensive test coverage added to validate cryptographic random bytes generation and UUID v4 specification compliance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/163)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->