### PR TITLE
Add Decimal Interface With String Float And Int Wrappers

### DIFF
--- a/src/Decimal/Decimal.php
+++ b/src/Decimal/Decimal.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Decimal;
+
+use Primus\Number\Number;
+
+/**
+ * Marker for arbitrary-precision decimal primitives.
+ *
+ * Inherits the int, float and text projections from {@see Number}.
+ * Implementations preserve the decimal representation through `asText`
+ * without going through `(string)(float)` normalization, so values such
+ * as `"100000000000000.000001"` keep their precision beyond what float
+ * can encode.
+ */
+interface Decimal extends Number {}

--- a/src/Decimal/DecimalOf.php
+++ b/src/Decimal/DecimalOf.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Decimal;
+
+use Override;
+use Primus\Text\Text;
+use Primus\Text\TextOf;
+
+/**
+ * Decimal lifted from a plain decimal string.
+ *
+ * The string is stored as-is (no float roundtrip, no normalization), so
+ * precision past float53 is preserved through `asText`. Caller is
+ * responsible for passing a well-formed plain decimal — `(int)` and
+ * `(float)` casts on malformed input follow PHP's native behavior, and
+ * downstream bcmath-backed aggregates will reject non-decimal inputs at
+ * the moment of computation.
+ *
+ * Example:
+ *     $d = new DecimalOf('100000000000000.000001');
+ *     $d->asText()->value(); // "100000000000000.000001" (exact)
+ *     $d->asInt(); // 100000000000000 (truncated toward zero)
+ */
+final readonly class DecimalOf implements Decimal
+{
+    /**
+     * Ctor.
+     *
+     * @param string $value Plain decimal string.
+     */
+    public function __construct(private string $value) {}
+
+    #[Override]
+    public function asInt(): int
+    {
+        return (int) $this->value;
+    }
+
+    #[Override]
+    public function asFloat(): float
+    {
+        return (float) $this->value;
+    }
+
+    #[Override]
+    public function asText(): Text
+    {
+        return new TextOf($this->value);
+    }
+}

--- a/src/Decimal/DecimalOfFloat.php
+++ b/src/Decimal/DecimalOfFloat.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Decimal;
+
+use Override;
+use Primus\Text\Text;
+use Primus\Text\TextOf;
+
+/**
+ * Decimal lifted from a native float.
+ *
+ * The float is serialized through PHP's default `(string)` cast, which
+ * uses `serialize_precision=-1` (shortest round-trip repr). Short decimals
+ * stay exact (`0.3` → `"0.3"`), but values whose precision exceeds float53
+ * are already truncated at the float boundary on the caller side.
+ *
+ * NaN and infinite inputs are not rejected here — they will surface as
+ * `"NAN"` or `"INF"` in `asText` and as the corresponding native sentinels
+ * in `asInt`/`asFloat`, mirroring PHP's own casting semantics.
+ *
+ * Example:
+ *     $d = new DecimalOfFloat(0.3);
+ *     $d->asText()->value(); // "0.3"
+ *     $d->asFloat(); // 0.3
+ */
+final readonly class DecimalOfFloat implements Decimal
+{
+    /**
+     * Ctor.
+     *
+     * @param float $value Native float.
+     */
+    public function __construct(private float $value) {}
+
+    #[Override]
+    public function asInt(): int
+    {
+        return (int) $this->value;
+    }
+
+    #[Override]
+    public function asFloat(): float
+    {
+        return $this->value;
+    }
+
+    #[Override]
+    public function asText(): Text
+    {
+        return new TextOf((string) $this->value);
+    }
+}

--- a/src/Decimal/DecimalOfInt.php
+++ b/src/Decimal/DecimalOfInt.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Decimal;
+
+use Override;
+use Primus\Text\Text;
+use Primus\Text\TextOf;
+
+/**
+ * Decimal lifted from a native int.
+ *
+ * Always exact — every PHP int fits in its string form without precision
+ * loss. The text projection has scale 0 (no fractional part).
+ *
+ * Example:
+ *     $d = new DecimalOfInt(42);
+ *     $d->asText()->value(); // "42"
+ *     $d->asInt(); // 42
+ */
+final readonly class DecimalOfInt implements Decimal
+{
+    /**
+     * Ctor.
+     *
+     * @param int $value Native int to wrap.
+     */
+    public function __construct(private int $value) {}
+
+    #[Override]
+    public function asInt(): int
+    {
+        return $this->value;
+    }
+
+    #[Override]
+    public function asFloat(): float
+    {
+        return (float) $this->value;
+    }
+
+    #[Override]
+    public function asText(): Text
+    {
+        return new TextOf((string) $this->value);
+    }
+}

--- a/tests/Decimal/DecimalOfFloatTest.php
+++ b/tests/Decimal/DecimalOfFloatTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Decimal;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Decimal\DecimalOfFloat;
+
+final class DecimalOfFloatTest extends TestCase
+{
+    #[Test]
+    public function rendersShortDecimalExactly(): void
+    {
+        $this->assertSame('0.3', (new DecimalOfFloat(0.3))->asText()->value());
+    }
+
+    #[Test]
+    public function rendersIntegerValuedFloatWithoutDecimalPoint(): void
+    {
+        $this->assertSame('42', (new DecimalOfFloat(42.0))->asText()->value());
+    }
+
+    #[Test]
+    public function rendersNegativeFloat(): void
+    {
+        $this->assertSame('-3.14', (new DecimalOfFloat(-3.14))->asText()->value());
+    }
+
+    #[Test]
+    public function truncatesIntProjectionTowardZero(): void
+    {
+        $this->assertSame(3, (new DecimalOfFloat(3.99))->asInt());
+    }
+
+    #[Test]
+    public function returnsFloatProjection(): void
+    {
+        $this->assertSame(3.14, (new DecimalOfFloat(3.14))->asFloat());
+    }
+}

--- a/tests/Decimal/DecimalOfIntTest.php
+++ b/tests/Decimal/DecimalOfIntTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Decimal;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Decimal\DecimalOfInt;
+
+final class DecimalOfIntTest extends TestCase
+{
+    #[Test]
+    public function rendersPositiveIntAsText(): void
+    {
+        $this->assertSame('42', (new DecimalOfInt(42))->asText()->value());
+    }
+
+    #[Test]
+    public function rendersNegativeIntAsText(): void
+    {
+        $this->assertSame('-7', (new DecimalOfInt(-7))->asText()->value());
+    }
+
+    #[Test]
+    public function rendersZeroAsText(): void
+    {
+        $this->assertSame('0', (new DecimalOfInt(0))->asText()->value());
+    }
+
+    #[Test]
+    public function returnsIntProjection(): void
+    {
+        $this->assertSame(42, (new DecimalOfInt(42))->asInt());
+    }
+
+    #[Test]
+    public function returnsFloatProjection(): void
+    {
+        $this->assertSame(42.0, (new DecimalOfInt(42))->asFloat());
+    }
+
+    #[Test]
+    public function preservesPrecisionBeyondFloat53InText(): void
+    {
+        $this->assertSame('9007199254740993', (new DecimalOfInt(9007199254740993))->asText()->value());
+    }
+}

--- a/tests/Decimal/DecimalOfTest.php
+++ b/tests/Decimal/DecimalOfTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Decimal;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Decimal\DecimalOf;
+
+final class DecimalOfTest extends TestCase
+{
+    #[Test]
+    public function keepsPlainDecimalAsIs(): void
+    {
+        $this->assertSame('3.14', (new DecimalOf('3.14'))->asText()->value());
+    }
+
+    #[Test]
+    public function preservesPrecisionBeyondFloat53(): void
+    {
+        $this->assertSame(
+            '100000000000000.000001',
+            (new DecimalOf('100000000000000.000001'))->asText()->value(),
+        );
+    }
+
+    #[Test]
+    public function keepsNegativeAsIs(): void
+    {
+        $this->assertSame('-7.5', (new DecimalOf('-7.5'))->asText()->value());
+    }
+
+    #[Test]
+    public function truncatesIntProjectionTowardZero(): void
+    {
+        $this->assertSame(3, (new DecimalOf('3.99'))->asInt());
+    }
+
+    #[Test]
+    public function truncatesNegativeIntProjectionTowardZero(): void
+    {
+        $this->assertSame(-3, (new DecimalOf('-3.99'))->asInt());
+    }
+
+    #[Test]
+    public function returnsFloatProjection(): void
+    {
+        $this->assertSame(3.14, (new DecimalOf('3.14'))->asFloat());
+    }
+}


### PR DESCRIPTION
- Added Decimal marker interface extending Number to scope arbitrary-precision decimal primitives
- Added DecimalOf wrapping a plain decimal string so precision beyond float53 stays intact
- Added DecimalOfFloat and DecimalOfInt wrapping native float and int through PHP's default scalar serialization

Part of #192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added arbitrary-precision decimal number support for enhanced numerical accuracy.
  * Create decimals from strings, floats, or integers while preserving precision.
  * Convert decimals to text, integer, and float representations as needed.

* **Tests**
  * Added comprehensive test coverage for decimal functionality and conversions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/193)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->