### PR TITLE
Rename IntNumber Namespace To Integer

### DIFF
--- a/.sheriff.yaml
+++ b/.sheriff.yaml
@@ -1,7 +1,11 @@
 # Sheriff configuration. All available keys and their defaults are in .sheriff/config.yaml.
 
 override:
-    php_cs_fixer.extend: "        'phpdoc_types' => ['exclude' => ['scalar']],"
+    php_cs_fixer.extend: "        'phpdoc_types' => ['exclude' => ['scalar', 'integer']],"
+    phpcs.extend: |
+        <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints.UsedLongTypeHint">
+            <exclude-pattern>*/src/Integer/*</exclude-pattern>
+        </rule>
     phpmetrics.coupling.max_afferent: 18
     phpstan.parameters:
         haspadar:

--- a/.sheriff/php-cs-fixer/php-cs-fixer.php
+++ b/.sheriff/php-cs-fixer/php-cs-fixer.php
@@ -106,6 +106,6 @@ return (new PhpCsFixer\Config())
         // PHP 8.4 compatibility: keep parentheses around `new` expressions
         // so tools based on pdepend (phpmd) can still parse the code
         'new_expression_parentheses' => ['use_parentheses' => true],
-        'phpdoc_types' => ['exclude' => ['scalar']],
+        'phpdoc_types' => ['exclude' => ['scalar', 'integer']],
     ]))
     ->setUnsupportedPhpVersionAllowed(true);

--- a/.sheriff/phpcs/phpcs.xml
+++ b/.sheriff/phpcs/phpcs.xml
@@ -20,5 +20,8 @@
     <rule ref=".sheriff/phpcs/slevomat-flow.xml"/>
     <rule ref=".sheriff/phpcs/slevomat-style.xml"/>
 
+<rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints.UsedLongTypeHint">
+    <exclude-pattern>*/src/Integer/*</exclude-pattern>
+</rule>
 
 </ruleset>

--- a/src/Integer/Integer.php
+++ b/src/Integer/Integer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Primus\IntNumber;
+namespace Primus\Integer;
 
 use Primus\Number\Number;
 
@@ -13,4 +13,4 @@ use Primus\Number\Number;
  * back their projections with native PHP int arithmetic so the int projection
  * preserves precision beyond the float53 boundary.
  */
-interface IntNumber extends Number {}
+interface Integer extends Number {}

--- a/src/Integer/IntegerOf.php
+++ b/src/Integer/IntegerOf.php
@@ -2,22 +2,22 @@
 
 declare(strict_types=1);
 
-namespace Primus\IntNumber;
+namespace Primus\Integer;
 
 use Override;
 use Primus\Text\Text;
 use Primus\Text\TextOf;
 
 /**
- * IntNumber lifted from a native int.
+ * Integer lifted from a native int.
  *
  * Example:
- *     $n = new IntNumberOf(42);
+ *     $n = new IntegerOf(42);
  *     $n->asInt(); // 42
  *     $n->asFloat(); // 42.0
  *     $n->asText()->value(); // "42"
  */
-final readonly class IntNumberOf implements IntNumber
+final readonly class IntegerOf implements Integer
 {
     /**
      * Ctor.

--- a/src/Integer/MaxOf.php
+++ b/src/Integer/MaxOf.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Primus\IntNumber;
+namespace Primus\Integer;
 
 use Override;
 use Primus\Text\Text;
@@ -10,25 +10,25 @@ use Primus\Text\TextOf;
 use UnderflowException;
 
 /**
- * Maximum of one or more IntNumber operands, computed in native PHP int arithmetic.
+ * Maximum of one or more Integer operands, computed in native PHP int arithmetic.
  *
  * Throws on an empty operand list — maximum is undefined without operands.
  *
  * Example:
- *     $max = new MaxOf(new IntNumberOf(3), new IntNumberOf(9), new IntNumberOf(5));
+ *     $max = new MaxOf(new IntegerOf(3), new IntegerOf(9), new IntegerOf(5));
  *     $max->asInt(); // 9
  */
-final readonly class MaxOf implements IntNumber
+final readonly class MaxOf implements Integer
 {
-    /** @var array<array-key, IntNumber> */
+    /** @var array<array-key, Integer> */
     private array $operands;
 
     /**
      * Ctor.
      *
-     * @param IntNumber ...$operands The integers to compare.
+     * @param Integer ...$operands The integers to compare.
      */
-    public function __construct(IntNumber ...$operands)
+    public function __construct(Integer ...$operands)
     {
         $this->operands = $operands;
     }
@@ -40,7 +40,7 @@ final readonly class MaxOf implements IntNumber
             throw new UnderflowException('Cannot compute maximum of empty operand list');
         }
 
-        return max(array_map(static fn(IntNumber $n): int => $n->asInt(), $this->operands));
+        return max(array_map(static fn(Integer $n): int => $n->asInt(), $this->operands));
     }
 
     #[Override]

--- a/src/Integer/MinOf.php
+++ b/src/Integer/MinOf.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Primus\IntNumber;
+namespace Primus\Integer;
 
 use Override;
 use Primus\Text\Text;
@@ -10,25 +10,25 @@ use Primus\Text\TextOf;
 use UnderflowException;
 
 /**
- * Minimum of one or more IntNumber operands, computed in native PHP int arithmetic.
+ * Minimum of one or more Integer operands, computed in native PHP int arithmetic.
  *
  * Throws on an empty operand list — minimum is undefined without operands.
  *
  * Example:
- *     $min = new MinOf(new IntNumberOf(9), new IntNumberOf(3), new IntNumberOf(5));
+ *     $min = new MinOf(new IntegerOf(9), new IntegerOf(3), new IntegerOf(5));
  *     $min->asInt(); // 3
  */
-final readonly class MinOf implements IntNumber
+final readonly class MinOf implements Integer
 {
-    /** @var array<array-key, IntNumber> */
+    /** @var array<array-key, Integer> */
     private array $operands;
 
     /**
      * Ctor.
      *
-     * @param IntNumber ...$operands The integers to compare.
+     * @param Integer ...$operands The integers to compare.
      */
-    public function __construct(IntNumber ...$operands)
+    public function __construct(Integer ...$operands)
     {
         $this->operands = $operands;
     }
@@ -40,7 +40,7 @@ final readonly class MinOf implements IntNumber
             throw new UnderflowException('Cannot compute minimum of empty operand list');
         }
 
-        return min(array_map(static fn(IntNumber $n): int => $n->asInt(), $this->operands));
+        return min(array_map(static fn(Integer $n): int => $n->asInt(), $this->operands));
     }
 
     #[Override]

--- a/src/Integer/MultOf.php
+++ b/src/Integer/MultOf.php
@@ -2,35 +2,35 @@
 
 declare(strict_types=1);
 
-namespace Primus\IntNumber;
+namespace Primus\Integer;
 
 use Override;
 use Primus\Text\Text;
 use Primus\Text\TextOf;
 
 /**
- * Product of zero or more IntNumber factors, computed in native PHP int arithmetic.
+ * Product of zero or more Integer factors, computed in native PHP int arithmetic.
  *
  * Each operand contributes its int projection; overflow follows native PHP
  * semantics (the result silently widens to float, breaking the int contract).
  * Callers are responsible for staying within PHP_INT_MAX.
  *
  * Example:
- *     $product = new MultOf(new IntNumberOf(3), new IntNumberOf(4));
+ *     $product = new MultOf(new IntegerOf(3), new IntegerOf(4));
  *     $product->asInt(); // 12
  *     (new MultOf())->asInt(); // 1 (multiplicative identity)
  */
-final readonly class MultOf implements IntNumber
+final readonly class MultOf implements Integer
 {
-    /** @var array<array-key, IntNumber> */
+    /** @var array<array-key, Integer> */
     private array $factors;
 
     /**
      * Ctor.
      *
-     * @param IntNumber ...$factors The integers to multiply.
+     * @param Integer ...$factors The integers to multiply.
      */
-    public function __construct(IntNumber ...$factors)
+    public function __construct(Integer ...$factors)
     {
         $this->factors = $factors;
     }

--- a/src/Integer/SumOf.php
+++ b/src/Integer/SumOf.php
@@ -2,35 +2,35 @@
 
 declare(strict_types=1);
 
-namespace Primus\IntNumber;
+namespace Primus\Integer;
 
 use Override;
 use Primus\Text\Text;
 use Primus\Text\TextOf;
 
 /**
- * Sum of zero or more IntNumber addends, computed in native PHP int arithmetic.
+ * Sum of zero or more Integer addends, computed in native PHP int arithmetic.
  *
  * Each operand contributes its int projection; overflow follows native PHP
  * semantics (the result silently widens to float, breaking the int contract).
  * Callers are responsible for staying within PHP_INT_MAX.
  *
  * Example:
- *     $sum = new SumOf(new IntNumberOf(2), new IntNumberOf(3));
+ *     $sum = new SumOf(new IntegerOf(2), new IntegerOf(3));
  *     $sum->asInt(); // 5
  *     (new SumOf())->asInt(); // 0 (additive identity)
  */
-final readonly class SumOf implements IntNumber
+final readonly class SumOf implements Integer
 {
-    /** @var array<array-key, IntNumber> */
+    /** @var array<array-key, Integer> */
     private array $addends;
 
     /**
      * Ctor.
      *
-     * @param IntNumber ...$addends The integers to add.
+     * @param Integer ...$addends The integers to add.
      */
-    public function __construct(IntNumber ...$addends)
+    public function __construct(Integer ...$addends)
     {
         $this->addends = $addends;
     }

--- a/tests/Integer/IntegerOfTest.php
+++ b/tests/Integer/IntegerOfTest.php
@@ -2,59 +2,59 @@
 
 declare(strict_types=1);
 
-namespace Primus\Tests\IntNumber;
+namespace Primus\Tests\Integer;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Primus\IntNumber\IntNumberOf;
+use Primus\Integer\IntegerOf;
 
-final class IntNumberOfTest extends TestCase
+final class IntegerOfTest extends TestCase
 {
     #[Test]
     public function returnsIntForPositiveSource(): void
     {
-        $this->assertSame(42, (new IntNumberOf(42))->asInt());
+        $this->assertSame(42, (new IntegerOf(42))->asInt());
     }
 
     #[Test]
     public function returnsIntForNegativeSource(): void
     {
-        $this->assertSame(-7, (new IntNumberOf(-7))->asInt());
+        $this->assertSame(-7, (new IntegerOf(-7))->asInt());
     }
 
     #[Test]
     public function returnsIntForZeroSource(): void
     {
-        $this->assertSame(0, (new IntNumberOf(0))->asInt());
+        $this->assertSame(0, (new IntegerOf(0))->asInt());
     }
 
     #[Test]
     public function returnsFloatForIntegerSource(): void
     {
-        $this->assertSame(42.0, (new IntNumberOf(42))->asFloat());
+        $this->assertSame(42.0, (new IntegerOf(42))->asFloat());
     }
 
     #[Test]
     public function returnsFloatForNegativeSource(): void
     {
-        $this->assertSame(-7.0, (new IntNumberOf(-7))->asFloat());
+        $this->assertSame(-7.0, (new IntegerOf(-7))->asFloat());
     }
 
     #[Test]
     public function returnsTextForPositiveSource(): void
     {
-        $this->assertSame('42', (new IntNumberOf(42))->asText()->value());
+        $this->assertSame('42', (new IntegerOf(42))->asText()->value());
     }
 
     #[Test]
     public function returnsTextForNegativeSource(): void
     {
-        $this->assertSame('-7', (new IntNumberOf(-7))->asText()->value());
+        $this->assertSame('-7', (new IntegerOf(-7))->asText()->value());
     }
 
     #[Test]
     public function preservesPrecisionBeyondFloat53(): void
     {
-        $this->assertSame('9007199254740993', (new IntNumberOf(9007199254740993))->asText()->value());
+        $this->assertSame('9007199254740993', (new IntegerOf(9007199254740993))->asText()->value());
     }
 }

--- a/tests/Integer/MaxOfTest.php
+++ b/tests/Integer/MaxOfTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Primus\Tests\IntNumber;
+namespace Primus\Tests\Integer;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Primus\IntNumber\IntNumberOf;
-use Primus\IntNumber\MaxOf;
+use Primus\Integer\IntegerOf;
+use Primus\Integer\MaxOf;
 use UnderflowException;
 
 final class MaxOfTest extends TestCase
@@ -17,7 +17,7 @@ final class MaxOfTest extends TestCase
     {
         $this->assertSame(
             9,
-            (new MaxOf(new IntNumberOf(3), new IntNumberOf(9), new IntNumberOf(5)))->asInt(),
+            (new MaxOf(new IntegerOf(3), new IntegerOf(9), new IntegerOf(5)))->asInt(),
         );
     }
 
@@ -26,7 +26,7 @@ final class MaxOfTest extends TestCase
     {
         $this->assertSame(
             -2,
-            (new MaxOf(new IntNumberOf(-7), new IntNumberOf(-2), new IntNumberOf(-5)))->asInt(),
+            (new MaxOf(new IntegerOf(-7), new IntegerOf(-2), new IntegerOf(-5)))->asInt(),
         );
     }
 
@@ -35,7 +35,7 @@ final class MaxOfTest extends TestCase
     {
         $this->assertSame(
             9.0,
-            (new MaxOf(new IntNumberOf(3), new IntNumberOf(9)))->asFloat(),
+            (new MaxOf(new IntegerOf(3), new IntegerOf(9)))->asFloat(),
         );
     }
 
@@ -44,7 +44,7 @@ final class MaxOfTest extends TestCase
     {
         $this->assertSame(
             '9',
-            (new MaxOf(new IntNumberOf(3), new IntNumberOf(9)))->asText()->value(),
+            (new MaxOf(new IntegerOf(3), new IntegerOf(9)))->asText()->value(),
         );
     }
 

--- a/tests/Integer/MinOfTest.php
+++ b/tests/Integer/MinOfTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Primus\Tests\IntNumber;
+namespace Primus\Tests\Integer;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Primus\IntNumber\IntNumberOf;
-use Primus\IntNumber\MinOf;
+use Primus\Integer\IntegerOf;
+use Primus\Integer\MinOf;
 use UnderflowException;
 
 final class MinOfTest extends TestCase
@@ -17,7 +17,7 @@ final class MinOfTest extends TestCase
     {
         $this->assertSame(
             3,
-            (new MinOf(new IntNumberOf(9), new IntNumberOf(3), new IntNumberOf(5)))->asInt(),
+            (new MinOf(new IntegerOf(9), new IntegerOf(3), new IntegerOf(5)))->asInt(),
         );
     }
 
@@ -26,7 +26,7 @@ final class MinOfTest extends TestCase
     {
         $this->assertSame(
             -7,
-            (new MinOf(new IntNumberOf(-7), new IntNumberOf(-2), new IntNumberOf(-5)))->asInt(),
+            (new MinOf(new IntegerOf(-7), new IntegerOf(-2), new IntegerOf(-5)))->asInt(),
         );
     }
 
@@ -35,7 +35,7 @@ final class MinOfTest extends TestCase
     {
         $this->assertSame(
             3.0,
-            (new MinOf(new IntNumberOf(9), new IntNumberOf(3)))->asFloat(),
+            (new MinOf(new IntegerOf(9), new IntegerOf(3)))->asFloat(),
         );
     }
 
@@ -44,7 +44,7 @@ final class MinOfTest extends TestCase
     {
         $this->assertSame(
             '3',
-            (new MinOf(new IntNumberOf(9), new IntNumberOf(3)))->asText()->value(),
+            (new MinOf(new IntegerOf(9), new IntegerOf(3)))->asText()->value(),
         );
     }
 

--- a/tests/Integer/MultOfTest.php
+++ b/tests/Integer/MultOfTest.php
@@ -2,31 +2,31 @@
 
 declare(strict_types=1);
 
-namespace Primus\Tests\IntNumber;
+namespace Primus\Tests\Integer;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Primus\IntNumber\IntNumberOf;
-use Primus\IntNumber\MultOf;
+use Primus\Integer\IntegerOf;
+use Primus\Integer\MultOf;
 
 final class MultOfTest extends TestCase
 {
     #[Test]
     public function multipliesTwoPositives(): void
     {
-        $this->assertSame(12, (new MultOf(new IntNumberOf(3), new IntNumberOf(4)))->asInt());
+        $this->assertSame(12, (new MultOf(new IntegerOf(3), new IntegerOf(4)))->asInt());
     }
 
     #[Test]
     public function multipliesMixedSigns(): void
     {
-        $this->assertSame(-12, (new MultOf(new IntNumberOf(3), new IntNumberOf(-4)))->asInt());
+        $this->assertSame(-12, (new MultOf(new IntegerOf(3), new IntegerOf(-4)))->asInt());
     }
 
     #[Test]
     public function zeroFactorYieldsZero(): void
     {
-        $this->assertSame(0, (new MultOf(new IntNumberOf(5), new IntNumberOf(0)))->asInt());
+        $this->assertSame(0, (new MultOf(new IntegerOf(5), new IntegerOf(0)))->asInt());
     }
 
     #[Test]
@@ -50,12 +50,12 @@ final class MultOfTest extends TestCase
     #[Test]
     public function returnsFloatOfProduct(): void
     {
-        $this->assertSame(12.0, (new MultOf(new IntNumberOf(3), new IntNumberOf(4)))->asFloat());
+        $this->assertSame(12.0, (new MultOf(new IntegerOf(3), new IntegerOf(4)))->asFloat());
     }
 
     #[Test]
     public function returnsTextOfProduct(): void
     {
-        $this->assertSame('12', (new MultOf(new IntNumberOf(3), new IntNumberOf(4)))->asText()->value());
+        $this->assertSame('12', (new MultOf(new IntegerOf(3), new IntegerOf(4)))->asText()->value());
     }
 }

--- a/tests/Integer/SumOfTest.php
+++ b/tests/Integer/SumOfTest.php
@@ -2,25 +2,25 @@
 
 declare(strict_types=1);
 
-namespace Primus\Tests\IntNumber;
+namespace Primus\Tests\Integer;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Primus\IntNumber\IntNumberOf;
-use Primus\IntNumber\SumOf;
+use Primus\Integer\IntegerOf;
+use Primus\Integer\SumOf;
 
 final class SumOfTest extends TestCase
 {
     #[Test]
     public function sumsTwoPositives(): void
     {
-        $this->assertSame(5, (new SumOf(new IntNumberOf(2), new IntNumberOf(3)))->asInt());
+        $this->assertSame(5, (new SumOf(new IntegerOf(2), new IntegerOf(3)))->asInt());
     }
 
     #[Test]
     public function sumsMixedSigns(): void
     {
-        $this->assertSame(-1, (new SumOf(new IntNumberOf(2), new IntNumberOf(-3)))->asInt());
+        $this->assertSame(-1, (new SumOf(new IntegerOf(2), new IntegerOf(-3)))->asInt());
     }
 
     #[Test]
@@ -44,12 +44,12 @@ final class SumOfTest extends TestCase
     #[Test]
     public function returnsFloatOfSum(): void
     {
-        $this->assertSame(5.0, (new SumOf(new IntNumberOf(2), new IntNumberOf(3)))->asFloat());
+        $this->assertSame(5.0, (new SumOf(new IntegerOf(2), new IntegerOf(3)))->asFloat());
     }
 
     #[Test]
     public function returnsTextOfSum(): void
     {
-        $this->assertSame('5', (new SumOf(new IntNumberOf(2), new IntNumberOf(3)))->asText()->value());
+        $this->assertSame('5', (new SumOf(new IntegerOf(2), new IntegerOf(3)))->asText()->value());
     }
 }


### PR DESCRIPTION
- Renamed Primus\IntNumber namespace and IntNumberOf class to Primus\Integer and IntegerOf for plain naming
- Renamed src/IntNumber and tests/IntNumber directories accordingly
- Excluded Slevomat long-type-hint sniff for src/Integer to keep PascalCase class name Integer
- Excluded integer pseudo-type from php-cs-fixer phpdoc_types so docblocks keep the Integer class type

Part of #178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal code structure for improved consistency and maintainability.

* **Chores**
  * Updated code style and static analysis rule configurations.
  * Updated test suite to reflect internal restructuring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/183)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->