### PR TITLE
Add IntNumber Family With Native Int Precision

### DIFF
--- a/src/IntNumber/IntNumber.php
+++ b/src/IntNumber/IntNumber.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\IntNumber;
+
+use Primus\Number\Number;
+
+/**
+ * Marker for whole-number primitives.
+ *
+ * Inherits the int, float and text projections from {@see Number}. Implementations
+ * back their projections with native PHP int arithmetic so the int projection
+ * preserves precision beyond the float53 boundary.
+ */
+interface IntNumber extends Number {}

--- a/src/IntNumber/IntNumberOf.php
+++ b/src/IntNumber/IntNumberOf.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\IntNumber;
+
+use Override;
+use Primus\Text\Text;
+use Primus\Text\TextOf;
+
+/**
+ * IntNumber lifted from a native int.
+ *
+ * Example:
+ *     $n = new IntNumberOf(42);
+ *     $n->asInt(); // 42
+ *     $n->asFloat(); // 42.0
+ *     $n->asText()->value(); // "42"
+ */
+final readonly class IntNumberOf implements IntNumber
+{
+    /**
+     * Ctor.
+     *
+     * @param int $value The native int to wrap.
+     */
+    public function __construct(private int $value) {}
+
+    #[Override]
+    public function asInt(): int
+    {
+        return $this->value;
+    }
+
+    #[Override]
+    public function asFloat(): float
+    {
+        return (float) $this->value;
+    }
+
+    #[Override]
+    public function asText(): Text
+    {
+        return new TextOf((string) $this->value);
+    }
+}

--- a/src/Number/Number.php
+++ b/src/Number/Number.php
@@ -11,8 +11,8 @@ use Primus\Text\Text;
  *
  * Truncation toward zero on the int accessor follows native PHP `(int)` cast
  * semantics; the float accessor preserves the source magnitude; the text
- * accessor returns the float projection rendered through PHP's default
- * decimal format — integer values render without a trailing `.0`.
+ * accessor returns the canonical decimal form of the value, with the exact
+ * format determined by the implementation family.
  */
 interface Number
 {

--- a/tests/IntNumber/IntNumberOfTest.php
+++ b/tests/IntNumber/IntNumberOfTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\IntNumber;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\IntNumber\IntNumberOf;
+
+final class IntNumberOfTest extends TestCase
+{
+    #[Test]
+    public function returnsIntForPositiveSource(): void
+    {
+        $this->assertSame(42, (new IntNumberOf(42))->asInt());
+    }
+
+    #[Test]
+    public function returnsIntForNegativeSource(): void
+    {
+        $this->assertSame(-7, (new IntNumberOf(-7))->asInt());
+    }
+
+    #[Test]
+    public function returnsIntForZeroSource(): void
+    {
+        $this->assertSame(0, (new IntNumberOf(0))->asInt());
+    }
+
+    #[Test]
+    public function returnsFloatForIntegerSource(): void
+    {
+        $this->assertSame(42.0, (new IntNumberOf(42))->asFloat());
+    }
+
+    #[Test]
+    public function returnsFloatForNegativeSource(): void
+    {
+        $this->assertSame(-7.0, (new IntNumberOf(-7))->asFloat());
+    }
+
+    #[Test]
+    public function returnsTextForPositiveSource(): void
+    {
+        $this->assertSame('42', (new IntNumberOf(42))->asText()->value());
+    }
+
+    #[Test]
+    public function returnsTextForNegativeSource(): void
+    {
+        $this->assertSame('-7', (new IntNumberOf(-7))->asText()->value());
+    }
+
+    #[Test]
+    public function preservesPrecisionBeyondFloat53(): void
+    {
+        $this->assertSame('9007199254740993', (new IntNumberOf(9007199254740993))->asText()->value());
+    }
+}


### PR DESCRIPTION
- Added IntNumber marker interface extending Number to scope whole-number primitives
- Added IntNumberOf with native PHP int storage so the int and text projections preserve precision beyond float53
- Loosened Number::asText docblock so each implementation family chooses its own canonical decimal format

Part of #178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added integer number type with support for precision preservation beyond standard floating-point limits
  * Provides seamless conversion capabilities to text and float formats

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/180)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->