### PR TITLE
Add Public AGENTS.md Contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,402 @@
+# AGENTS.md
+
+Guidance for AI agents (Claude Code, Codex, Cursor, Aider, Gemini CLI,
+Continue, and any tool that respects the `agentsmd.org` convention) when
+working **with** the `haspadar/primus` library — either as a consumer
+through Composer or as a contributor inside the repository.
+
+This file is the public agent contract. Read it before touching the code.
+
+**Required prerequisite:** read [`README.md`](README.md) first. It covers
+what Primus is, the philosophy (`Why?`), and themed end-user examples
+(Text, Lists, Maps, Scalars, Functions, Numbers, Time, Bytes). This file
+does **not** repeat that material — it adds what an agent needs on top.
+
+Supports PHP `~8.3.16 || ~8.4.3 || ~8.5.0`.
+
+---
+
+## How to discover classes
+
+Every class lives under `src/<Namespace>/<ClassName>.php`. To find what's
+available without grepping the world:
+
+```sh
+ls src/                      # list namespaces
+ls src/Text/                 # classes in a namespace
+```
+
+Every class has a PHPDoc summary plus a runnable usage example. To get
+the exact constructor signature and return type, read the file directly —
+do **not** guess.
+
+### Namespace map
+
+The lists below are highlights, not exhaustive. Run `ls src/<Namespace>/`
+for the full inventory and read the PHPDoc on each class. Most namespaces
+also have an `<Namespace>Envelope` abstract class that simplifies writing
+new decorators — extend it to inherit interface compliance for free.
+
+- **`Primus\Text`** — string operations.
+  `TextOf`, `Trimmed`, `TrimmedLeft`, `TrimmedRight`, `Lowered`, `Uppered`,
+  `Sub`, `HtmlEscaped`, `WithoutTags`, `Mapped` (string→string transform),
+  `Joined`, `Repeated`, `Replaced`, `Split`, `Capitalized`, `Normalized`,
+  `Abbreviated`, `LeftPadded`, `RightPadded`, `IsEmpty`, `LengthOfText`,
+  `RandomText`, `TextOfScalar`, `TextEnvelope`.
+
+- **`Primus\List`** — ordered list operations over `List_<T>` (the
+  trailing underscore avoids the reserved keyword).
+  `ListOf`, `Filtered`, `Mapped`, `Sorted`, `SortedBy`, `Plucked`, `Unique`,
+  `NoNulls`, `Chunks`, `Sliced`, `Range`, `Reversed`, `Joined`,
+  `Contains`, `IndexOf`, `Difference`, `Intersection`, `ListEnvelope`.
+
+- **`Primus\Map`** — associative-map operations over `Map<K, V>`.
+  `MapOf`, `Merged`, `Combined`, `PluckedBy`, `Filtered`, `Mapped`,
+  `BiFiltered`, `BiMapped`, `NoNulls`, `Diff`, `DiffAssoc`, `Intersect`,
+  `IntersectAssoc`, `Keys`, `Values`, `Sliced`, `Unique`, `MapEnvelope`.
+
+- **`Primus\Scalar`** — generic `Scalar<T>` plus boolean, comparison and
+  control primitives.
+  `ScalarOf`, `Constant`, `Sticky` (memoize), `Ternary`, `And_`, `Or_`,
+  `Not`, `Xor_`, `EqualTo`, `GreaterThan`, `LessThan`, `Between`,
+  `RootCause` (unwrap a Throwable chain), `ScalarEnvelope`.
+
+- **`Primus\Number`** — numeric primitives.
+  `Number` interface (`asInt()` + `asFloat()`), `NumberOf`,
+  `NumberOfScalar`, `NumberOfText`, `Sticky` (memoize both projections),
+  `SumOf`, `MinOf`, `MaxOf`, `AvgOf`, `MultOf`, `DivOf`.
+
+- **`Primus\Numeric`** — a parallel numeric hierarchy: the `Number`
+  interface here extends `Scalar<int|float|string>` and exposes `value()`
+  instead of split `asInt()`/`asFloat()`. Use `Primus\Number` for the
+  decorator-friendly two-projection API; use `Primus\Numeric` only when
+  composing with generic `Scalar<T>` machinery.
+
+- **`Primus\Time`** — `DateTimeImmutable` wrappers.
+  `Time` interface, `TimeOf` (parse a string), `Now` (current moment),
+  `Iso` (format as ISO 8601 string).
+
+- **`Primus\Bytes`** — byte-sequence primitives.
+  `Bytes` interface, `BytesOf`, `Base64Encoded`, `Base64Decoded`,
+  `HexEncoded`, `HexDecoded`, `Md5`, `Sha256`, `RandomBytes`, `UuidV4`
+  (random), `UuidV7` (time-ordered).
+
+- **`Primus\Func`** — function-as-object primitives.
+  `Func<I, O>` (`apply()`), `Proc<X>` (`exec()`, side-effect), `Predicate`
+  (boolean check), plus `FuncOf`, `BiFunc`/`BiFuncOf`, `ProcOf`,
+  `BiProc`/`BiProcOf`, `PredicateOf`, `StickyFunc`, `FuncWithFallback`,
+  `Repeated`, `ForEach_` (iterate a `List_` with a `Proc`), `FuncEnvelope`.
+
+---
+
+## Composition rules (binding contract)
+
+These rules describe how Primus objects behave. Code that uses Primus
+must respect them, otherwise it will not type-check, will fail the
+project's lint gates, or will surprise the caller at runtime.
+
+1. **Construction never executes work.** `new Trimmed(new TextOf($s))`
+   does no string work. Computation happens only when `value()` (or
+   `asInt()`/`asFloat()`/`exec()`/etc.) is called.
+
+2. **Computation methods are repeatable but not memoized by default.**
+   `new Now()` returns a different moment per `value()` call. Same for
+   `new RandomBytes(16)` and any value built from them. To freeze a
+   result, wrap in `Sticky` (per-namespace memoizer: `Scalar\Sticky`,
+   `Number\Sticky`, `Func\StickyFunc`).
+
+3. **No `null` ever crosses an API boundary.** Constructors take concrete
+   typed values; computation methods return concrete typed values.
+   Missing data fails fast with an exception, not a `null` return.
+
+4. **Compose by wrapping, not by configuration.** Behaviour changes by
+   constructing a new decorator (`Sticky(new ScalarOf(...))`), not by
+   passing flags to an existing class.
+
+5. **Interfaces are the substitution points.** Anywhere a class accepts
+   `Text`, `Bytes`, `List_<T>`, `Map<K, V>`, `Scalar<T>`, `Number`,
+   `Time`, `Func<I, O>`, `Proc<X>`, or `Predicate`, you can pass any
+   implementation — including a test stub built from a literal value via
+   `TextOf` / `BytesOf` / `ListOf` / `Constant`.
+
+---
+
+## What NOT to do
+
+Patterns that look reasonable but are wrong for Primus:
+
+- **Do not call computation methods inside a constructor.**
+  `new Trimmed((new TextOf($s))->value())` is wrong — the inner call
+  eagerly extracts the value and breaks composition. Pass the decorator
+  object, not its result.
+
+- **Do not mutate instances.** Every concrete class is `final readonly`
+  with the sole exception of `Sticky` variants, whose mutation is the
+  memoization slot. Trying to clone-with-replacement is a sign you
+  picked the wrong decorator — look for an existing one that takes the
+  parameter you wanted to mutate.
+
+- **Do not pass raw `null` where a primitive is expected.** There is no
+  `?Text`, no `?Number`. If a value is genuinely optional in your
+  application logic, that's a higher-level concern — handle it with
+  `Ternary`, `Or_`, or explicit branching in caller code.
+
+- **Do not expect `Now`/`RandomBytes` to memoize.** Two calls to
+  `value()` return two different moments / two different byte sequences.
+  Wrap in `Sticky` if you need stability.
+
+- **Do not introduce static factory methods.** `Trimmed::of($s)` is not
+  a Primus pattern. Use the constructor.
+
+---
+
+## Extending: how to add a new primitive
+
+A typical contribution adds one class plus one test file, ~50 lines of
+code, fits in a single ~250-line PR.
+
+### 1. Pick the namespace
+
+Match the value's nature, not the operation:
+
+- transforms a string → `src/Text/`
+- transforms a list of T → `src/List/`
+- transforms an assoc-map → `src/Map/`
+- numeric → `src/Number/`
+- moment in time → `src/Time/`
+- byte sequence → `src/Bytes/`
+- generic computation → `src/Scalar/`
+- function-like → `src/Func/`
+
+### 2. Decide what it decorates
+
+A Primus class is almost always a **decorator over its own interface**:
+
+```php
+final readonly class Trimmed implements Text
+{
+    public function __construct(private Text $origin) {}
+}
+```
+
+If the new class produces a `Text` from a `Text`, it implements `Text`
+and accepts `Text` in the constructor. Same for `Number → Number`,
+`Bytes → Bytes`, etc. Cross-type decorators are also valid: `HexEncoded`
+takes `Bytes` and implements `Text`. The constructor parameter is the
+"input type"; the implemented interface is the "output type".
+
+### 3. Write the class
+
+Template:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Text;
+
+use Override;
+
+/**
+ * <One-line summary that does NOT start with a digit.>
+ *
+ * <Optional second paragraph with the "why".>
+ *
+ * Example:
+ *     $value = (new MyDecorator(new TextOf('input')))->value();
+ *     // expected output
+ */
+final readonly class MyDecorator implements Text
+{
+    /**
+     * Ctor.
+     *
+     * @param Text $origin <What this dependency represents>.
+     */
+    public function __construct(private Text $origin) {}
+
+    #[Override]
+    public function value(): string
+    {
+        // All work happens here. Constructor is empty.
+        return /* transform $this->origin->value() */;
+    }
+}
+```
+
+Constructor must do **nothing** beyond property capture — no `throw`, no
+branches, no I/O. Validation, parsing, anything that can fail belongs
+inside the computation method.
+
+### 4. Write the test
+
+Follow Angry Tests: inline `new` of the SUT, no factories, no `setUp`,
+no shared state. One behaviour per `#[Test]` method.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Text;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Text\MyDecorator;
+use Primus\Text\TextOf;
+
+final class MyDecoratorTest extends TestCase
+{
+    #[Test]
+    public function transformsInputDeterministically(): void
+    {
+        $this->assertSame(
+            'expected',
+            (new MyDecorator(new TextOf('input')))->value(),
+        );
+    }
+}
+```
+
+Cover edge cases that change behaviour: empty input, boundary values,
+error paths. Do not test PHP itself.
+
+### 5. Magic numbers → constants
+
+Any literal except `0`, `1`, `-1` triggers `haspadar.constantUsage`:
+
+```php
+private const int UUID_LENGTH = 16;
+private const int VERSION_BYTE = 6;
+```
+
+Name the constant by **what the number means**, not by its value.
+
+### 6. Run the gate
+
+```sh
+vendor/bin/sheriff check        # all linters + tests + mutation
+vendor/bin/sheriff fix          # auto-fix what can be auto-fixed
+```
+
+Green locally → push. CI re-runs the same checks plus Codecov,
+SonarCloud, PR-size, release-label, Infection mutation.
+
+---
+
+## Design principles (with rationale)
+
+Each rule is enforced by a linter; the **why** explains the tradeoff so
+you can argue an exception when it really makes sense.
+
+- **`final readonly` classes.**
+  Final blocks accidental inheritance; readonly blocks accidental
+  mutation. Together they make every instance a value, safe to share,
+  pass, and reason about without defensive copying. Exception: the
+  `Sticky` variants, whose private memoization slot is the documented
+  mutation point.
+
+- **No work in `__construct`.** (`haspadar.constructorInit`)
+  Construction must always succeed. If parsing/IO/branching lives in the
+  ctor, building a graph of objects can fail unexpectedly, and lazy
+  composition stops working. Move work into the computation method.
+
+- **One class = one behaviour.**
+  When you need two behaviours, write two classes and compose them. The
+  cost is one extra wrapper — the benefit is each class staying testable
+  and swappable on its own.
+
+- **No `null`, no `isset`, no `empty`.**
+  These make signatures lie. A `?Text` parameter says "this might be
+  nothing" and forces every caller to check. Use a real fallback object
+  (`Constant`, `Ternary`, `FuncWithFallback`) at the boundary where the
+  optionality is decided.
+
+- **No `static` methods or properties.**
+  Static means "behaviour owned by a class, not an instance". You lose
+  substitution: you can't swap `Trimmed::of($s)` for a test double.
+  Constructors are the only construction path.
+
+- **No procedural helpers, no mutable state.**
+  Functions that take an array and mutate it (`sort()`, `array_push()`,
+  …) cannot be lazily composed. A Primus decorator returns a new value.
+
+- **One computation method per class.**
+  `value()` for generic scalars, `asInt()`/`asFloat()` for `Number`,
+  `exec()` for `Proc`. Don't invent new method names; pick the one that
+  matches your interface.
+
+- **PHPDoc summary does not start with a digit.** (`haspadar.phpdocStyle`)
+  Tools choke on summaries like `16-byte digest...`. Rephrase as
+  `Raw 16-byte digest...`.
+
+---
+
+## Quality gates
+
+The pre-push hook and CI run `vendor/bin/sheriff check`. Tools that will
+trip your branch:
+
+- **phpstan** (level 9, custom `haspadar.*` rules) — type holes, missing
+  PHPDoc on non-trivial constructors, magic numbers, mutable state.
+- **psalm** with EO rules — same niche, slightly different angle.
+- **phpcs** (PSR-12) — formatting; mostly auto-fixed by `sheriff fix`.
+- **php-cs-fixer** — additional formatting passes; also auto-fixable.
+- **phpmd** — complexity metrics.
+- **phpmetrics** — afferent coupling hard gate (regression fails build).
+- **infection** — mutation testing; new code is expected to kill its
+  mutations.
+- **phpunit** — full test suite; new code is expected at 100% coverage
+  on the patch (Codecov gate).
+- **typos / markdownlint / yamllint / shellcheck / hadolint** — infra.
+
+Common stumbles:
+
+- "Magic number 16 found" → `private const int NAME = 16;`.
+- "Property must be readonly" → mark `private readonly Foo $bar;` or use
+  promoted properties.
+- "PHPDoc summary starts with a digit" → reorder the summary.
+- "Symbol declared but not used" → drop the unused import.
+
+### Suppression policy
+
+Do not add `@phpstan-ignore`, `@psalm-suppress`, `// NOSONAR`, baseline
+entries, or equivalents without explicit user approval. Investigate the
+root cause first. The only sanctioned suppressions live inside the
+`Sticky` variants, where memoization inherently requires a mutable slot.
+
+### CI extras beyond `sheriff check`
+
+- **PR size limit: 500 changed lines** (target ~250). Split larger work.
+- **Exactly one release label** (`feat`, `fix`, `refactor`, `docs`,
+  `ci`, `chore`, `test`, `dependencies`) unless the PR has
+  `skip-changelog`.
+- **Codecov** patch coverage on changed lines.
+- **SonarCloud** Quality Gate; cryptographic primitives (`Md5`,
+  `Sha256`, `Base64*`) trigger Security Hotspots that are marked Safe
+  per project policy (this is a primitives library, not auth code).
+
+---
+
+## File layout
+
+```
+src/<Namespace>/<ClassName>.php           # production code, one class per file
+tests/<Namespace>/<ClassName>Test.php     # one test class per production class
+tests/<Namespace>/Fakes/<Name>.php        # named test doubles (PSR-1, autoloaded)
+README.md                                  # end-user examples and philosophy
+AGENTS.md                                  # this file — agent contract
+composer.json                              # package metadata, PHP version range
+.sheriff/                                  # generated lint configuration; do not edit
+.github/workflows/                         # CI definitions; do not edit
+```
+
+---
+
+## Links
+
+- Source: <https://github.com/haspadar/primus>
+- Packagist: <https://packagist.org/packages/haspadar/primus>
+- Elegant Objects manifesto: <https://www.elegantobjects.org>
+- Cactoos (Java inspiration): <https://github.com/yegor256/cactoos>


### PR DESCRIPTION
- Added AGENTS.md as the public agent-facing contract: namespace map of all eight Primus namespaces, composition rules, antipatterns, step-by-step extension guide, design principles with rationale, and quality-gate summary
- Updated structure to reference README.md as the philosophy entry point so the two files complement rather than duplicate each other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive public agent contract documentation defining how AI agents should interact with the repository, including platform support details, class discovery methods, composition patterns, design principles, quality standards, common anti-patterns to avoid, and contribution guidelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/175)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->