### PR TITLE
Add Decimal SumOf Via bcadd

### DIFF
--- a/src/Decimal/SumOf.php
+++ b/src/Decimal/SumOf.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Decimal;
+
+use Override;
+use Primus\Text\Text;
+use Primus\Text\TextOf;
+
+/**
+ * Sum of two Decimal addends, computed via bcmath at the given scale.
+ *
+ * Digits beyond `$scale` past the decimal point are truncated toward zero
+ * by bcmath without rounding.
+ *
+ * Example:
+ *     $sum = new SumOf(new DecimalOf('1.5'), new DecimalOf('2.5'), 1);
+ *     $sum->asString(); // "4.0"
+ */
+final readonly class SumOf implements Decimal
+{
+    /**
+     * Ctor.
+     *
+     * @param Decimal $left The first addend.
+     * @param Decimal $right The second addend.
+     * @param int $scale Number of digits to keep past the decimal point.
+     */
+    public function __construct(private Decimal $left, private Decimal $right, private int $scale) {}
+
+    #[Override]
+    public function asInt(): int
+    {
+        return (int) $this->asString();
+    }
+
+    #[Override]
+    public function asFloat(): float
+    {
+        return (float) $this->asString();
+    }
+
+    #[Override]
+    public function asText(): Text
+    {
+        return new TextOf($this->asString());
+    }
+
+    #[Override]
+    public function asString(): string
+    {
+        return bcadd($this->left->asString(), $this->right->asString(), $this->scale);
+    }
+}

--- a/tests/Decimal/SumOfTest.php
+++ b/tests/Decimal/SumOfTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Decimal;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Decimal\DecimalOf;
+use Primus\Decimal\SumOf;
+
+final class SumOfTest extends TestCase
+{
+    #[Test]
+    public function addsTwoPlainDecimals(): void
+    {
+        $this->assertSame(
+            '4.0',
+            (new SumOf(new DecimalOf('1.5'), new DecimalOf('2.5'), 1))->asString(),
+        );
+    }
+
+    #[Test]
+    public function keepsExactFractionalSum(): void
+    {
+        $this->assertSame(
+            '0.3',
+            (new SumOf(new DecimalOf('0.1'), new DecimalOf('0.2'), 1))->asString(),
+        );
+    }
+
+    #[Test]
+    public function handlesNegativeAddend(): void
+    {
+        $this->assertSame(
+            '-1.0',
+            (new SumOf(new DecimalOf('2.0'), new DecimalOf('-3.0'), 1))->asString(),
+        );
+    }
+
+    #[Test]
+    public function truncatesBeyondScale(): void
+    {
+        $this->assertSame(
+            '0.12',
+            (new SumOf(new DecimalOf('0.123'), new DecimalOf('0.001'), 2))->asString(),
+        );
+    }
+
+    #[Test]
+    public function preservesPrecisionBeyondFloat53(): void
+    {
+        $this->assertSame(
+            '100000000000000.000003',
+            (new SumOf(
+                new DecimalOf('100000000000000.000001'),
+                new DecimalOf('0.000002'),
+                6,
+            ))->asString(),
+        );
+    }
+
+    #[Test]
+    public function returnsIntProjectionTruncatedTowardZero(): void
+    {
+        $this->assertSame(
+            3,
+            (new SumOf(new DecimalOf('1.7'), new DecimalOf('1.5'), 1))->asInt(),
+        );
+    }
+
+    #[Test]
+    public function returnsFloatProjection(): void
+    {
+        $this->assertSame(
+            4.0,
+            (new SumOf(new DecimalOf('1.5'), new DecimalOf('2.5'), 1))->asFloat(),
+        );
+    }
+
+    #[Test]
+    public function returnsTextProjection(): void
+    {
+        $this->assertSame(
+            '4.0',
+            (new SumOf(new DecimalOf('1.5'), new DecimalOf('2.5'), 1))->asText()->value(),
+        );
+    }
+}


### PR DESCRIPTION
- Added Decimal\SumOf taking two Decimal operands and an explicit scale, delegating to bcadd
- Truncation toward zero on digits beyond scale matches bcmath default and the project rounding-free baseline

Part of #192