### PR TITLE
Time-Ordered UUID v7 From Time And Bytes Sources

### DIFF
--- a/src/Bytes/UuidV7.php
+++ b/src/Bytes/UuidV7.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Bytes;
+
+use InvalidArgumentException;
+use Override;
+use Primus\Time\Time;
+
+/**
+ * Raw 16-byte UUID version 7 derived from a Time source and a Bytes random source.
+ *
+ * Encodes 48 bits of Unix milliseconds (big-endian) in bytes 0-5, then forces
+ * the version (byte 6 high nibble = 0x7) and variant (byte 8 high bits = 0b10)
+ * fields per RFC 9562. The remaining bits come from the random source.
+ *
+ * Compose with {@see HexEncoded} for canonical hexadecimal form.
+ *
+ * Example:
+ *     $hex = new HexEncoded(new UuidV7(new Now(), new RandomBytes(10)));
+ *     $hex->value(); // 32 lowercase hex chars, first 12 digits encode the timestamp
+ */
+final readonly class UuidV7 implements Bytes
+{
+    private const int TIME_BYTES = 6;
+    private const int TIME_BYTES_OFFSET = 2;
+    private const int RANDOM_BYTES_REQUIRED = 10;
+    private const int VERSION_BYTE = 6;
+    private const int VERSION_MASK = 0x0F;
+    private const int VERSION_7 = 0x70;
+    private const int VARIANT_BYTE = 8;
+    private const int VARIANT_MASK = 0x3F;
+    private const int VARIANT_RFC9562 = 0x80;
+
+    /**
+     * Ctor.
+     *
+     * @param Time $time Time source providing the moment to encode.
+     * @param Bytes $random Random byte source providing at least 10 bytes.
+     */
+    public function __construct(private Time $time, private Bytes $random) {}
+
+    #[Override]
+    public function value(): string
+    {
+        $rand = $this->random->value();
+
+        if (strlen($rand) < self::RANDOM_BYTES_REQUIRED) {
+            throw new InvalidArgumentException(
+                sprintf('UuidV7 random source must provide at least %d bytes', self::RANDOM_BYTES_REQUIRED),
+            );
+        }
+
+        $unixMs = (int) $this->time->value()->format('Uv');
+        $timeBytes = substr(pack('J', $unixMs), self::TIME_BYTES_OFFSET, self::TIME_BYTES);
+        $bytes = $timeBytes . substr($rand, 0, self::RANDOM_BYTES_REQUIRED);
+        $bytes[self::VERSION_BYTE] = chr((ord($bytes[self::VERSION_BYTE]) & self::VERSION_MASK) | self::VERSION_7);
+        $bytes[self::VARIANT_BYTE] = chr(
+            (ord($bytes[self::VARIANT_BYTE]) & self::VARIANT_MASK) | self::VARIANT_RFC9562,
+        );
+
+        return $bytes;
+    }
+}

--- a/tests/Bytes/UuidV7Test.php
+++ b/tests/Bytes/UuidV7Test.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Bytes;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Bytes\BytesOf;
+use Primus\Bytes\HexEncoded;
+use Primus\Bytes\RandomBytes;
+use Primus\Bytes\UuidV7;
+use Primus\Time\TimeOf;
+
+final class UuidV7Test extends TestCase
+{
+    #[Test]
+    public function valueIsSixteenBytes(): void
+    {
+        $this->assertSame(
+            16,
+            strlen((new UuidV7(new TimeOf('2026-05-12T12:00:00Z'), new RandomBytes(10)))->value()),
+        );
+    }
+
+    #[Test]
+    public function versionNibbleIsSeven(): void
+    {
+        $bytes = (new UuidV7(new TimeOf('2026-05-12T12:00:00Z'), new RandomBytes(10)))->value();
+
+        $this->assertSame(0x70, ord($bytes[6]) & 0xF0);
+    }
+
+    #[Test]
+    public function variantBitsAreRfc9562(): void
+    {
+        $bytes = (new UuidV7(new TimeOf('2026-05-12T12:00:00Z'), new RandomBytes(10)))->value();
+
+        $this->assertSame(0x80, ord($bytes[8]) & 0xC0);
+    }
+
+    #[Test]
+    public function encodesUnixMillisecondsAsBigEndianInLeadingSixBytes(): void
+    {
+        $time = new TimeOf('1970-01-01T00:00:00.001Z');
+        $random = new BytesOf(str_repeat("\x00", 10));
+
+        $bytes = (new UuidV7($time, $random))->value();
+
+        $this->assertSame("\x00\x00\x00\x00\x00\x01", substr($bytes, 0, 6));
+    }
+
+    #[Test]
+    public function encodesLaterTimestampAsHigherLeadingBytes(): void
+    {
+        $earlier = (new UuidV7(new TimeOf('2026-05-12T12:00:00Z'), new BytesOf(str_repeat("\x00", 10))))->value();
+        $later = (new UuidV7(new TimeOf('2026-05-12T12:00:01Z'), new BytesOf(str_repeat("\x00", 10))))->value();
+
+        $this->assertGreaterThan(substr($earlier, 0, 6), substr($later, 0, 6));
+    }
+
+    #[Test]
+    public function preservesNonVersionVariantBitsFromRandomSource(): void
+    {
+        $time = new TimeOf('1970-01-01T00:00:00Z');
+        $random = new BytesOf(str_repeat("\x00", 10));
+
+        $bytes = (new UuidV7($time, $random))->value();
+
+        $this->assertSame("\x00\x00\x00\x00\x00\x00\x70\x00\x80\x00\x00\x00\x00\x00\x00\x00", $bytes);
+    }
+
+    #[Test]
+    public function composesWithHexEncodedToCanonicalForm(): void
+    {
+        $time = new TimeOf('1970-01-01T00:00:00Z');
+        $random = new BytesOf(str_repeat("\xff", 10));
+
+        $this->assertSame(
+            '0000000000007fffbfffffffffffffff',
+            (new HexEncoded(new UuidV7($time, $random)))->value(),
+        );
+    }
+
+    #[Test]
+    public function consecutiveCallsRereadSources(): void
+    {
+        $uuid = new UuidV7(new TimeOf('2026-05-12T12:00:00Z'), new RandomBytes(10));
+
+        $this->assertNotSame($uuid->value(), $uuid->value());
+    }
+
+    #[Test]
+    public function rejectsTooShortRandomSource(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new UuidV7(new TimeOf('2026-05-12T12:00:00Z'), new BytesOf('short')))->value();
+    }
+}


### PR DESCRIPTION
- Added UuidV7 encoding 48-bit Unix milliseconds with RFC 9562 version/variant bits
- Updated Bytes namespace with composable time-ordered identity primitives

Closes #164
Closes #162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * UUID v7 generation now supported with RFC 9562 compliance

* **Tests**
  * Comprehensive test coverage added for UUID v7 functionality, including timestamp encoding, variant validation, and random source handling

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/165)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->