### PR TITLE
Memoize Number Projections Without Unwrapping

### DIFF
--- a/src/Number/Sticky.php
+++ b/src/Number/Sticky.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Number;
+
+use Override;
+
+/**
+ * Cached version of a {@see Number}.
+ *
+ * Evaluates each projection (asInt, asFloat) at most once and stores the
+ * result. Subsequent calls return the cached value instead of re-traversing
+ * the underlying decorator graph.
+ *
+ * This class is not thread-safe. To share cached data across threads use an
+ * external synchronization mechanism.
+ *
+ * Example:
+ *     $cached = new Sticky(new SumOf(...$deepTree));
+ *     $cached->asFloat(); // computed once, traverses the tree
+ *     $cached->asFloat(); // cached
+ *     $cached->asInt(); // computed once, traverses the tree
+ *     $cached->asInt(); // cached
+ */
+final class Sticky implements Number
+{
+    private const int EMPTY_INT = 0;
+    private const float EMPTY_FLOAT = 0.0;
+
+    /** @phpstan-ignore haspadar.immutable (lazy memoization flag; idempotent externally) */
+    private bool $intComputed = false;
+
+    /** @phpstan-ignore haspadar.immutable (lazy memoization slot; idempotent externally) */
+    private int $intStored = self::EMPTY_INT;
+
+    /** @phpstan-ignore haspadar.immutable (lazy memoization flag; idempotent externally) */
+    private bool $floatComputed = false;
+
+    /** @phpstan-ignore haspadar.immutable (lazy memoization slot; idempotent externally) */
+    private float $floatStored = self::EMPTY_FLOAT;
+
+    /**
+     * Ctor.
+     *
+     * @param Number $origin The number whose projections are cached.
+     */
+    public function __construct(private readonly Number $origin) {}
+
+    #[Override]
+    public function asInt(): int
+    {
+        if (!$this->intComputed) {
+            $this->intStored = $this->origin->asInt();
+            $this->intComputed = true;
+        }
+
+        return $this->intStored;
+    }
+
+    #[Override]
+    public function asFloat(): float
+    {
+        if (!$this->floatComputed) {
+            $this->floatStored = $this->origin->asFloat();
+            $this->floatComputed = true;
+        }
+
+        return $this->floatStored;
+    }
+}

--- a/tests/Number/Fakes/CountingNumber.php
+++ b/tests/Number/Fakes/CountingNumber.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Number\Fakes;
+
+use Override;
+use Primus\Number\Number;
+
+/**
+ * Number fake that counts how many times each projection is invoked.
+ *
+ * Used to verify caching behaviour of decorators such as {@see \Primus\Number\Sticky}.
+ */
+final class CountingNumber implements Number
+{
+    public int $intCalls = 0;
+    public int $floatCalls = 0;
+
+    public function __construct(private readonly int $intValue, private readonly float $floatValue) {}
+
+    #[Override]
+    public function asInt(): int
+    {
+        ++$this->intCalls;
+
+        return $this->intValue;
+    }
+
+    #[Override]
+    public function asFloat(): float
+    {
+        ++$this->floatCalls;
+
+        return $this->floatValue;
+    }
+}

--- a/tests/Number/StickyTest.php
+++ b/tests/Number/StickyTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Number;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Number\Sticky;
+use Primus\Tests\Number\Fakes\CountingNumber;
+
+final class StickyTest extends TestCase
+{
+    #[Test]
+    public function returnsSameIntOnRepeatedCalls(): void
+    {
+        $sticky = new Sticky(new CountingNumber(42, 3.14));
+
+        $this->assertSame(42, $sticky->asInt());
+        $this->assertSame(42, $sticky->asInt());
+    }
+
+    #[Test]
+    public function returnsSameFloatOnRepeatedCalls(): void
+    {
+        $sticky = new Sticky(new CountingNumber(42, 3.14));
+
+        $this->assertSame(3.14, $sticky->asFloat());
+        $this->assertSame(3.14, $sticky->asFloat());
+    }
+
+    #[Test]
+    public function callsOriginAsIntAtMostOnce(): void
+    {
+        $origin = new CountingNumber(42, 3.14);
+        $sticky = new Sticky($origin);
+
+        $sticky->asInt();
+        $sticky->asInt();
+        $sticky->asInt();
+
+        $this->assertSame(1, $origin->intCalls);
+    }
+
+    #[Test]
+    public function callsOriginAsFloatAtMostOnce(): void
+    {
+        $origin = new CountingNumber(42, 3.14);
+        $sticky = new Sticky($origin);
+
+        $sticky->asFloat();
+        $sticky->asFloat();
+        $sticky->asFloat();
+
+        $this->assertSame(1, $origin->floatCalls);
+    }
+
+    #[Test]
+    public function cachesIntAndFloatIndependently(): void
+    {
+        $origin = new CountingNumber(42, 3.14);
+        $sticky = new Sticky($origin);
+
+        $sticky->asInt();
+        $sticky->asFloat();
+
+        $this->assertSame(1, $origin->intCalls);
+        $this->assertSame(1, $origin->floatCalls);
+    }
+}


### PR DESCRIPTION
- Added Number\Sticky caching asInt() and asFloat() projections independently on first call
- Updated Number namespace with a memoizing decorator that preserves the Number contract end-to-end

Closes #173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automatic caching for numeric computations, storing calculated values to prevent redundant recalculations on repeated access.

* **Tests**
  * Added comprehensive test coverage validating that computations are cached independently and executed only once per projection type.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/174)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->