### PR TITLE
Expose Decimal asString Returning Numeric String

### DIFF
--- a/src/Decimal/Decimal.php
+++ b/src/Decimal/Decimal.php
@@ -15,4 +15,13 @@ use Primus\Number\Number;
  * as `"100000000000000.000001"` keep their precision beyond what float
  * can encode.
  */
-interface Decimal extends Number {}
+interface Decimal extends Number
+{
+    /**
+     * Returns the canonical decimal as a numeric string, safe to feed into
+     * bcmath arithmetic without further parsing or roundtrips.
+     *
+     * @return numeric-string
+     */
+    public function asString(): string;
+}

--- a/src/Decimal/DecimalOf.php
+++ b/src/Decimal/DecimalOf.php
@@ -9,18 +9,16 @@ use Primus\Text\Text;
 use Primus\Text\TextOf;
 
 /**
- * Decimal lifted from a plain decimal string.
+ * Decimal lifted from a numeric string.
  *
  * The string is stored as-is (no float roundtrip, no normalization), so
- * precision past float53 is preserved through `asText`. Caller is
- * responsible for passing a well-formed plain decimal — `(int)` and
- * `(float)` casts on malformed input follow PHP's native behavior, and
- * downstream bcmath-backed aggregates will reject non-decimal inputs at
- * the moment of computation.
+ * precision past float53 is preserved through both `asText` and `asString`.
+ * The `numeric-string` annotation forces static analyzers to verify the
+ * literal at the call site.
  *
  * Example:
  *     $d = new DecimalOf('100000000000000.000001');
- *     $d->asText()->value(); // "100000000000000.000001" (exact)
+ *     $d->asString(); // "100000000000000.000001" (exact)
  *     $d->asInt(); // 100000000000000 (truncated toward zero)
  */
 final readonly class DecimalOf implements Decimal
@@ -28,7 +26,7 @@ final readonly class DecimalOf implements Decimal
     /**
      * Ctor.
      *
-     * @param string $value Plain decimal string.
+     * @param numeric-string $value Numeric string suitable for bcmath.
      */
     public function __construct(private string $value) {}
 
@@ -48,5 +46,11 @@ final readonly class DecimalOf implements Decimal
     public function asText(): Text
     {
         return new TextOf($this->value);
+    }
+
+    #[Override]
+    public function asString(): string
+    {
+        return $this->value;
     }
 }

--- a/src/Decimal/DecimalOfFloat.php
+++ b/src/Decimal/DecimalOfFloat.php
@@ -30,7 +30,7 @@ final readonly class DecimalOfFloat implements Decimal
     /**
      * Ctor.
      *
-     * @param float $value Native finite float.
+     * @param float $value Native float (validated on first projection).
      */
     public function __construct(private float $value) {}
 

--- a/src/Decimal/DecimalOfFloat.php
+++ b/src/Decimal/DecimalOfFloat.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Primus\Decimal;
 
+use InvalidArgumentException;
 use Override;
 use Primus\Text\Text;
 use Primus\Text\TextOf;
@@ -16,13 +17,12 @@ use Primus\Text\TextOf;
  * stay exact (`0.3` → `"0.3"`), but values whose precision exceeds float53
  * are already truncated at the float boundary on the caller side.
  *
- * NaN and infinite inputs are not rejected here — they will surface as
- * `"NAN"` or `"INF"` in `asText` and as the corresponding native sentinels
- * in `asInt`/`asFloat`, mirroring PHP's own casting semantics.
+ * NaN and infinite inputs raise {@see InvalidArgumentException} at the
+ * first projection call — they have no meaningful decimal representation.
  *
  * Example:
  *     $d = new DecimalOfFloat(0.3);
- *     $d->asText()->value(); // "0.3"
+ *     $d->asString(); // "0.3"
  *     $d->asFloat(); // 0.3
  */
 final readonly class DecimalOfFloat implements Decimal
@@ -30,25 +30,45 @@ final readonly class DecimalOfFloat implements Decimal
     /**
      * Ctor.
      *
-     * @param float $value Native float.
+     * @param float $value Native finite float.
      */
     public function __construct(private float $value) {}
 
     #[Override]
     public function asInt(): int
     {
-        return (int) $this->value;
+        return (int) $this->finite();
     }
 
     #[Override]
     public function asFloat(): float
     {
-        return $this->value;
+        return $this->finite();
     }
 
     #[Override]
     public function asText(): Text
     {
-        return new TextOf((string) $this->value);
+        return new TextOf($this->asString());
+    }
+
+    #[Override]
+    public function asString(): string
+    {
+        return (string) $this->finite();
+    }
+
+    /**
+     * Returns the wrapped float, throwing for NaN or infinity.
+     *
+     * @throws InvalidArgumentException When the wrapped float is NaN or infinite.
+     */
+    private function finite(): float
+    {
+        if (!is_finite($this->value)) {
+            throw new InvalidArgumentException('DecimalOfFloat rejects NaN and infinite values');
+        }
+
+        return $this->value;
     }
 }

--- a/src/Decimal/DecimalOfInt.php
+++ b/src/Decimal/DecimalOfInt.php
@@ -45,4 +45,10 @@ final readonly class DecimalOfInt implements Decimal
     {
         return new TextOf((string) $this->value);
     }
+
+    #[Override]
+    public function asString(): string
+    {
+        return (string) $this->value;
+    }
 }

--- a/tests/Decimal/DecimalOfFloatTest.php
+++ b/tests/Decimal/DecimalOfFloatTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Primus\Tests\Decimal;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Primus\Decimal\DecimalOfFloat;
@@ -38,5 +39,27 @@ final class DecimalOfFloatTest extends TestCase
     public function returnsFloatProjection(): void
     {
         $this->assertSame(3.14, (new DecimalOfFloat(3.14))->asFloat());
+    }
+
+    #[Test]
+    public function returnsNumericStringProjection(): void
+    {
+        $this->assertSame('0.3', (new DecimalOfFloat(0.3))->asString());
+    }
+
+    #[Test]
+    public function rejectsNanOnFirstProjection(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new DecimalOfFloat(NAN))->asString();
+    }
+
+    #[Test]
+    public function rejectsInfinityOnFirstProjection(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new DecimalOfFloat(INF))->asString();
     }
 }

--- a/tests/Decimal/DecimalOfIntTest.php
+++ b/tests/Decimal/DecimalOfIntTest.php
@@ -45,4 +45,10 @@ final class DecimalOfIntTest extends TestCase
     {
         $this->assertSame('9007199254740993', (new DecimalOfInt(9007199254740993))->asText()->value());
     }
+
+    #[Test]
+    public function returnsNumericStringProjection(): void
+    {
+        $this->assertSame('42', (new DecimalOfInt(42))->asString());
+    }
 }

--- a/tests/Decimal/DecimalOfTest.php
+++ b/tests/Decimal/DecimalOfTest.php
@@ -48,4 +48,10 @@ final class DecimalOfTest extends TestCase
     {
         $this->assertSame(3.14, (new DecimalOf('3.14'))->asFloat());
     }
+
+    #[Test]
+    public function returnsNumericStringProjection(): void
+    {
+        $this->assertSame('100000000000000.000001', (new DecimalOf('100000000000000.000001'))->asString());
+    }
 }


### PR DESCRIPTION
- Added Decimal::asString returning numeric-string so bcmath-backed aggregates can consume the value without casts or psalm overrides
- Implemented asString in DecimalOf (param narrowed to numeric-string), DecimalOfFloat (rejects NaN and infinity at projection time), and DecimalOfInt
- Added tests covering the new projection on each wrapper

Part of #192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `asString()` method to decimal classes for retrieving numeric strings with full precision preservation suitable for direct use in math operations.

* **Bug Fixes**
  * Enhanced validation to reject NaN and infinite float values during conversion, raising appropriate exceptions on first access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/194)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->