### PR TITLE
Bump Sheriff To v0.29.3

### DIFF
--- a/.sheriff.yaml
+++ b/.sheriff.yaml
@@ -1,7 +1,7 @@
 # Sheriff configuration. All available keys and their defaults are in .sheriff/config.yaml.
 
 override:
-    php_cs_fixer.extend: "        'phpdoc_types' => ['groups' => ['meta', 'simple'], 'exclude' => ['scalar']],"
+    php_cs_fixer.extend: "        'phpdoc_types' => ['groups' => ['meta', 'simple', 'alias'], 'exclude' => ['scalar', 'integer']],"
     phpmetrics.coupling.max_afferent: 22
     phpstan.parameters:
         haspadar:

--- a/.sheriff/php-cs-fixer/php-cs-fixer.php
+++ b/.sheriff/php-cs-fixer/php-cs-fixer.php
@@ -76,7 +76,7 @@ return (new PhpCsFixer\Config())
         'phpdoc_order' => true,
         'phpdoc_scalar' => true,
         'phpdoc_trim' => true,
-        'phpdoc_types' => ['groups' => ['meta', 'simple']],
+        'phpdoc_types' => true,
         'phpdoc_var_without_name' => true,
 
         // Clean code
@@ -106,6 +106,6 @@ return (new PhpCsFixer\Config())
         // PHP 8.4 compatibility: keep parentheses around `new` expressions
         // so tools based on pdepend (phpmd) can still parse the code
         'new_expression_parentheses' => ['use_parentheses' => true],
-        'phpdoc_types' => ['groups' => ['meta', 'simple'], 'exclude' => ['scalar']],
+        'phpdoc_types' => ['groups' => ['meta', 'simple', 'alias'], 'exclude' => ['scalar', 'integer']],
     ]))
     ->setUnsupportedPhpVersionAllowed(true);

--- a/.sheriff/phpstan/phpstan.neon
+++ b/.sheriff/phpstan/phpstan.neon
@@ -3,8 +3,8 @@ includes:
     - ../../vendor/haspadar/phpstan-rules/rules.neon
 
 parameters:
-    # paths sit outside phpstan.parameters because they are derived from php.src
-    # rather than declared as a static tree leaf.
+    # Path values below are dynamically derived from php.src configuration
+    # rather than being statically declared.
     paths:
         - ../../src
 

--- a/composer.lock
+++ b/composer.lock
@@ -1868,16 +1868,16 @@
         },
         {
             "name": "haspadar/sheriff",
-            "version": "v0.29.2",
+            "version": "v0.29.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/sheriff.git",
-                "reference": "c2a224fcac6d2553be9608bc358410cbb980294d"
+                "reference": "949efca03c5eb1fde18f634eef180611bdca079f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/sheriff/zipball/c2a224fcac6d2553be9608bc358410cbb980294d",
-                "reference": "c2a224fcac6d2553be9608bc358410cbb980294d",
+                "url": "https://api.github.com/repos/haspadar/sheriff/zipball/949efca03c5eb1fde18f634eef180611bdca079f",
+                "reference": "949efca03c5eb1fde18f634eef180611bdca079f",
                 "shasum": ""
             },
             "require": {
@@ -1930,9 +1930,9 @@
             "description": "Picky standards for PHP projects",
             "support": {
                 "issues": "https://github.com/haspadar/sheriff/issues",
-                "source": "https://github.com/haspadar/sheriff/tree/v0.29.2"
+                "source": "https://github.com/haspadar/sheriff/tree/v0.29.3"
             },
-            "time": "2026-05-15T05:10:36+00:00"
+            "time": "2026-05-15T10:17:02+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",


### PR DESCRIPTION
- Updated haspadar/sheriff to v0.29.3, where the template no longer trims phpdoc_types by default
- Configured phpdoc_types exclude in .sheriff.yaml to keep Integer and Scalar PascalCase class names out of the rule's case-insensitive match