### PR TITLE
Side-Effect Iteration And One-Shot Procedure

### DIFF
--- a/src/Func/ForEach_.php
+++ b/src/Func/ForEach_.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Func;
+
+use Primus\List\List_;
+
+/**
+ * Applies a Proc to each element of a List in iteration order.
+ *
+ * Example:
+ *     $log = new ForEach_(
+ *         new ListOf(['a', 'b']),
+ *         new ProcOf(fn(string $s) => error_log($s)),
+ *     );
+ *     $log->exec(); // error_log('a'); error_log('b');
+ *
+ * @template T
+ */
+final readonly class ForEach_
+{
+    /**
+     * Ctor.
+     *
+     * @param List_<T> $list The list to iterate over.
+     * @param Proc<T> $proc The procedure to apply to each element.
+     */
+    public function __construct(private List_ $list, private Proc $proc) {}
+
+    /**
+     * Apply the procedure to each element.
+     */
+    public function exec(): void
+    {
+        foreach ($this->list as $element) {
+            $this->proc->exec($element);
+        }
+    }
+}

--- a/src/Func/RunOnce.php
+++ b/src/Func/RunOnce.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Func;
+
+use Override;
+
+/**
+ * Delegates exec() to the origin only on the first call; subsequent calls are no-ops.
+ *
+ * Holds a private boolean flag that flips before delegating to the origin. This
+ * is the single primitive in Primus that intentionally departs from the
+ * readonly doctrine — memoization of "already executed" inherently requires
+ * mutation. If the origin throws, the slot is still consumed — subsequent
+ * calls remain no-ops.
+ *
+ * Example:
+ *     $init = new RunOnce(new ProcOf(fn() => bootstrap()));
+ *     $init->exec(null); // bootstrap() runs
+ *     $init->exec(null); // no-op
+ *
+ * @template X
+ * @implements Proc<X>
+ */
+final class RunOnce implements Proc
+{
+    /** @phpstan-ignore haspadar.immutable (RunOnce is the documented mutable-state exception in Primus — memoization of "already executed" inherently requires mutation) */
+    private bool $done = false;
+
+    /**
+     * Ctor.
+     *
+     * @param Proc<X> $origin The procedure to run once.
+     */
+    public function __construct(private readonly Proc $origin) {}
+
+    #[Override]
+    public function exec(mixed $input): void
+    {
+        if ($this->done) {
+            return;
+        }
+
+        $this->done = true;
+        $this->origin->exec($input);
+    }
+}

--- a/tests/Func/ForEach_Test.php
+++ b/tests/Func/ForEach_Test.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Func;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Func\ForEach_;
+use Primus\Func\ProcOf;
+use Primus\List\ListOf;
+
+final class ForEach_Test extends TestCase
+{
+    #[Test]
+    public function appliesProcToEachElementInOrder(): void
+    {
+        $collected = [];
+
+        (new ForEach_(
+            new ListOf('a', 'b', 'c'),
+            new ProcOf(static function (string $s) use (&$collected): void {
+                $collected[] = $s;
+            }),
+        ))->exec();
+
+        $this->assertSame(['a', 'b', 'c'], $collected);
+    }
+
+    #[Test]
+    public function emptyListIsNoOp(): void
+    {
+        $calls = 0;
+
+        (new ForEach_(
+            new ListOf(),
+            new ProcOf(static function () use (&$calls): void {
+                ++$calls;
+            }),
+        ))->exec();
+
+        $this->assertSame(0, $calls);
+    }
+
+}

--- a/tests/Func/RunOnceTest.php
+++ b/tests/Func/RunOnceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Func;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Func\ProcOf;
+use Primus\Func\RunOnce;
+
+final class RunOnceTest extends TestCase
+{
+    #[Test]
+    public function delegatesOnFirstCall(): void
+    {
+        $received = [];
+
+        $once = new RunOnce(new ProcOf(static function (string $input) use (&$received): void {
+            $received[] = $input;
+        }));
+
+        $once->exec('alpha');
+
+        $this->assertSame(['alpha'], $received);
+    }
+
+    #[Test]
+    public function ignoresSubsequentCalls(): void
+    {
+        $received = [];
+
+        $once = new RunOnce(new ProcOf(static function (string $input) use (&$received): void {
+            $received[] = $input;
+        }));
+
+        $once->exec('first');
+        $once->exec('second');
+        $once->exec('third');
+
+        $this->assertSame(['first'], $received);
+    }
+}


### PR DESCRIPTION
- Added ForEach_ applying a Proc to each element of a List_
- Added RunOnce delegating to a Proc on the first call only
- Documented RunOnce as the single mutable-state exception in Primus

Closes #166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an iterator utility to apply operations sequentially to each element in a list.
  * Added a wrapper utility to ensure operations execute only once, ignoring all subsequent invocations.

* **Tests**
  * Added comprehensive test coverage for the new utilities, verifying correct behavior across various scenarios including empty collections and repeated invocations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/167)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->