### PR TITLE
Add IntNumber MaxOf And MinOf Aggregates

### DIFF
--- a/.sheriff.yaml
+++ b/.sheriff.yaml
@@ -3,6 +3,16 @@
 override:
     php_cs_fixer.extend: "        'phpdoc_types' => ['exclude' => ['scalar']],"
     phpmetrics.coupling.max_afferent: 18
+    phpstan.parameters:
+        haspadar:
+            afferentCoupling:
+                maxAfferent: 10
+                ignoreInterfaces: true
+                excludedClasses:
+                    - Primus\Text\TextOf
+                    - Primus\Text\Mapped
+                    - Primus\Func\FuncOf
+                    - Primus\Scalar\ScalarOf
     phpunit.testsuites.unit: ["../../tests"]
     phpunit.testsuites.integration: []
     ci.pr.max_lines_changed: 500

--- a/.sheriff/phpstan/phpstan.neon
+++ b/.sheriff/phpstan/phpstan.neon
@@ -20,4 +20,9 @@ parameters:
     haspadar:
         afferentCoupling:
             ignoreInterfaces: true
-            excludedClasses: []
+            excludedClasses:
+                - Primus\Text\TextOf
+                - Primus\Text\Mapped
+                - Primus\Func\FuncOf
+                - Primus\Scalar\ScalarOf
+            maxAfferent: 10

--- a/src/IntNumber/MaxOf.php
+++ b/src/IntNumber/MaxOf.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\IntNumber;
+
+use Override;
+use Primus\Text\Text;
+use Primus\Text\TextOf;
+use UnderflowException;
+
+/**
+ * Maximum of one or more IntNumber operands, computed in native PHP int arithmetic.
+ *
+ * Throws on an empty operand list — maximum is undefined without operands.
+ *
+ * Example:
+ *     $max = new MaxOf(new IntNumberOf(3), new IntNumberOf(9), new IntNumberOf(5));
+ *     $max->asInt(); // 9
+ */
+final readonly class MaxOf implements IntNumber
+{
+    /** @var array<array-key, IntNumber> */
+    private array $operands;
+
+    /**
+     * Ctor.
+     *
+     * @param IntNumber ...$operands The integers to compare.
+     */
+    public function __construct(IntNumber ...$operands)
+    {
+        $this->operands = $operands;
+    }
+
+    #[Override]
+    public function asInt(): int
+    {
+        if ($this->operands === []) {
+            throw new UnderflowException('Cannot compute maximum of empty operand list');
+        }
+
+        return max(array_map(static fn(IntNumber $n): int => $n->asInt(), $this->operands));
+    }
+
+    #[Override]
+    public function asFloat(): float
+    {
+        return (float) $this->asInt();
+    }
+
+    #[Override]
+    public function asText(): Text
+    {
+        return new TextOf((string) $this->asInt());
+    }
+}

--- a/src/IntNumber/MinOf.php
+++ b/src/IntNumber/MinOf.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\IntNumber;
+
+use Override;
+use Primus\Text\Text;
+use Primus\Text\TextOf;
+use UnderflowException;
+
+/**
+ * Minimum of one or more IntNumber operands, computed in native PHP int arithmetic.
+ *
+ * Throws on an empty operand list — minimum is undefined without operands.
+ *
+ * Example:
+ *     $min = new MinOf(new IntNumberOf(9), new IntNumberOf(3), new IntNumberOf(5));
+ *     $min->asInt(); // 3
+ */
+final readonly class MinOf implements IntNumber
+{
+    /** @var array<array-key, IntNumber> */
+    private array $operands;
+
+    /**
+     * Ctor.
+     *
+     * @param IntNumber ...$operands The integers to compare.
+     */
+    public function __construct(IntNumber ...$operands)
+    {
+        $this->operands = $operands;
+    }
+
+    #[Override]
+    public function asInt(): int
+    {
+        if ($this->operands === []) {
+            throw new UnderflowException('Cannot compute minimum of empty operand list');
+        }
+
+        return min(array_map(static fn(IntNumber $n): int => $n->asInt(), $this->operands));
+    }
+
+    #[Override]
+    public function asFloat(): float
+    {
+        return (float) $this->asInt();
+    }
+
+    #[Override]
+    public function asText(): Text
+    {
+        return new TextOf((string) $this->asInt());
+    }
+}

--- a/tests/IntNumber/MaxOfTest.php
+++ b/tests/IntNumber/MaxOfTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\IntNumber;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\IntNumber\IntNumberOf;
+use Primus\IntNumber\MaxOf;
+use UnderflowException;
+
+final class MaxOfTest extends TestCase
+{
+    #[Test]
+    public function picksLargestPositive(): void
+    {
+        $this->assertSame(
+            9,
+            (new MaxOf(new IntNumberOf(3), new IntNumberOf(9), new IntNumberOf(5)))->asInt(),
+        );
+    }
+
+    #[Test]
+    public function picksLargestWithNegatives(): void
+    {
+        $this->assertSame(
+            -2,
+            (new MaxOf(new IntNumberOf(-7), new IntNumberOf(-2), new IntNumberOf(-5)))->asInt(),
+        );
+    }
+
+    #[Test]
+    public function returnsFloatOfMaximum(): void
+    {
+        $this->assertSame(
+            9.0,
+            (new MaxOf(new IntNumberOf(3), new IntNumberOf(9)))->asFloat(),
+        );
+    }
+
+    #[Test]
+    public function returnsTextOfMaximum(): void
+    {
+        $this->assertSame(
+            '9',
+            (new MaxOf(new IntNumberOf(3), new IntNumberOf(9)))->asText()->value(),
+        );
+    }
+
+    #[Test]
+    public function emptyOperandsRejectIntAccess(): void
+    {
+        $this->expectException(UnderflowException::class);
+
+        (new MaxOf())->asInt();
+    }
+
+    #[Test]
+    public function emptyOperandsRejectFloatAccess(): void
+    {
+        $this->expectException(UnderflowException::class);
+
+        (new MaxOf())->asFloat();
+    }
+
+    #[Test]
+    public function emptyOperandsRejectTextAccess(): void
+    {
+        $this->expectException(UnderflowException::class);
+
+        (new MaxOf())->asText();
+    }
+}

--- a/tests/IntNumber/MinOfTest.php
+++ b/tests/IntNumber/MinOfTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\IntNumber;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\IntNumber\IntNumberOf;
+use Primus\IntNumber\MinOf;
+use UnderflowException;
+
+final class MinOfTest extends TestCase
+{
+    #[Test]
+    public function picksSmallestPositive(): void
+    {
+        $this->assertSame(
+            3,
+            (new MinOf(new IntNumberOf(9), new IntNumberOf(3), new IntNumberOf(5)))->asInt(),
+        );
+    }
+
+    #[Test]
+    public function picksSmallestWithNegatives(): void
+    {
+        $this->assertSame(
+            -7,
+            (new MinOf(new IntNumberOf(-7), new IntNumberOf(-2), new IntNumberOf(-5)))->asInt(),
+        );
+    }
+
+    #[Test]
+    public function returnsFloatOfMinimum(): void
+    {
+        $this->assertSame(
+            3.0,
+            (new MinOf(new IntNumberOf(9), new IntNumberOf(3)))->asFloat(),
+        );
+    }
+
+    #[Test]
+    public function returnsTextOfMinimum(): void
+    {
+        $this->assertSame(
+            '3',
+            (new MinOf(new IntNumberOf(9), new IntNumberOf(3)))->asText()->value(),
+        );
+    }
+
+    #[Test]
+    public function emptyOperandsRejectIntAccess(): void
+    {
+        $this->expectException(UnderflowException::class);
+
+        (new MinOf())->asInt();
+    }
+
+    #[Test]
+    public function emptyOperandsRejectFloatAccess(): void
+    {
+        $this->expectException(UnderflowException::class);
+
+        (new MinOf())->asFloat();
+    }
+
+    #[Test]
+    public function emptyOperandsRejectTextAccess(): void
+    {
+        $this->expectException(UnderflowException::class);
+
+        (new MinOf())->asText();
+    }
+}


### PR DESCRIPTION
- Added IntNumber\MaxOf with native int comparison; empty operand list throws UnderflowException on access
- Added IntNumber\MinOf with native int comparison; empty operand list throws UnderflowException on access
- Tightened PHPStan afferent-coupling guard to 10 and excluded factory and base-decorator classes

Part of #178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added minimum and maximum operations for integer numbers, allowing users to find the smallest or largest value from a collection of integers.
  * Both operations support multiple output formats: integer, floating-point, and text representations.
  * Includes error handling for edge cases (empty operand lists).

* **Tests**
  * Added comprehensive test coverage for new minimum and maximum operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/182)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->