### PR TITLE
Bump Sheriff To v0.29.2

### DIFF
--- a/.sheriff.yaml
+++ b/.sheriff.yaml
@@ -1,11 +1,7 @@
 # Sheriff configuration. All available keys and their defaults are in .sheriff/config.yaml.
 
 override:
-    php_cs_fixer.extend: "        'phpdoc_types' => ['exclude' => ['scalar', 'integer']],"
-    phpcs.extend: |
-        <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints.UsedLongTypeHint">
-            <exclude-pattern>*/src/Integer/*</exclude-pattern>
-        </rule>
+    php_cs_fixer.extend: "        'phpdoc_types' => ['groups' => ['meta', 'simple'], 'exclude' => ['scalar']],"
     phpmetrics.coupling.max_afferent: 22
     phpstan.parameters:
         haspadar:

--- a/.sheriff/_docker.sh
+++ b/.sheriff/_docker.sh
@@ -7,7 +7,7 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 PROJECT_ROOT="$(pwd)"
-DEFAULT_IMAGE="ghcr.io/haspadar/sheriff-infra@sha256:88c76164614b7a8eaa26db74470966458389c237bbf2d6e819ac222cd2ac3762"
+DEFAULT_IMAGE="ghcr.io/haspadar/sheriff-infra@sha256:3c15f3419f6e417c345fe22eded042146a11cdba4cd9032cdc4355f7036215d0"
 IMAGE="${SHERIFF_INFRA_IMAGE:-$DEFAULT_IMAGE}"
 
 docker run --rm \

--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -33,7 +33,7 @@ defaults:
   coderabbit.cloud: true
   coderabbit.cli: false
 
-  docker.image: "ghcr.io/haspadar/sheriff-infra@sha256:88c76164614b7a8eaa26db74470966458389c237bbf2d6e819ac222cd2ac3762"
+  docker.image: "ghcr.io/haspadar/sheriff-infra@sha256:3c15f3419f6e417c345fe22eded042146a11cdba4cd9032cdc4355f7036215d0"
 
   actionlint.cli: true
 

--- a/.sheriff/php-cs-fixer/php-cs-fixer.php
+++ b/.sheriff/php-cs-fixer/php-cs-fixer.php
@@ -76,7 +76,7 @@ return (new PhpCsFixer\Config())
         'phpdoc_order' => true,
         'phpdoc_scalar' => true,
         'phpdoc_trim' => true,
-        'phpdoc_types' => true,
+        'phpdoc_types' => ['groups' => ['meta', 'simple']],
         'phpdoc_var_without_name' => true,
 
         // Clean code
@@ -106,6 +106,6 @@ return (new PhpCsFixer\Config())
         // PHP 8.4 compatibility: keep parentheses around `new` expressions
         // so tools based on pdepend (phpmd) can still parse the code
         'new_expression_parentheses' => ['use_parentheses' => true],
-        'phpdoc_types' => ['exclude' => ['scalar', 'integer']],
+        'phpdoc_types' => ['groups' => ['meta', 'simple'], 'exclude' => ['scalar']],
     ]))
     ->setUnsupportedPhpVersionAllowed(true);

--- a/.sheriff/phpcs/phpcs.xml
+++ b/.sheriff/phpcs/phpcs.xml
@@ -20,8 +20,5 @@
     <rule ref=".sheriff/phpcs/slevomat-flow.xml"/>
     <rule ref=".sheriff/phpcs/slevomat-style.xml"/>
 
-<rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints.UsedLongTypeHint">
-    <exclude-pattern>*/src/Integer/*</exclude-pattern>
-</rule>
 
 </ruleset>

--- a/.sheriff/phpcs/slevomat-types.xml
+++ b/.sheriff/phpcs/slevomat-types.xml
@@ -4,7 +4,6 @@
     <rule ref="SlevomatCodingStandard.TypeHints.ClassConstantTypeHint"/>
     <rule ref="SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax"/>
     <rule ref="SlevomatCodingStandard.TypeHints.DNFTypeHintFormat"/>
-    <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
     <rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition"/>
     <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>

--- a/.sheriff/sonar/command.sh
+++ b/.sheriff/sonar/command.sh
@@ -37,7 +37,7 @@ else
 fi
 
 PROJECT_ROOT="$(pwd)"
-DEFAULT_IMAGE="ghcr.io/haspadar/sheriff-infra@sha256:88c76164614b7a8eaa26db74470966458389c237bbf2d6e819ac222cd2ac3762"
+DEFAULT_IMAGE="ghcr.io/haspadar/sheriff-infra@sha256:3c15f3419f6e417c345fe22eded042146a11cdba4cd9032cdc4355f7036215d0"
 IMAGE="${SHERIFF_INFRA_IMAGE:-$DEFAULT_IMAGE}"
 
 docker run --rm \

--- a/composer.lock
+++ b/composer.lock
@@ -1868,16 +1868,16 @@
         },
         {
             "name": "haspadar/sheriff",
-            "version": "v0.29.0",
+            "version": "v0.29.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/sheriff.git",
-                "reference": "f4a9b6b0489ed848e0230801ad63bdd7de1dde45"
+                "reference": "c2a224fcac6d2553be9608bc358410cbb980294d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/sheriff/zipball/f4a9b6b0489ed848e0230801ad63bdd7de1dde45",
-                "reference": "f4a9b6b0489ed848e0230801ad63bdd7de1dde45",
+                "url": "https://api.github.com/repos/haspadar/sheriff/zipball/c2a224fcac6d2553be9608bc358410cbb980294d",
+                "reference": "c2a224fcac6d2553be9608bc358410cbb980294d",
                 "shasum": ""
             },
             "require": {
@@ -1930,9 +1930,9 @@
             "description": "Picky standards for PHP projects",
             "support": {
                 "issues": "https://github.com/haspadar/sheriff/issues",
-                "source": "https://github.com/haspadar/sheriff/tree/v0.29.0"
+                "source": "https://github.com/haspadar/sheriff/tree/v0.29.2"
             },
-            "time": "2026-05-07T13:42:40+00:00"
+            "time": "2026-05-15T05:10:36+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",


### PR DESCRIPTION
- Updated haspadar/sheriff to v0.29.2 so the upstream template handles the Integer/integer false positive
- Removed phpcs slevomat exclude-pattern for src/Integer that the new template makes obsolete
- Kept the Scalar workaround in php-cs-fixer phpdoc_types until sheriff covers it too

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image digests for code quality tool infrastructure across multiple services
  * Revised PHP-CS-Fixer rules configuration to adjust type documentation validation behavior
  * Removed deprecated type hint validation checks from PHPCS ruleset
  * Updated Sonar scanner Docker image reference

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/186)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->