### PR TITLE
Rebuild Decimal Aggregates On DecimalEnvelope With MaxOf And MinOf

### DIFF
--- a/src/Decimal/DecimalEnvelope.php
+++ b/src/Decimal/DecimalEnvelope.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Decimal;
+
+use Override;
+use Primus\Text\Text;
+
+/**
+ * Base class for Decimal decorators.
+ *
+ * Envelope for {@see Decimal}, delegating all projections to the origin.
+ * Used as a parent for aggregates whose only job is to wrap a freshly
+ * computed Decimal in the same numeric contract.
+ */
+abstract readonly class DecimalEnvelope implements Decimal
+{
+    /**
+     * Ctor.
+     *
+     * @param Decimal $origin The wrapped decimal.
+     */
+    public function __construct(protected Decimal $origin) {}
+
+    #[Override]
+    final public function asInt(): int
+    {
+        return $this->origin->asInt();
+    }
+
+    #[Override]
+    final public function asFloat(): float
+    {
+        return $this->origin->asFloat();
+    }
+
+    #[Override]
+    final public function asText(): Text
+    {
+        return $this->origin->asText();
+    }
+
+    #[Override]
+    final public function asString(): string
+    {
+        return $this->origin->asString();
+    }
+}

--- a/src/Decimal/DecimalOfScalar.php
+++ b/src/Decimal/DecimalOfScalar.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Decimal;
+
+use Override;
+use Primus\Scalar\Scalar;
+use Primus\Text\Text;
+use Primus\Text\TextOf;
+
+/**
+ * Decimal lifted from a deferred {@see Scalar} producing a numeric string.
+ *
+ * The scalar is evaluated lazily on each projection call. Wrap in
+ * {@see Sticky} to memoize.
+ *
+ * Example:
+ *     $d = new DecimalOfScalar(new ScalarOf(static fn(): string => '3.14'));
+ *     $d->asString(); // "3.14"
+ *
+ * @phpstan-type NumericScalar Scalar<numeric-string>
+ */
+final readonly class DecimalOfScalar implements Decimal
+{
+    /**
+     * Ctor.
+     *
+     * @param NumericScalar $origin The deferred numeric-string scalar.
+     */
+    public function __construct(private Scalar $origin) {}
+
+    #[Override]
+    public function asInt(): int
+    {
+        return (int) $this->asString();
+    }
+
+    #[Override]
+    public function asFloat(): float
+    {
+        return (float) $this->asString();
+    }
+
+    #[Override]
+    public function asText(): Text
+    {
+        return new TextOf($this->asString());
+    }
+
+    #[Override]
+    public function asString(): string
+    {
+        return $this->origin->value();
+    }
+}

--- a/src/Decimal/MaxOf.php
+++ b/src/Decimal/MaxOf.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Decimal;
+
+use Primus\Scalar\ScalarOf;
+
+/**
+ * Greater of two Decimal operands, compared via bcmath at the given scale.
+ *
+ * Digits past `$scale` are ignored during comparison; ties resolve to the
+ * left operand.
+ *
+ * Example:
+ *     $max = new MaxOf(new DecimalOf('1.5'), new DecimalOf('2.7'), 1);
+ *     $max->asString(); // "2.7"
+ */
+final readonly class MaxOf extends DecimalEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Decimal $left The first operand.
+     * @param Decimal $right The second operand.
+     * @param int $scale Number of digits considered past the decimal point.
+     */
+    public function __construct(Decimal $left, Decimal $right, int $scale)
+    {
+        parent::__construct(new DecimalOfScalar(new ScalarOf(
+            static function () use ($left, $right, $scale): string {
+                $leftValue = $left->asString();
+                $rightValue = $right->asString();
+
+                return bccomp($leftValue, $rightValue, $scale) >= 0
+                    ? $leftValue
+                    : $rightValue;
+            },
+        )));
+    }
+}

--- a/src/Decimal/MinOf.php
+++ b/src/Decimal/MinOf.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Decimal;
+
+use Primus\Scalar\ScalarOf;
+
+/**
+ * Lesser of two Decimal operands, compared via bcmath at the given scale.
+ *
+ * Digits past `$scale` are ignored during comparison; ties resolve to the
+ * left operand.
+ *
+ * Example:
+ *     $min = new MinOf(new DecimalOf('1.5'), new DecimalOf('2.7'), 1);
+ *     $min->asString(); // "1.5"
+ */
+final readonly class MinOf extends DecimalEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Decimal $left The first operand.
+     * @param Decimal $right The second operand.
+     * @param int $scale Number of digits considered past the decimal point.
+     */
+    public function __construct(Decimal $left, Decimal $right, int $scale)
+    {
+        parent::__construct(new DecimalOfScalar(new ScalarOf(
+            static function () use ($left, $right, $scale): string {
+                $leftValue = $left->asString();
+                $rightValue = $right->asString();
+
+                return bccomp($leftValue, $rightValue, $scale) <= 0
+                    ? $leftValue
+                    : $rightValue;
+            },
+        )));
+    }
+}

--- a/src/Decimal/MultOf.php
+++ b/src/Decimal/MultOf.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Primus\Decimal;
 
-use Override;
-use Primus\Text\Text;
-use Primus\Text\TextOf;
+use Primus\Scalar\ScalarOf;
 
 /**
  * Product of two Decimal factors, computed via bcmath at the given scale.
@@ -18,7 +16,7 @@ use Primus\Text\TextOf;
  *     $product = new MultOf(new DecimalOf('1.5'), new DecimalOf('2'), 1);
  *     $product->asString(); // "3.0"
  */
-final readonly class MultOf implements Decimal
+final readonly class MultOf extends DecimalEnvelope
 {
     /**
      * Ctor.
@@ -27,29 +25,10 @@ final readonly class MultOf implements Decimal
      * @param Decimal $right The second factor.
      * @param int $scale Number of digits to keep past the decimal point.
      */
-    public function __construct(private Decimal $left, private Decimal $right, private int $scale) {}
-
-    #[Override]
-    public function asInt(): int
+    public function __construct(Decimal $left, Decimal $right, int $scale)
     {
-        return (int) $this->asString();
-    }
-
-    #[Override]
-    public function asFloat(): float
-    {
-        return (float) $this->asString();
-    }
-
-    #[Override]
-    public function asText(): Text
-    {
-        return new TextOf($this->asString());
-    }
-
-    #[Override]
-    public function asString(): string
-    {
-        return bcmul($this->left->asString(), $this->right->asString(), $this->scale);
+        parent::__construct(new DecimalOfScalar(new ScalarOf(
+            static fn(): string => bcmul($left->asString(), $right->asString(), $scale),
+        )));
     }
 }

--- a/src/Decimal/SumOf.php
+++ b/src/Decimal/SumOf.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Primus\Decimal;
 
-use Override;
-use Primus\Text\Text;
-use Primus\Text\TextOf;
+use Primus\Scalar\ScalarOf;
 
 /**
  * Sum of two Decimal addends, computed via bcmath at the given scale.
@@ -18,7 +16,7 @@ use Primus\Text\TextOf;
  *     $sum = new SumOf(new DecimalOf('1.5'), new DecimalOf('2.5'), 1);
  *     $sum->asString(); // "4.0"
  */
-final readonly class SumOf implements Decimal
+final readonly class SumOf extends DecimalEnvelope
 {
     /**
      * Ctor.
@@ -27,29 +25,10 @@ final readonly class SumOf implements Decimal
      * @param Decimal $right The second addend.
      * @param int $scale Number of digits to keep past the decimal point.
      */
-    public function __construct(private Decimal $left, private Decimal $right, private int $scale) {}
-
-    #[Override]
-    public function asInt(): int
+    public function __construct(Decimal $left, Decimal $right, int $scale)
     {
-        return (int) $this->asString();
-    }
-
-    #[Override]
-    public function asFloat(): float
-    {
-        return (float) $this->asString();
-    }
-
-    #[Override]
-    public function asText(): Text
-    {
-        return new TextOf($this->asString());
-    }
-
-    #[Override]
-    public function asString(): string
-    {
-        return bcadd($this->left->asString(), $this->right->asString(), $this->scale);
+        parent::__construct(new DecimalOfScalar(new ScalarOf(
+            static fn(): string => bcadd($left->asString(), $right->asString(), $scale),
+        )));
     }
 }

--- a/tests/Decimal/DecimalOfScalarTest.php
+++ b/tests/Decimal/DecimalOfScalarTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Decimal;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Decimal\DecimalOfScalar;
+use Primus\Scalar\ScalarOf;
+
+final class DecimalOfScalarTest extends TestCase
+{
+    #[Test]
+    public function liftsNumericStringFromScalar(): void
+    {
+        $this->assertSame(
+            '3.14',
+            (new DecimalOfScalar(new ScalarOf(static fn(): string => '3.14')))->asString(),
+        );
+    }
+
+    #[Test]
+    public function truncatesIntProjectionTowardZero(): void
+    {
+        $this->assertSame(
+            3,
+            (new DecimalOfScalar(new ScalarOf(static fn(): string => '3.99')))->asInt(),
+        );
+    }
+
+    #[Test]
+    public function returnsFloatProjection(): void
+    {
+        $this->assertSame(
+            3.14,
+            (new DecimalOfScalar(new ScalarOf(static fn(): string => '3.14')))->asFloat(),
+        );
+    }
+
+    #[Test]
+    public function returnsTextProjection(): void
+    {
+        $this->assertSame(
+            '3.14',
+            (new DecimalOfScalar(new ScalarOf(static fn(): string => '3.14')))->asText()->value(),
+        );
+    }
+}

--- a/tests/Decimal/MaxOfTest.php
+++ b/tests/Decimal/MaxOfTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Decimal;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Decimal\DecimalOf;
+use Primus\Decimal\MaxOf;
+
+final class MaxOfTest extends TestCase
+{
+    #[Test]
+    public function picksLargerOperand(): void
+    {
+        $this->assertSame(
+            '2.7',
+            (new MaxOf(new DecimalOf('1.5'), new DecimalOf('2.7'), 1))->asString(),
+        );
+    }
+
+    #[Test]
+    public function picksLeftOnTie(): void
+    {
+        $this->assertSame(
+            '1.5',
+            (new MaxOf(new DecimalOf('1.5'), new DecimalOf('1.5'), 1))->asString(),
+        );
+    }
+
+    #[Test]
+    public function comparesAtGivenScaleOnly(): void
+    {
+        $this->assertSame(
+            '1.5',
+            (new MaxOf(new DecimalOf('1.5'), new DecimalOf('1.51'), 1))->asString(),
+        );
+    }
+
+    #[Test]
+    public function picksLargerOfNegatives(): void
+    {
+        $this->assertSame(
+            '-2.7',
+            (new MaxOf(new DecimalOf('-3.0'), new DecimalOf('-2.7'), 1))->asString(),
+        );
+    }
+
+    #[Test]
+    public function picksPositiveOverNegative(): void
+    {
+        $this->assertSame(
+            '1.5',
+            (new MaxOf(new DecimalOf('-2.7'), new DecimalOf('1.5'), 1))->asString(),
+        );
+    }
+
+    #[Test]
+    public function preservesPrecisionBeyondFloat53(): void
+    {
+        $this->assertSame(
+            '100000000000000.000002',
+            (new MaxOf(
+                new DecimalOf('100000000000000.000001'),
+                new DecimalOf('100000000000000.000002'),
+                6,
+            ))->asString(),
+        );
+    }
+}

--- a/tests/Decimal/MinOfTest.php
+++ b/tests/Decimal/MinOfTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Decimal;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Decimal\DecimalOf;
+use Primus\Decimal\MinOf;
+
+final class MinOfTest extends TestCase
+{
+    #[Test]
+    public function picksSmallerOperand(): void
+    {
+        $this->assertSame(
+            '1.5',
+            (new MinOf(new DecimalOf('1.5'), new DecimalOf('2.7'), 1))->asString(),
+        );
+    }
+
+    #[Test]
+    public function picksLeftOnTie(): void
+    {
+        $this->assertSame(
+            '1.5',
+            (new MinOf(new DecimalOf('1.5'), new DecimalOf('1.5'), 1))->asString(),
+        );
+    }
+
+    #[Test]
+    public function comparesAtGivenScaleOnly(): void
+    {
+        $this->assertSame(
+            '1.5',
+            (new MinOf(new DecimalOf('1.5'), new DecimalOf('1.51'), 1))->asString(),
+        );
+    }
+
+    #[Test]
+    public function picksSmallerOfNegatives(): void
+    {
+        $this->assertSame(
+            '-3.0',
+            (new MinOf(new DecimalOf('-3.0'), new DecimalOf('-2.7'), 1))->asString(),
+        );
+    }
+
+    #[Test]
+    public function picksNegativeOverPositive(): void
+    {
+        $this->assertSame(
+            '-2.7',
+            (new MinOf(new DecimalOf('-2.7'), new DecimalOf('1.5'), 1))->asString(),
+        );
+    }
+
+    #[Test]
+    public function preservesPrecisionBeyondFloat53(): void
+    {
+        $this->assertSame(
+            '100000000000000.000001',
+            (new MinOf(
+                new DecimalOf('100000000000000.000001'),
+                new DecimalOf('100000000000000.000002'),
+                6,
+            ))->asString(),
+        );
+    }
+}


### PR DESCRIPTION
- Introduced DecimalEnvelope so aggregates inherit asInt asFloat asText asString projections from a single delegate
- Added DecimalOfScalar lifting a Scalar of numeric-string into a Decimal for lazy decorator construction
- Rebuilt SumOf and MultOf on top of DecimalEnvelope, dropping per-class projection boilerplate
- Added MaxOf and MinOf on the same base, picking the left operand on tie

Part of #192