### PR TITLE
Add asText Projection To Number Interface

### DIFF
--- a/src/Number/AvgOf.php
+++ b/src/Number/AvgOf.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Primus\Number;
 
 use Override;
+use Primus\Text\Text;
+use Primus\Text\TextOf;
 
 /**
  * Arithmetic mean of one or more Number operands.
@@ -53,8 +55,8 @@ final readonly class AvgOf implements Number
     }
 
     #[Override]
-    public function asString(): string
+    public function asText(): Text
     {
-        return (string) $this->asFloat();
+        return new TextOf((string) $this->asFloat());
     }
 }

--- a/src/Number/AvgOf.php
+++ b/src/Number/AvgOf.php
@@ -53,7 +53,7 @@ final readonly class AvgOf implements Number
     }
 
     #[Override]
-    public function asText(): string
+    public function asString(): string
     {
         return (string) $this->asFloat();
     }

--- a/src/Number/AvgOf.php
+++ b/src/Number/AvgOf.php
@@ -51,4 +51,10 @@ final readonly class AvgOf implements Number
 
         return $total / (float) count($this->operands);
     }
+
+    #[Override]
+    public function asText(): string
+    {
+        return (string) $this->asFloat();
+    }
 }

--- a/src/Number/DivOf.php
+++ b/src/Number/DivOf.php
@@ -42,7 +42,7 @@ final readonly class DivOf implements Number
     }
 
     #[Override]
-    public function asText(): string
+    public function asString(): string
     {
         return (string) $this->asFloat();
     }

--- a/src/Number/DivOf.php
+++ b/src/Number/DivOf.php
@@ -40,4 +40,10 @@ final readonly class DivOf implements Number
     {
         return $this->dividend->asFloat() / $this->divisor->asFloat();
     }
+
+    #[Override]
+    public function asText(): string
+    {
+        return (string) $this->asFloat();
+    }
 }

--- a/src/Number/DivOf.php
+++ b/src/Number/DivOf.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Primus\Number;
 
 use Override;
+use Primus\Text\Text;
+use Primus\Text\TextOf;
 
 /**
  * Quotient of a dividend Number and a divisor Number.
@@ -42,8 +44,8 @@ final readonly class DivOf implements Number
     }
 
     #[Override]
-    public function asString(): string
+    public function asText(): Text
     {
-        return (string) $this->asFloat();
+        return new TextOf((string) $this->asFloat());
     }
 }

--- a/src/Number/MaxOf.php
+++ b/src/Number/MaxOf.php
@@ -51,4 +51,10 @@ final readonly class MaxOf implements Number
 
         return max(array_map(static fn(Number $n): float => $n->asFloat(), $this->operands));
     }
+
+    #[Override]
+    public function asText(): string
+    {
+        return (string) $this->asFloat();
+    }
 }

--- a/src/Number/MaxOf.php
+++ b/src/Number/MaxOf.php
@@ -53,7 +53,7 @@ final readonly class MaxOf implements Number
     }
 
     #[Override]
-    public function asText(): string
+    public function asString(): string
     {
         return (string) $this->asFloat();
     }

--- a/src/Number/MaxOf.php
+++ b/src/Number/MaxOf.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Primus\Number;
 
 use Override;
+use Primus\Text\Text;
+use Primus\Text\TextOf;
 use UnderflowException;
 
 /**
@@ -53,8 +55,8 @@ final readonly class MaxOf implements Number
     }
 
     #[Override]
-    public function asString(): string
+    public function asText(): Text
     {
-        return (string) $this->asFloat();
+        return new TextOf((string) $this->asFloat());
     }
 }

--- a/src/Number/MinOf.php
+++ b/src/Number/MinOf.php
@@ -51,4 +51,10 @@ final readonly class MinOf implements Number
 
         return min(array_map(static fn(Number $n): float => $n->asFloat(), $this->numbers));
     }
+
+    #[Override]
+    public function asText(): string
+    {
+        return (string) $this->asFloat();
+    }
 }

--- a/src/Number/MinOf.php
+++ b/src/Number/MinOf.php
@@ -53,7 +53,7 @@ final readonly class MinOf implements Number
     }
 
     #[Override]
-    public function asText(): string
+    public function asString(): string
     {
         return (string) $this->asFloat();
     }

--- a/src/Number/MinOf.php
+++ b/src/Number/MinOf.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Primus\Number;
 
 use Override;
+use Primus\Text\Text;
+use Primus\Text\TextOf;
 use UnderflowException;
 
 /**
@@ -53,8 +55,8 @@ final readonly class MinOf implements Number
     }
 
     #[Override]
-    public function asString(): string
+    public function asText(): Text
     {
-        return (string) $this->asFloat();
+        return new TextOf((string) $this->asFloat());
     }
 }

--- a/src/Number/MultOf.php
+++ b/src/Number/MultOf.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Primus\Number;
 
 use Override;
+use Primus\Text\Text;
+use Primus\Text\TextOf;
 
 /**
  * Product of zero or more Number factors.
@@ -52,8 +54,8 @@ final readonly class MultOf implements Number
     }
 
     #[Override]
-    public function asString(): string
+    public function asText(): Text
     {
-        return (string) $this->asFloat();
+        return new TextOf((string) $this->asFloat());
     }
 }

--- a/src/Number/MultOf.php
+++ b/src/Number/MultOf.php
@@ -52,7 +52,7 @@ final readonly class MultOf implements Number
     }
 
     #[Override]
-    public function asText(): string
+    public function asString(): string
     {
         return (string) $this->asFloat();
     }

--- a/src/Number/MultOf.php
+++ b/src/Number/MultOf.php
@@ -50,4 +50,10 @@ final readonly class MultOf implements Number
 
         return $total;
     }
+
+    #[Override]
+    public function asText(): string
+    {
+        return (string) $this->asFloat();
+    }
 }

--- a/src/Number/Number.php
+++ b/src/Number/Number.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace Primus\Number;
 
+use Primus\Text\Text;
+
 /**
  * Represents a numeric value with explicit int, float and text projections.
  *
  * Truncation toward zero on the int accessor follows native PHP `(int)` cast
  * semantics; the float accessor preserves the source magnitude; the text
- * accessor returns the string form of the float projection — integer values
- * render without a trailing `.0`, fractional values render in PHP's default
- * decimal format.
+ * accessor returns the float projection rendered through PHP's default
+ * decimal format — integer values render without a trailing `.0`.
  */
 interface Number
 {
@@ -26,7 +27,7 @@ interface Number
     public function asFloat(): float;
 
     /**
-     * Returns the canonical decimal string projection of this number.
+     * Returns the canonical decimal text projection of this number.
      */
-    public function asString(): string;
+    public function asText(): Text;
 }

--- a/src/Number/Number.php
+++ b/src/Number/Number.php
@@ -28,5 +28,5 @@ interface Number
     /**
      * Returns the canonical decimal text projection of this number.
      */
-    public function asText(): string;
+    public function asString(): string;
 }

--- a/src/Number/Number.php
+++ b/src/Number/Number.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Primus\Number;
 
 /**
- * Represents a numeric value with explicit int and float accessors.
+ * Represents a numeric value with explicit int, float and text projections.
  *
  * Truncation toward zero on the int accessor follows native PHP `(int)` cast
- * semantics; the float accessor preserves the source magnitude.
+ * semantics; the float accessor preserves the source magnitude; the text
+ * accessor returns the canonical decimal representation of the value.
  */
 interface Number
 {
@@ -21,4 +22,9 @@ interface Number
      * Returns the float projection of this number.
      */
     public function asFloat(): float;
+
+    /**
+     * Returns the canonical decimal text projection of this number.
+     */
+    public function asText(): string;
 }

--- a/src/Number/Number.php
+++ b/src/Number/Number.php
@@ -26,7 +26,7 @@ interface Number
     public function asFloat(): float;
 
     /**
-     * Returns the canonical decimal text projection of this number.
+     * Returns the canonical decimal string projection of this number.
      */
     public function asString(): string;
 }

--- a/src/Number/Number.php
+++ b/src/Number/Number.php
@@ -9,7 +9,9 @@ namespace Primus\Number;
  *
  * Truncation toward zero on the int accessor follows native PHP `(int)` cast
  * semantics; the float accessor preserves the source magnitude; the text
- * accessor returns the canonical decimal representation of the value.
+ * accessor returns the string form of the float projection — integer values
+ * render without a trailing `.0`, fractional values render in PHP's default
+ * decimal format.
  */
 interface Number
 {

--- a/src/Number/NumberOf.php
+++ b/src/Number/NumberOf.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Primus\Number;
 
 use Override;
+use Primus\Text\Text;
+use Primus\Text\TextOf;
 
 /**
  * Number lifted from a native int or float scalar.
@@ -36,8 +38,8 @@ final readonly class NumberOf implements Number
     }
 
     #[Override]
-    public function asString(): string
+    public function asText(): Text
     {
-        return (string) (float) $this->value;
+        return new TextOf((string) (float) $this->value);
     }
 }

--- a/src/Number/NumberOf.php
+++ b/src/Number/NumberOf.php
@@ -38,6 +38,6 @@ final readonly class NumberOf implements Number
     #[Override]
     public function asText(): string
     {
-        return (string) $this->value;
+        return (string) (float) $this->value;
     }
 }

--- a/src/Number/NumberOf.php
+++ b/src/Number/NumberOf.php
@@ -34,4 +34,10 @@ final readonly class NumberOf implements Number
     {
         return (float) $this->value;
     }
+
+    #[Override]
+    public function asText(): string
+    {
+        return (string) $this->value;
+    }
 }

--- a/src/Number/NumberOf.php
+++ b/src/Number/NumberOf.php
@@ -36,7 +36,7 @@ final readonly class NumberOf implements Number
     }
 
     #[Override]
-    public function asText(): string
+    public function asString(): string
     {
         return (string) (float) $this->value;
     }

--- a/src/Number/NumberOfScalar.php
+++ b/src/Number/NumberOfScalar.php
@@ -38,4 +38,10 @@ final readonly class NumberOfScalar implements Number
     {
         return (float) $this->origin->value();
     }
+
+    #[Override]
+    public function asText(): string
+    {
+        return (string) $this->origin->value();
+    }
 }

--- a/src/Number/NumberOfScalar.php
+++ b/src/Number/NumberOfScalar.php
@@ -40,7 +40,7 @@ final readonly class NumberOfScalar implements Number
     }
 
     #[Override]
-    public function asText(): string
+    public function asString(): string
     {
         return (string) (float) $this->origin->value();
     }

--- a/src/Number/NumberOfScalar.php
+++ b/src/Number/NumberOfScalar.php
@@ -42,6 +42,6 @@ final readonly class NumberOfScalar implements Number
     #[Override]
     public function asText(): string
     {
-        return (string) $this->origin->value();
+        return (string) (float) $this->origin->value();
     }
 }

--- a/src/Number/NumberOfScalar.php
+++ b/src/Number/NumberOfScalar.php
@@ -6,6 +6,8 @@ namespace Primus\Number;
 
 use Override;
 use Primus\Scalar\Scalar;
+use Primus\Text\Text;
+use Primus\Text\TextOf;
 
 /**
  * Number lifted from a deferred numeric Scalar.
@@ -40,8 +42,8 @@ final readonly class NumberOfScalar implements Number
     }
 
     #[Override]
-    public function asString(): string
+    public function asText(): Text
     {
-        return (string) (float) $this->origin->value();
+        return new TextOf((string) (float) $this->origin->value());
     }
 }

--- a/src/Number/NumberOfText.php
+++ b/src/Number/NumberOfText.php
@@ -12,14 +12,14 @@ use Primus\Text\Text;
  *
  * Parsing follows native PHP `(int)` and `(float)` cast semantics on
  * the Text's value: leading numeric prefix is read, the rest is dropped.
- * `asText` returns the normalized numeric form (the source text passed
+ * `asString` returns the normalized numeric form (the source text passed
  * through `(float)` and back through `(string)`), not the original input.
  *
  * Example:
  *     $n = new NumberOfText(new TextOf('3.14'));
  *     $n->asInt(); // 3
  *     $n->asFloat(); // 3.14
- *     $n->asText(); // "3.14"
+ *     $n->asString(); // "3.14"
  */
 final readonly class NumberOfText implements Number
 {
@@ -43,7 +43,7 @@ final readonly class NumberOfText implements Number
     }
 
     #[Override]
-    public function asText(): string
+    public function asString(): string
     {
         return (string) (float) $this->origin->value();
     }

--- a/src/Number/NumberOfText.php
+++ b/src/Number/NumberOfText.php
@@ -38,4 +38,10 @@ final readonly class NumberOfText implements Number
     {
         return (float) $this->origin->value();
     }
+
+    #[Override]
+    public function asText(): string
+    {
+        return (string) (float) $this->origin->value();
+    }
 }

--- a/src/Number/NumberOfText.php
+++ b/src/Number/NumberOfText.php
@@ -6,20 +6,21 @@ namespace Primus\Number;
 
 use Override;
 use Primus\Text\Text;
+use Primus\Text\TextOf;
 
 /**
  * Number parsed from the textual representation of a Text.
  *
  * Parsing follows native PHP `(int)` and `(float)` cast semantics on
  * the Text's value: leading numeric prefix is read, the rest is dropped.
- * `asString` returns the normalized numeric form (the source text passed
+ * `asText` returns the normalized numeric form (the source text passed
  * through `(float)` and back through `(string)`), not the original input.
  *
  * Example:
  *     $n = new NumberOfText(new TextOf('3.14'));
  *     $n->asInt(); // 3
  *     $n->asFloat(); // 3.14
- *     $n->asString(); // "3.14"
+ *     $n->asText(); // "3.14"
  */
 final readonly class NumberOfText implements Number
 {
@@ -43,8 +44,8 @@ final readonly class NumberOfText implements Number
     }
 
     #[Override]
-    public function asString(): string
+    public function asText(): Text
     {
-        return (string) (float) $this->origin->value();
+        return new TextOf((string) (float) $this->origin->value());
     }
 }

--- a/src/Number/NumberOfText.php
+++ b/src/Number/NumberOfText.php
@@ -12,11 +12,14 @@ use Primus\Text\Text;
  *
  * Parsing follows native PHP `(int)` and `(float)` cast semantics on
  * the Text's value: leading numeric prefix is read, the rest is dropped.
+ * `asText` returns the normalized numeric form (the source text passed
+ * through `(float)` and back through `(string)`), not the original input.
  *
  * Example:
  *     $n = new NumberOfText(new TextOf('3.14'));
  *     $n->asInt(); // 3
  *     $n->asFloat(); // 3.14
+ *     $n->asText(); // "3.14"
  */
 final readonly class NumberOfText implements Number
 {

--- a/src/Number/Sticky.php
+++ b/src/Number/Sticky.php
@@ -9,7 +9,7 @@ use Override;
 /**
  * Cached version of a {@see Number}.
  *
- * Evaluates each projection (asInt, asFloat, asText) at most once and stores
+ * Evaluates each projection (asInt, asFloat, asString) at most once and stores
  * the result. Subsequent calls return the cached value instead of re-traversing
  * the underlying decorator graph.
  *
@@ -22,14 +22,14 @@ use Override;
  *     $cached->asFloat(); // cached
  *     $cached->asInt(); // computed once, traverses the tree
  *     $cached->asInt(); // cached
- *     $cached->asText(); // computed once, traverses the tree
- *     $cached->asText(); // cached
+ *     $cached->asString(); // computed once, traverses the tree
+ *     $cached->asString(); // cached
  */
 final class Sticky implements Number
 {
     private const int EMPTY_INT = 0;
     private const float EMPTY_FLOAT = 0.0;
-    private const string EMPTY_TEXT = '';
+    private const string EMPTY_STRING = '';
 
     /** @phpstan-ignore haspadar.immutable (lazy memoization flag; idempotent externally) */
     private bool $intComputed = false;
@@ -44,10 +44,10 @@ final class Sticky implements Number
     private float $floatStored = self::EMPTY_FLOAT;
 
     /** @phpstan-ignore haspadar.immutable (lazy memoization flag; idempotent externally) */
-    private bool $textComputed = false;
+    private bool $stringComputed = false;
 
     /** @phpstan-ignore haspadar.immutable (lazy memoization slot; idempotent externally) */
-    private string $textStored = self::EMPTY_TEXT;
+    private string $stringStored = self::EMPTY_STRING;
 
     /**
      * Ctor.
@@ -79,13 +79,13 @@ final class Sticky implements Number
     }
 
     #[Override]
-    public function asText(): string
+    public function asString(): string
     {
-        if (!$this->textComputed) {
-            $this->textStored = $this->origin->asText();
-            $this->textComputed = true;
+        if (!$this->stringComputed) {
+            $this->stringStored = $this->origin->asString();
+            $this->stringComputed = true;
         }
 
-        return $this->textStored;
+        return $this->stringStored;
     }
 }

--- a/src/Number/Sticky.php
+++ b/src/Number/Sticky.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Primus\Number;
 
 use Override;
+use Primus\Text\Text;
+use Primus\Text\TextOf;
 
 /**
  * Cached version of a {@see Number}.
  *
- * Evaluates each projection (asInt, asFloat, asString) at most once and stores
+ * Evaluates each projection (asInt, asFloat, asText) at most once and stores
  * the result. Subsequent calls return the cached value instead of re-traversing
  * the underlying decorator graph.
  *
@@ -22,14 +24,13 @@ use Override;
  *     $cached->asFloat(); // cached
  *     $cached->asInt(); // computed once, traverses the tree
  *     $cached->asInt(); // cached
- *     $cached->asString(); // computed once, traverses the tree
- *     $cached->asString(); // cached
+ *     $cached->asText(); // computed once, traverses the tree
+ *     $cached->asText(); // cached
  */
 final class Sticky implements Number
 {
     private const int EMPTY_INT = 0;
     private const float EMPTY_FLOAT = 0.0;
-    private const string EMPTY_STRING = '';
 
     /** @phpstan-ignore haspadar.immutable (lazy memoization flag; idempotent externally) */
     private bool $intComputed = false;
@@ -44,17 +45,20 @@ final class Sticky implements Number
     private float $floatStored = self::EMPTY_FLOAT;
 
     /** @phpstan-ignore haspadar.immutable (lazy memoization flag; idempotent externally) */
-    private bool $stringComputed = false;
+    private bool $textComputed = false;
 
     /** @phpstan-ignore haspadar.immutable (lazy memoization slot; idempotent externally) */
-    private string $stringStored = self::EMPTY_STRING;
+    private Text $textStored;
 
     /**
      * Ctor.
      *
      * @param Number $origin The number whose projections are cached.
      */
-    public function __construct(private readonly Number $origin) {}
+    public function __construct(private readonly Number $origin)
+    {
+        $this->textStored = new TextOf('');
+    }
 
     #[Override]
     public function asInt(): int
@@ -79,13 +83,13 @@ final class Sticky implements Number
     }
 
     #[Override]
-    public function asString(): string
+    public function asText(): Text
     {
-        if (!$this->stringComputed) {
-            $this->stringStored = $this->origin->asString();
-            $this->stringComputed = true;
+        if (!$this->textComputed) {
+            $this->textStored = $this->origin->asText();
+            $this->textComputed = true;
         }
 
-        return $this->stringStored;
+        return $this->textStored;
     }
 }

--- a/src/Number/Sticky.php
+++ b/src/Number/Sticky.php
@@ -9,8 +9,8 @@ use Override;
 /**
  * Cached version of a {@see Number}.
  *
- * Evaluates each projection (asInt, asFloat) at most once and stores the
- * result. Subsequent calls return the cached value instead of re-traversing
+ * Evaluates each projection (asInt, asFloat, asText) at most once and stores
+ * the result. Subsequent calls return the cached value instead of re-traversing
  * the underlying decorator graph.
  *
  * This class is not thread-safe. To share cached data across threads use an
@@ -22,11 +22,14 @@ use Override;
  *     $cached->asFloat(); // cached
  *     $cached->asInt(); // computed once, traverses the tree
  *     $cached->asInt(); // cached
+ *     $cached->asText(); // computed once, traverses the tree
+ *     $cached->asText(); // cached
  */
 final class Sticky implements Number
 {
     private const int EMPTY_INT = 0;
     private const float EMPTY_FLOAT = 0.0;
+    private const string EMPTY_TEXT = '';
 
     /** @phpstan-ignore haspadar.immutable (lazy memoization flag; idempotent externally) */
     private bool $intComputed = false;
@@ -39,6 +42,12 @@ final class Sticky implements Number
 
     /** @phpstan-ignore haspadar.immutable (lazy memoization slot; idempotent externally) */
     private float $floatStored = self::EMPTY_FLOAT;
+
+    /** @phpstan-ignore haspadar.immutable (lazy memoization flag; idempotent externally) */
+    private bool $textComputed = false;
+
+    /** @phpstan-ignore haspadar.immutable (lazy memoization slot; idempotent externally) */
+    private string $textStored = self::EMPTY_TEXT;
 
     /**
      * Ctor.
@@ -67,5 +76,16 @@ final class Sticky implements Number
         }
 
         return $this->floatStored;
+    }
+
+    #[Override]
+    public function asText(): string
+    {
+        if (!$this->textComputed) {
+            $this->textStored = $this->origin->asText();
+            $this->textComputed = true;
+        }
+
+        return $this->textStored;
     }
 }

--- a/src/Number/SumOf.php
+++ b/src/Number/SumOf.php
@@ -49,4 +49,10 @@ final readonly class SumOf implements Number
 
         return $total;
     }
+
+    #[Override]
+    public function asText(): string
+    {
+        return (string) $this->asFloat();
+    }
 }

--- a/src/Number/SumOf.php
+++ b/src/Number/SumOf.php
@@ -51,7 +51,7 @@ final readonly class SumOf implements Number
     }
 
     #[Override]
-    public function asText(): string
+    public function asString(): string
     {
         return (string) $this->asFloat();
     }

--- a/src/Number/SumOf.php
+++ b/src/Number/SumOf.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Primus\Number;
 
 use Override;
+use Primus\Text\Text;
+use Primus\Text\TextOf;
 
 /**
  * Sum of one or more Number addends.
@@ -51,8 +53,8 @@ final readonly class SumOf implements Number
     }
 
     #[Override]
-    public function asString(): string
+    public function asText(): Text
     {
-        return (string) $this->asFloat();
+        return new TextOf((string) $this->asFloat());
     }
 }

--- a/tests/Number/AvgOfTest.php
+++ b/tests/Number/AvgOfTest.php
@@ -73,6 +73,6 @@ final class AvgOfTest extends TestCase
     #[Test]
     public function returnsTextOfAverage(): void
     {
-        $this->assertSame('2', (new AvgOf(new NumberOf(1), new NumberOf(2), new NumberOf(3)))->asText());
+        $this->assertSame('2', (new AvgOf(new NumberOf(1), new NumberOf(2), new NumberOf(3)))->asString());
     }
 }

--- a/tests/Number/AvgOfTest.php
+++ b/tests/Number/AvgOfTest.php
@@ -71,8 +71,8 @@ final class AvgOfTest extends TestCase
     }
 
     #[Test]
-    public function returnsStringOfAverage(): void
+    public function returnsTextOfAverage(): void
     {
-        $this->assertSame('2', (new AvgOf(new NumberOf(1), new NumberOf(2), new NumberOf(3)))->asString());
+        $this->assertSame('2', (new AvgOf(new NumberOf(1), new NumberOf(2), new NumberOf(3)))->asText()->value());
     }
 }

--- a/tests/Number/AvgOfTest.php
+++ b/tests/Number/AvgOfTest.php
@@ -71,7 +71,7 @@ final class AvgOfTest extends TestCase
     }
 
     #[Test]
-    public function returnsTextOfAverage(): void
+    public function returnsStringOfAverage(): void
     {
         $this->assertSame('2', (new AvgOf(new NumberOf(1), new NumberOf(2), new NumberOf(3)))->asString());
     }

--- a/tests/Number/AvgOfTest.php
+++ b/tests/Number/AvgOfTest.php
@@ -69,4 +69,10 @@ final class AvgOfTest extends TestCase
 
         (new AvgOf())->asInt();
     }
+
+    #[Test]
+    public function returnsTextOfAverage(): void
+    {
+        $this->assertSame('2', (new AvgOf(new NumberOf(1), new NumberOf(2), new NumberOf(3)))->asText());
+    }
 }

--- a/tests/Number/DivOfTest.php
+++ b/tests/Number/DivOfTest.php
@@ -66,7 +66,7 @@ final class DivOfTest extends TestCase
     }
 
     #[Test]
-    public function returnsTextOfQuotient(): void
+    public function returnsStringOfQuotient(): void
     {
         $this->assertSame('2.5', (new DivOf(new NumberOf(5), new NumberOf(2)))->asString());
     }

--- a/tests/Number/DivOfTest.php
+++ b/tests/Number/DivOfTest.php
@@ -64,4 +64,10 @@ final class DivOfTest extends TestCase
 
         (new DivOf(new NumberOf(1), new NumberOf(0)))->asInt();
     }
+
+    #[Test]
+    public function returnsTextOfQuotient(): void
+    {
+        $this->assertSame('2.5', (new DivOf(new NumberOf(5), new NumberOf(2)))->asText());
+    }
 }

--- a/tests/Number/DivOfTest.php
+++ b/tests/Number/DivOfTest.php
@@ -68,6 +68,6 @@ final class DivOfTest extends TestCase
     #[Test]
     public function returnsTextOfQuotient(): void
     {
-        $this->assertSame('2.5', (new DivOf(new NumberOf(5), new NumberOf(2)))->asText());
+        $this->assertSame('2.5', (new DivOf(new NumberOf(5), new NumberOf(2)))->asString());
     }
 }

--- a/tests/Number/DivOfTest.php
+++ b/tests/Number/DivOfTest.php
@@ -66,8 +66,8 @@ final class DivOfTest extends TestCase
     }
 
     #[Test]
-    public function returnsStringOfQuotient(): void
+    public function returnsTextOfQuotient(): void
     {
-        $this->assertSame('2.5', (new DivOf(new NumberOf(5), new NumberOf(2)))->asString());
+        $this->assertSame('2.5', (new DivOf(new NumberOf(5), new NumberOf(2)))->asText()->value());
     }
 }

--- a/tests/Number/Fakes/CountingNumber.php
+++ b/tests/Number/Fakes/CountingNumber.php
@@ -16,8 +16,13 @@ final class CountingNumber implements Number
 {
     public int $intCalls = 0;
     public int $floatCalls = 0;
+    public int $textCalls = 0;
 
-    public function __construct(private readonly int $intValue, private readonly float $floatValue) {}
+    public function __construct(
+        private readonly int $intValue,
+        private readonly float $floatValue,
+        private readonly string $textValue = '',
+    ) {}
 
     #[Override]
     public function asInt(): int
@@ -33,5 +38,13 @@ final class CountingNumber implements Number
         ++$this->floatCalls;
 
         return $this->floatValue;
+    }
+
+    #[Override]
+    public function asText(): string
+    {
+        ++$this->textCalls;
+
+        return $this->textValue;
     }
 }

--- a/tests/Number/Fakes/CountingNumber.php
+++ b/tests/Number/Fakes/CountingNumber.php
@@ -16,12 +16,12 @@ final class CountingNumber implements Number
 {
     public int $intCalls = 0;
     public int $floatCalls = 0;
-    public int $textCalls = 0;
+    public int $stringCalls = 0;
 
     public function __construct(
         private readonly int $intValue,
         private readonly float $floatValue,
-        private readonly string $textValue = '',
+        private readonly string $stringValue = '',
     ) {}
 
     #[Override]
@@ -41,10 +41,10 @@ final class CountingNumber implements Number
     }
 
     #[Override]
-    public function asText(): string
+    public function asString(): string
     {
-        ++$this->textCalls;
+        ++$this->stringCalls;
 
-        return $this->textValue;
+        return $this->stringValue;
     }
 }

--- a/tests/Number/Fakes/CountingNumber.php
+++ b/tests/Number/Fakes/CountingNumber.php
@@ -6,6 +6,8 @@ namespace Primus\Tests\Number\Fakes;
 
 use Override;
 use Primus\Number\Number;
+use Primus\Text\Text;
+use Primus\Text\TextOf;
 
 /**
  * Number fake that counts how many times each projection is invoked.
@@ -16,12 +18,12 @@ final class CountingNumber implements Number
 {
     public int $intCalls = 0;
     public int $floatCalls = 0;
-    public int $stringCalls = 0;
+    public int $textCalls = 0;
 
     public function __construct(
         private readonly int $intValue,
         private readonly float $floatValue,
-        private readonly string $stringValue = '',
+        private readonly string $textValue = '',
     ) {}
 
     #[Override]
@@ -41,10 +43,10 @@ final class CountingNumber implements Number
     }
 
     #[Override]
-    public function asString(): string
+    public function asText(): Text
     {
-        ++$this->stringCalls;
+        ++$this->textCalls;
 
-        return $this->stringValue;
+        return new TextOf($this->textValue);
     }
 }

--- a/tests/Number/MaxOfTest.php
+++ b/tests/Number/MaxOfTest.php
@@ -79,6 +79,6 @@ final class MaxOfTest extends TestCase
     #[Test]
     public function returnsTextOfMaximum(): void
     {
-        $this->assertSame('9', (new MaxOf(new NumberOf(3), new NumberOf(9), new NumberOf(5)))->asText());
+        $this->assertSame('9', (new MaxOf(new NumberOf(3), new NumberOf(9), new NumberOf(5)))->asString());
     }
 }

--- a/tests/Number/MaxOfTest.php
+++ b/tests/Number/MaxOfTest.php
@@ -77,7 +77,7 @@ final class MaxOfTest extends TestCase
     }
 
     #[Test]
-    public function returnsTextOfMaximum(): void
+    public function returnsStringOfMaximum(): void
     {
         $this->assertSame('9', (new MaxOf(new NumberOf(3), new NumberOf(9), new NumberOf(5)))->asString());
     }

--- a/tests/Number/MaxOfTest.php
+++ b/tests/Number/MaxOfTest.php
@@ -77,8 +77,8 @@ final class MaxOfTest extends TestCase
     }
 
     #[Test]
-    public function returnsStringOfMaximum(): void
+    public function returnsTextOfMaximum(): void
     {
-        $this->assertSame('9', (new MaxOf(new NumberOf(3), new NumberOf(9), new NumberOf(5)))->asString());
+        $this->assertSame('9', (new MaxOf(new NumberOf(3), new NumberOf(9), new NumberOf(5)))->asText()->value());
     }
 }

--- a/tests/Number/MaxOfTest.php
+++ b/tests/Number/MaxOfTest.php
@@ -75,4 +75,10 @@ final class MaxOfTest extends TestCase
 
         (new MaxOf())->asFloat();
     }
+
+    #[Test]
+    public function returnsTextOfMaximum(): void
+    {
+        $this->assertSame('9', (new MaxOf(new NumberOf(3), new NumberOf(9), new NumberOf(5)))->asText());
+    }
 }

--- a/tests/Number/MinOfTest.php
+++ b/tests/Number/MinOfTest.php
@@ -71,7 +71,7 @@ final class MinOfTest extends TestCase
     }
 
     #[Test]
-    public function returnsTextOfMinimum(): void
+    public function returnsStringOfMinimum(): void
     {
         $this->assertSame('3', (new MinOf(new NumberOf(9), new NumberOf(3), new NumberOf(5)))->asString());
     }

--- a/tests/Number/MinOfTest.php
+++ b/tests/Number/MinOfTest.php
@@ -73,6 +73,6 @@ final class MinOfTest extends TestCase
     #[Test]
     public function returnsTextOfMinimum(): void
     {
-        $this->assertSame('3', (new MinOf(new NumberOf(9), new NumberOf(3), new NumberOf(5)))->asText());
+        $this->assertSame('3', (new MinOf(new NumberOf(9), new NumberOf(3), new NumberOf(5)))->asString());
     }
 }

--- a/tests/Number/MinOfTest.php
+++ b/tests/Number/MinOfTest.php
@@ -71,8 +71,8 @@ final class MinOfTest extends TestCase
     }
 
     #[Test]
-    public function returnsStringOfMinimum(): void
+    public function returnsTextOfMinimum(): void
     {
-        $this->assertSame('3', (new MinOf(new NumberOf(9), new NumberOf(3), new NumberOf(5)))->asString());
+        $this->assertSame('3', (new MinOf(new NumberOf(9), new NumberOf(3), new NumberOf(5)))->asText()->value());
     }
 }

--- a/tests/Number/MinOfTest.php
+++ b/tests/Number/MinOfTest.php
@@ -69,4 +69,10 @@ final class MinOfTest extends TestCase
 
         (new MinOf())->asFloat();
     }
+
+    #[Test]
+    public function returnsTextOfMinimum(): void
+    {
+        $this->assertSame('3', (new MinOf(new NumberOf(9), new NumberOf(3), new NumberOf(5)))->asText());
+    }
 }

--- a/tests/Number/MultOfTest.php
+++ b/tests/Number/MultOfTest.php
@@ -70,12 +70,12 @@ final class MultOfTest extends TestCase
     #[Test]
     public function returnsTextOfProduct(): void
     {
-        $this->assertSame('12', (new MultOf(new NumberOf(3), new NumberOf(4)))->asText());
+        $this->assertSame('12', (new MultOf(new NumberOf(3), new NumberOf(4)))->asString());
     }
 
     #[Test]
     public function emptyProductIsOneText(): void
     {
-        $this->assertSame('1', (new MultOf())->asText());
+        $this->assertSame('1', (new MultOf())->asString());
     }
 }

--- a/tests/Number/MultOfTest.php
+++ b/tests/Number/MultOfTest.php
@@ -68,13 +68,13 @@ final class MultOfTest extends TestCase
     }
 
     #[Test]
-    public function returnsTextOfProduct(): void
+    public function returnsStringOfProduct(): void
     {
         $this->assertSame('12', (new MultOf(new NumberOf(3), new NumberOf(4)))->asString());
     }
 
     #[Test]
-    public function emptyProductIsOneText(): void
+    public function emptyProductIsOneString(): void
     {
         $this->assertSame('1', (new MultOf())->asString());
     }

--- a/tests/Number/MultOfTest.php
+++ b/tests/Number/MultOfTest.php
@@ -66,4 +66,10 @@ final class MultOfTest extends TestCase
     {
         $this->assertSame(0, (new MultOf(new NumberOf(5), new NumberOf(0)))->asInt());
     }
+
+    #[Test]
+    public function returnsTextOfProduct(): void
+    {
+        $this->assertSame('12', (new MultOf(new NumberOf(3), new NumberOf(4)))->asText());
+    }
 }

--- a/tests/Number/MultOfTest.php
+++ b/tests/Number/MultOfTest.php
@@ -68,14 +68,14 @@ final class MultOfTest extends TestCase
     }
 
     #[Test]
-    public function returnsStringOfProduct(): void
+    public function returnsTextOfProduct(): void
     {
-        $this->assertSame('12', (new MultOf(new NumberOf(3), new NumberOf(4)))->asString());
+        $this->assertSame('12', (new MultOf(new NumberOf(3), new NumberOf(4)))->asText()->value());
     }
 
     #[Test]
-    public function emptyProductIsOneString(): void
+    public function emptyProductIsOneText(): void
     {
-        $this->assertSame('1', (new MultOf())->asString());
+        $this->assertSame('1', (new MultOf())->asText()->value());
     }
 }

--- a/tests/Number/MultOfTest.php
+++ b/tests/Number/MultOfTest.php
@@ -72,4 +72,10 @@ final class MultOfTest extends TestCase
     {
         $this->assertSame('12', (new MultOf(new NumberOf(3), new NumberOf(4)))->asText());
     }
+
+    #[Test]
+    public function emptyProductIsOneText(): void
+    {
+        $this->assertSame('1', (new MultOf())->asText());
+    }
 }

--- a/tests/Number/NumberOfScalarTest.php
+++ b/tests/Number/NumberOfScalarTest.php
@@ -46,4 +46,22 @@ final class NumberOfScalarTest extends TestCase
             (new NumberOfScalar(new ScalarOf(static fn(): int => 5)))->asFloat(),
         );
     }
+
+    #[Test]
+    public function returnsTextForIntegerScalar(): void
+    {
+        $this->assertSame(
+            '42',
+            (new NumberOfScalar(new ScalarOf(static fn(): int => 42)))->asText(),
+        );
+    }
+
+    #[Test]
+    public function returnsTextForFloatScalar(): void
+    {
+        $this->assertSame(
+            '3.14',
+            (new NumberOfScalar(new ScalarOf(static fn(): float => 3.14)))->asText(),
+        );
+    }
 }

--- a/tests/Number/NumberOfScalarTest.php
+++ b/tests/Number/NumberOfScalarTest.php
@@ -48,7 +48,7 @@ final class NumberOfScalarTest extends TestCase
     }
 
     #[Test]
-    public function returnsTextForIntegerScalar(): void
+    public function returnsStringForIntegerScalar(): void
     {
         $this->assertSame(
             '42',
@@ -57,7 +57,7 @@ final class NumberOfScalarTest extends TestCase
     }
 
     #[Test]
-    public function returnsTextForFloatScalar(): void
+    public function returnsStringForFloatScalar(): void
     {
         $this->assertSame(
             '3.14',

--- a/tests/Number/NumberOfScalarTest.php
+++ b/tests/Number/NumberOfScalarTest.php
@@ -48,20 +48,20 @@ final class NumberOfScalarTest extends TestCase
     }
 
     #[Test]
-    public function returnsStringForIntegerScalar(): void
+    public function returnsTextForIntegerScalar(): void
     {
         $this->assertSame(
             '42',
-            (new NumberOfScalar(new ScalarOf(static fn(): int => 42)))->asString(),
+            (new NumberOfScalar(new ScalarOf(static fn(): int => 42)))->asText()->value(),
         );
     }
 
     #[Test]
-    public function returnsStringForFloatScalar(): void
+    public function returnsTextForFloatScalar(): void
     {
         $this->assertSame(
             '3.14',
-            (new NumberOfScalar(new ScalarOf(static fn(): float => 3.14)))->asString(),
+            (new NumberOfScalar(new ScalarOf(static fn(): float => 3.14)))->asText()->value(),
         );
     }
 }

--- a/tests/Number/NumberOfScalarTest.php
+++ b/tests/Number/NumberOfScalarTest.php
@@ -52,7 +52,7 @@ final class NumberOfScalarTest extends TestCase
     {
         $this->assertSame(
             '42',
-            (new NumberOfScalar(new ScalarOf(static fn(): int => 42)))->asText(),
+            (new NumberOfScalar(new ScalarOf(static fn(): int => 42)))->asString(),
         );
     }
 
@@ -61,7 +61,7 @@ final class NumberOfScalarTest extends TestCase
     {
         $this->assertSame(
             '3.14',
-            (new NumberOfScalar(new ScalarOf(static fn(): float => 3.14)))->asText(),
+            (new NumberOfScalar(new ScalarOf(static fn(): float => 3.14)))->asString(),
         );
     }
 }

--- a/tests/Number/NumberOfTest.php
+++ b/tests/Number/NumberOfTest.php
@@ -47,19 +47,19 @@ final class NumberOfTest extends TestCase
     }
 
     #[Test]
-    public function returnsTextForIntegerSource(): void
+    public function returnsStringForIntegerSource(): void
     {
         $this->assertSame('42', (new NumberOf(42))->asString());
     }
 
     #[Test]
-    public function returnsTextForFloatSource(): void
+    public function returnsStringForFloatSource(): void
     {
         $this->assertSame('3.14', (new NumberOf(3.14))->asString());
     }
 
     #[Test]
-    public function returnsTextForNegativeSource(): void
+    public function returnsStringForNegativeSource(): void
     {
         $this->assertSame('-7', (new NumberOf(-7))->asString());
     }

--- a/tests/Number/NumberOfTest.php
+++ b/tests/Number/NumberOfTest.php
@@ -45,4 +45,22 @@ final class NumberOfTest extends TestCase
     {
         $this->assertSame(0, (new NumberOf(0))->asInt());
     }
+
+    #[Test]
+    public function returnsTextForIntegerSource(): void
+    {
+        $this->assertSame('42', (new NumberOf(42))->asText());
+    }
+
+    #[Test]
+    public function returnsTextForFloatSource(): void
+    {
+        $this->assertSame('3.14', (new NumberOf(3.14))->asText());
+    }
+
+    #[Test]
+    public function returnsTextForNegativeSource(): void
+    {
+        $this->assertSame('-7', (new NumberOf(-7))->asText());
+    }
 }

--- a/tests/Number/NumberOfTest.php
+++ b/tests/Number/NumberOfTest.php
@@ -49,18 +49,18 @@ final class NumberOfTest extends TestCase
     #[Test]
     public function returnsTextForIntegerSource(): void
     {
-        $this->assertSame('42', (new NumberOf(42))->asText());
+        $this->assertSame('42', (new NumberOf(42))->asString());
     }
 
     #[Test]
     public function returnsTextForFloatSource(): void
     {
-        $this->assertSame('3.14', (new NumberOf(3.14))->asText());
+        $this->assertSame('3.14', (new NumberOf(3.14))->asString());
     }
 
     #[Test]
     public function returnsTextForNegativeSource(): void
     {
-        $this->assertSame('-7', (new NumberOf(-7))->asText());
+        $this->assertSame('-7', (new NumberOf(-7))->asString());
     }
 }

--- a/tests/Number/NumberOfTest.php
+++ b/tests/Number/NumberOfTest.php
@@ -47,20 +47,20 @@ final class NumberOfTest extends TestCase
     }
 
     #[Test]
-    public function returnsStringForIntegerSource(): void
+    public function returnsTextForIntegerSource(): void
     {
-        $this->assertSame('42', (new NumberOf(42))->asString());
+        $this->assertSame('42', (new NumberOf(42))->asText()->value());
     }
 
     #[Test]
-    public function returnsStringForFloatSource(): void
+    public function returnsTextForFloatSource(): void
     {
-        $this->assertSame('3.14', (new NumberOf(3.14))->asString());
+        $this->assertSame('3.14', (new NumberOf(3.14))->asText()->value());
     }
 
     #[Test]
-    public function returnsStringForNegativeSource(): void
+    public function returnsTextForNegativeSource(): void
     {
-        $this->assertSame('-7', (new NumberOf(-7))->asString());
+        $this->assertSame('-7', (new NumberOf(-7))->asText()->value());
     }
 }

--- a/tests/Number/NumberOfTextTest.php
+++ b/tests/Number/NumberOfTextTest.php
@@ -50,18 +50,18 @@ final class NumberOfTextTest extends TestCase
     #[Test]
     public function normalizesIntegerStringToText(): void
     {
-        $this->assertSame('42', (new NumberOfText(new TextOf('42')))->asString());
+        $this->assertSame('42', (new NumberOfText(new TextOf('42')))->asText()->value());
     }
 
     #[Test]
     public function normalizesFloatStringToText(): void
     {
-        $this->assertSame('3.14', (new NumberOfText(new TextOf('3.14')))->asString());
+        $this->assertSame('3.14', (new NumberOfText(new TextOf('3.14')))->asText()->value());
     }
 
     #[Test]
     public function dropsNonNumericTailFromText(): void
     {
-        $this->assertSame('3.14', (new NumberOfText(new TextOf('3.14abc')))->asString());
+        $this->assertSame('3.14', (new NumberOfText(new TextOf('3.14abc')))->asText()->value());
     }
 }

--- a/tests/Number/NumberOfTextTest.php
+++ b/tests/Number/NumberOfTextTest.php
@@ -46,4 +46,22 @@ final class NumberOfTextTest extends TestCase
     {
         $this->assertSame(42.0, (new NumberOfText(new TextOf('42')))->asFloat());
     }
+
+    #[Test]
+    public function normalizesIntegerStringToText(): void
+    {
+        $this->assertSame('42', (new NumberOfText(new TextOf('42')))->asText());
+    }
+
+    #[Test]
+    public function normalizesFloatStringToText(): void
+    {
+        $this->assertSame('3.14', (new NumberOfText(new TextOf('3.14')))->asText());
+    }
+
+    #[Test]
+    public function dropsNonNumericTailFromText(): void
+    {
+        $this->assertSame('3.14', (new NumberOfText(new TextOf('3.14abc')))->asText());
+    }
 }

--- a/tests/Number/NumberOfTextTest.php
+++ b/tests/Number/NumberOfTextTest.php
@@ -50,18 +50,18 @@ final class NumberOfTextTest extends TestCase
     #[Test]
     public function normalizesIntegerStringToText(): void
     {
-        $this->assertSame('42', (new NumberOfText(new TextOf('42')))->asText());
+        $this->assertSame('42', (new NumberOfText(new TextOf('42')))->asString());
     }
 
     #[Test]
     public function normalizesFloatStringToText(): void
     {
-        $this->assertSame('3.14', (new NumberOfText(new TextOf('3.14')))->asText());
+        $this->assertSame('3.14', (new NumberOfText(new TextOf('3.14')))->asString());
     }
 
     #[Test]
     public function dropsNonNumericTailFromText(): void
     {
-        $this->assertSame('3.14', (new NumberOfText(new TextOf('3.14abc')))->asText());
+        $this->assertSame('3.14', (new NumberOfText(new TextOf('3.14abc')))->asString());
     }
 }

--- a/tests/Number/StickyTest.php
+++ b/tests/Number/StickyTest.php
@@ -78,6 +78,14 @@ final class StickyTest extends TestCase
     }
 
     #[Test]
+    public function returnsSameTextInstanceOnRepeatedCalls(): void
+    {
+        $sticky = new Sticky(new CountingNumber(42, 3.14, '3.14'));
+
+        $this->assertSame($sticky->asText(), $sticky->asText());
+    }
+
+    #[Test]
     public function callsOriginAsTextAtMostOnce(): void
     {
         $origin = new CountingNumber(42, 3.14, '3.14');

--- a/tests/Number/StickyTest.php
+++ b/tests/Number/StickyTest.php
@@ -89,19 +89,4 @@ final class StickyTest extends TestCase
 
         $this->assertSame(1, $origin->textCalls);
     }
-
-    #[Test]
-    public function cachesAllProjectionsIndependently(): void
-    {
-        $origin = new CountingNumber(42, 3.14, '3.14');
-        $sticky = new Sticky($origin);
-
-        $sticky->asInt();
-        $sticky->asFloat();
-        $sticky->asText();
-
-        $this->assertSame(1, $origin->intCalls);
-        $this->assertSame(1, $origin->floatCalls);
-        $this->assertSame(1, $origin->textCalls);
-    }
 }

--- a/tests/Number/StickyTest.php
+++ b/tests/Number/StickyTest.php
@@ -99,6 +99,18 @@ final class StickyTest extends TestCase
     }
 
     #[Test]
+    public function cachesEmptyTextAsValidValue(): void
+    {
+        $origin = new CountingNumber(0, 0.0, '');
+        $sticky = new Sticky($origin);
+
+        $sticky->asText();
+        $sticky->asText();
+
+        $this->assertSame(1, $origin->textCalls);
+    }
+
+    #[Test]
     public function cachesProjectionsIndependently(): void
     {
         $origin = new CountingNumber(42, 3.14, '3.14');

--- a/tests/Number/StickyTest.php
+++ b/tests/Number/StickyTest.php
@@ -89,4 +89,19 @@ final class StickyTest extends TestCase
 
         $this->assertSame(1, $origin->textCalls);
     }
+
+    #[Test]
+    public function cachesProjectionsIndependently(): void
+    {
+        $origin = new CountingNumber(42, 3.14, '3.14');
+        $sticky = new Sticky($origin);
+
+        $sticky->asInt();
+        $sticky->asFloat();
+        $sticky->asText();
+
+        $this->assertSame(1, $origin->intCalls);
+        $this->assertSame(1, $origin->floatCalls);
+        $this->assertSame(1, $origin->textCalls);
+    }
 }

--- a/tests/Number/StickyTest.php
+++ b/tests/Number/StickyTest.php
@@ -69,25 +69,25 @@ final class StickyTest extends TestCase
     }
 
     #[Test]
-    public function returnsSameStringOnRepeatedCalls(): void
+    public function returnsSameTextOnRepeatedCalls(): void
     {
         $sticky = new Sticky(new CountingNumber(42, 3.14, '3.14'));
 
-        $this->assertSame('3.14', $sticky->asString());
-        $this->assertSame('3.14', $sticky->asString());
+        $this->assertSame('3.14', $sticky->asText()->value());
+        $this->assertSame('3.14', $sticky->asText()->value());
     }
 
     #[Test]
-    public function callsOriginAsStringAtMostOnce(): void
+    public function callsOriginAsTextAtMostOnce(): void
     {
         $origin = new CountingNumber(42, 3.14, '3.14');
         $sticky = new Sticky($origin);
 
-        $sticky->asString();
-        $sticky->asString();
-        $sticky->asString();
+        $sticky->asText();
+        $sticky->asText();
+        $sticky->asText();
 
-        $this->assertSame(1, $origin->stringCalls);
+        $this->assertSame(1, $origin->textCalls);
     }
 
     #[Test]
@@ -98,10 +98,10 @@ final class StickyTest extends TestCase
 
         $sticky->asInt();
         $sticky->asFloat();
-        $sticky->asString();
+        $sticky->asText();
 
         $this->assertSame(1, $origin->intCalls);
         $this->assertSame(1, $origin->floatCalls);
-        $this->assertSame(1, $origin->stringCalls);
+        $this->assertSame(1, $origin->textCalls);
     }
 }

--- a/tests/Number/StickyTest.php
+++ b/tests/Number/StickyTest.php
@@ -67,4 +67,41 @@ final class StickyTest extends TestCase
         $this->assertSame(1, $origin->intCalls);
         $this->assertSame(1, $origin->floatCalls);
     }
+
+    #[Test]
+    public function returnsSameTextOnRepeatedCalls(): void
+    {
+        $sticky = new Sticky(new CountingNumber(42, 3.14, '3.14'));
+
+        $this->assertSame('3.14', $sticky->asText());
+        $this->assertSame('3.14', $sticky->asText());
+    }
+
+    #[Test]
+    public function callsOriginAsTextAtMostOnce(): void
+    {
+        $origin = new CountingNumber(42, 3.14, '3.14');
+        $sticky = new Sticky($origin);
+
+        $sticky->asText();
+        $sticky->asText();
+        $sticky->asText();
+
+        $this->assertSame(1, $origin->textCalls);
+    }
+
+    #[Test]
+    public function cachesAllProjectionsIndependently(): void
+    {
+        $origin = new CountingNumber(42, 3.14, '3.14');
+        $sticky = new Sticky($origin);
+
+        $sticky->asInt();
+        $sticky->asFloat();
+        $sticky->asText();
+
+        $this->assertSame(1, $origin->intCalls);
+        $this->assertSame(1, $origin->floatCalls);
+        $this->assertSame(1, $origin->textCalls);
+    }
 }

--- a/tests/Number/StickyTest.php
+++ b/tests/Number/StickyTest.php
@@ -73,8 +73,8 @@ final class StickyTest extends TestCase
     {
         $sticky = new Sticky(new CountingNumber(42, 3.14, '3.14'));
 
-        $this->assertSame('3.14', $sticky->asText());
-        $this->assertSame('3.14', $sticky->asText());
+        $this->assertSame('3.14', $sticky->asString());
+        $this->assertSame('3.14', $sticky->asString());
     }
 
     #[Test]
@@ -83,11 +83,11 @@ final class StickyTest extends TestCase
         $origin = new CountingNumber(42, 3.14, '3.14');
         $sticky = new Sticky($origin);
 
-        $sticky->asText();
-        $sticky->asText();
-        $sticky->asText();
+        $sticky->asString();
+        $sticky->asString();
+        $sticky->asString();
 
-        $this->assertSame(1, $origin->textCalls);
+        $this->assertSame(1, $origin->stringCalls);
     }
 
     #[Test]
@@ -98,10 +98,10 @@ final class StickyTest extends TestCase
 
         $sticky->asInt();
         $sticky->asFloat();
-        $sticky->asText();
+        $sticky->asString();
 
         $this->assertSame(1, $origin->intCalls);
         $this->assertSame(1, $origin->floatCalls);
-        $this->assertSame(1, $origin->textCalls);
+        $this->assertSame(1, $origin->stringCalls);
     }
 }

--- a/tests/Number/StickyTest.php
+++ b/tests/Number/StickyTest.php
@@ -69,7 +69,7 @@ final class StickyTest extends TestCase
     }
 
     #[Test]
-    public function returnsSameTextOnRepeatedCalls(): void
+    public function returnsSameStringOnRepeatedCalls(): void
     {
         $sticky = new Sticky(new CountingNumber(42, 3.14, '3.14'));
 
@@ -78,7 +78,7 @@ final class StickyTest extends TestCase
     }
 
     #[Test]
-    public function callsOriginAsTextAtMostOnce(): void
+    public function callsOriginAsStringAtMostOnce(): void
     {
         $origin = new CountingNumber(42, 3.14, '3.14');
         $sticky = new Sticky($origin);

--- a/tests/Number/SumOfTest.php
+++ b/tests/Number/SumOfTest.php
@@ -68,20 +68,20 @@ final class SumOfTest extends TestCase
     }
 
     #[Test]
-    public function returnsStringOfIntegerSum(): void
+    public function returnsTextOfIntegerSum(): void
     {
-        $this->assertSame('5', (new SumOf(new NumberOf(2), new NumberOf(3)))->asString());
+        $this->assertSame('5', (new SumOf(new NumberOf(2), new NumberOf(3)))->asText()->value());
     }
 
     #[Test]
-    public function returnsStringOfFractionalSum(): void
+    public function returnsTextOfFractionalSum(): void
     {
-        $this->assertSame('3.5', (new SumOf(new NumberOf(1), new NumberOf(2.5)))->asString());
+        $this->assertSame('3.5', (new SumOf(new NumberOf(1), new NumberOf(2.5)))->asText()->value());
     }
 
     #[Test]
-    public function emptySumIsZeroString(): void
+    public function emptySumIsZeroText(): void
     {
-        $this->assertSame('0', (new SumOf())->asString());
+        $this->assertSame('0', (new SumOf())->asText()->value());
     }
 }

--- a/tests/Number/SumOfTest.php
+++ b/tests/Number/SumOfTest.php
@@ -68,19 +68,19 @@ final class SumOfTest extends TestCase
     }
 
     #[Test]
-    public function returnsTextOfIntegerSum(): void
+    public function returnsStringOfIntegerSum(): void
     {
         $this->assertSame('5', (new SumOf(new NumberOf(2), new NumberOf(3)))->asString());
     }
 
     #[Test]
-    public function returnsTextOfFractionalSum(): void
+    public function returnsStringOfFractionalSum(): void
     {
         $this->assertSame('3.5', (new SumOf(new NumberOf(1), new NumberOf(2.5)))->asString());
     }
 
     #[Test]
-    public function emptySumIsZeroText(): void
+    public function emptySumIsZeroString(): void
     {
         $this->assertSame('0', (new SumOf())->asString());
     }

--- a/tests/Number/SumOfTest.php
+++ b/tests/Number/SumOfTest.php
@@ -66,4 +66,16 @@ final class SumOfTest extends TestCase
     {
         $this->assertSame(0.0, (new SumOf())->asFloat());
     }
+
+    #[Test]
+    public function returnsTextOfIntegerSum(): void
+    {
+        $this->assertSame('5', (new SumOf(new NumberOf(2), new NumberOf(3)))->asText());
+    }
+
+    #[Test]
+    public function returnsTextOfFractionalSum(): void
+    {
+        $this->assertSame('3.5', (new SumOf(new NumberOf(1), new NumberOf(2.5)))->asText());
+    }
 }

--- a/tests/Number/SumOfTest.php
+++ b/tests/Number/SumOfTest.php
@@ -78,4 +78,10 @@ final class SumOfTest extends TestCase
     {
         $this->assertSame('3.5', (new SumOf(new NumberOf(1), new NumberOf(2.5)))->asText());
     }
+
+    #[Test]
+    public function emptySumIsZeroText(): void
+    {
+        $this->assertSame('0', (new SumOf())->asText());
+    }
 }

--- a/tests/Number/SumOfTest.php
+++ b/tests/Number/SumOfTest.php
@@ -70,18 +70,18 @@ final class SumOfTest extends TestCase
     #[Test]
     public function returnsTextOfIntegerSum(): void
     {
-        $this->assertSame('5', (new SumOf(new NumberOf(2), new NumberOf(3)))->asText());
+        $this->assertSame('5', (new SumOf(new NumberOf(2), new NumberOf(3)))->asString());
     }
 
     #[Test]
     public function returnsTextOfFractionalSum(): void
     {
-        $this->assertSame('3.5', (new SumOf(new NumberOf(1), new NumberOf(2.5)))->asText());
+        $this->assertSame('3.5', (new SumOf(new NumberOf(1), new NumberOf(2.5)))->asString());
     }
 
     #[Test]
     public function emptySumIsZeroText(): void
     {
-        $this->assertSame('0', (new SumOf())->asText());
+        $this->assertSame('0', (new SumOf())->asString());
     }
 }


### PR DESCRIPTION
- Added asText projection to the Number interface returning a Primus\Text\Text so callers can keep composing without dropping to a raw string
- Updated NumberOf, NumberOfScalar, NumberOfText, SumOf, AvgOf, MaxOf, MinOf, MultOf, DivOf and Sticky to implement the new projection
- Added asText coverage for every Number implementation, including cross-projection cache independence in Sticky

Part of #178

**Breaking changes:**
- Adding `asText(): Text` to `Primus\Number\Number` breaks any external class implementing this interface; implementors must add the method