### PR TITLE
Unwrap Throwable Chain To Root Cause

### DIFF
--- a/src/Scalar/RootCause.php
+++ b/src/Scalar/RootCause.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Scalar;
+
+use Override;
+use Throwable;
+
+/**
+ * Deepest cause of a Throwable chain.
+ *
+ * Walks getPrevious() until a Throwable without a previous one is reached and
+ * returns it. For a Throwable without any cause, returns the input itself.
+ *
+ * Example:
+ *     $root = new RootCause($outer);
+ *     $root->value(); // the innermost Throwable in the chain
+ *
+ * @implements Scalar<Throwable>
+ */
+final readonly class RootCause implements Scalar
+{
+    /**
+     * Ctor.
+     *
+     * @param Throwable $origin The Throwable whose chain to unwrap.
+     */
+    public function __construct(private Throwable $origin) {}
+
+    #[Override]
+    public function value(): Throwable
+    {
+        $cause = $this->origin;
+
+        for ($previous = $cause->getPrevious(); $previous !== null; $previous = $cause->getPrevious()) {
+            $cause = $previous;
+        }
+
+        return $cause;
+    }
+}

--- a/tests/Scalar/RootCauseTest.php
+++ b/tests/Scalar/RootCauseTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Scalar;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Scalar\RootCause;
+use RuntimeException;
+
+final class RootCauseTest extends TestCase
+{
+    #[Test]
+    public function returnsInputWhenChainIsSingle(): void
+    {
+        $only = new RuntimeException('only');
+
+        $this->assertSame($only, (new RootCause($only))->value());
+    }
+
+    #[Test]
+    public function unwrapsTwoLevelChainToDeepest(): void
+    {
+        $inner = new RuntimeException('inner');
+        $outer = new RuntimeException('outer', 0, $inner);
+
+        $this->assertSame($inner, (new RootCause($outer))->value());
+    }
+
+    #[Test]
+    public function unwrapsDeepChainToDeepest(): void
+    {
+        $deepest = new RuntimeException('deepest');
+        $middle = new RuntimeException('middle', 0, $deepest);
+        $outer = new RuntimeException('outer', 0, $middle);
+
+        $this->assertSame($deepest, (new RootCause($outer))->value());
+    }
+
+    #[Test]
+    public function repeatedCallsReturnSameInstance(): void
+    {
+        $inner = new RuntimeException('inner');
+        $outer = new RuntimeException('outer', 0, $inner);
+
+        $root = new RootCause($outer);
+
+        $this->assertSame($root->value(), $root->value());
+    }
+}


### PR DESCRIPTION
- Added RootCause walking Throwable getPrevious chain to its deepest non-null cause
- Updated Scalar namespace with Throwable-aware unwrapping primitive

Closes #168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced RootCause scalar to traverse exception chains and extract the deepest underlying exception, providing clearer visibility into root causes of errors even in complex, deeply nested scenarios.

* **Tests**
  * Added comprehensive test suite covering all scenarios including single exceptions, multi-level chains, deeply nested chains, and consistent value retrieval across repeated calls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/169)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->