### PR TITLE
Add Decimal DivOf And ModOf Via bcmath

### DIFF
--- a/src/Decimal/DivOf.php
+++ b/src/Decimal/DivOf.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Decimal;
+
+use Primus\Scalar\ScalarOf;
+
+/**
+ * Quotient of two Decimal operands, computed via bcmath at the given scale.
+ *
+ * Digits beyond `$scale` are truncated toward zero by bcmath without
+ * rounding. A zero divisor raises DivisionByZeroError at first projection.
+ *
+ * Example:
+ *     $div = new DivOf(new DecimalOf('1'), new DecimalOf('3'), 4);
+ *     $div->asString(); // "0.3333"
+ */
+final readonly class DivOf extends DecimalEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Decimal $dividend The number to divide.
+     * @param Decimal $divisor The number to divide by.
+     * @param int $scale Number of digits to keep past the decimal point.
+     */
+    public function __construct(Decimal $dividend, Decimal $divisor, int $scale)
+    {
+        parent::__construct(new DecimalOfScalar(new ScalarOf(
+            static fn(): string => bcdiv($dividend->asString(), $divisor->asString(), $scale),
+        )));
+    }
+}

--- a/src/Decimal/ModOf.php
+++ b/src/Decimal/ModOf.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Decimal;
+
+use Primus\Scalar\ScalarOf;
+
+/**
+ * Remainder of dividing one Decimal by another via bcmath.
+ *
+ * The sign follows the dividend. A zero divisor raises DivisionByZeroError
+ * at first projection.
+ *
+ * Example:
+ *     $mod = new ModOf(new DecimalOf('7.5'), new DecimalOf('2'), 1);
+ *     $mod->asString(); // "1.5"
+ */
+final readonly class ModOf extends DecimalEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Decimal $dividend The number to divide.
+     * @param Decimal $divisor The number to divide by.
+     * @param int $scale Number of digits to keep past the decimal point.
+     */
+    public function __construct(Decimal $dividend, Decimal $divisor, int $scale)
+    {
+        parent::__construct(new DecimalOfScalar(new ScalarOf(
+            static fn(): string => bcmod($dividend->asString(), $divisor->asString(), $scale),
+        )));
+    }
+}

--- a/tests/Decimal/DivOfTest.php
+++ b/tests/Decimal/DivOfTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Decimal;
+
+use DivisionByZeroError;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Decimal\DecimalOf;
+use Primus\Decimal\DivOf;
+
+final class DivOfTest extends TestCase
+{
+    #[Test]
+    public function dividesExactly(): void
+    {
+        $this->assertSame(
+            '3.00',
+            (new DivOf(new DecimalOf('6'), new DecimalOf('2'), 2))->asString(),
+        );
+    }
+
+    #[Test]
+    public function truncatesRepeatingDecimalAtScale(): void
+    {
+        $this->assertSame(
+            '0.3333',
+            (new DivOf(new DecimalOf('1'), new DecimalOf('3'), 4))->asString(),
+        );
+    }
+
+    #[Test]
+    public function truncatesNegativeQuotientTowardZero(): void
+    {
+        $this->assertSame(
+            '-3.5',
+            (new DivOf(new DecimalOf('-7'), new DecimalOf('2'), 1))->asString(),
+        );
+    }
+
+    #[Test]
+    public function preservesPrecisionBeyondFloat53(): void
+    {
+        $this->assertSame(
+            '50000000000000.000000',
+            (new DivOf(
+                new DecimalOf('100000000000000.000001'),
+                new DecimalOf('2'),
+                6,
+            ))->asString(),
+        );
+    }
+
+    #[Test]
+    public function zeroDivisorRejectsStringAccess(): void
+    {
+        $this->expectException(DivisionByZeroError::class);
+
+        (new DivOf(new DecimalOf('1'), new DecimalOf('0'), 4))->asString();
+    }
+}

--- a/tests/Decimal/ModOfTest.php
+++ b/tests/Decimal/ModOfTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Decimal;
+
+use DivisionByZeroError;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Decimal\DecimalOf;
+use Primus\Decimal\ModOf;
+
+final class ModOfTest extends TestCase
+{
+    #[Test]
+    public function returnsFractionalRemainder(): void
+    {
+        $this->assertSame(
+            '1.5',
+            (new ModOf(new DecimalOf('7.5'), new DecimalOf('2'), 1))->asString(),
+        );
+    }
+
+    #[Test]
+    public function returnsZeroOnExactDivision(): void
+    {
+        $this->assertSame(
+            '0.0',
+            (new ModOf(new DecimalOf('6'), new DecimalOf('2'), 1))->asString(),
+        );
+    }
+
+    #[Test]
+    public function signFollowsDividendForNegativeDividend(): void
+    {
+        $this->assertSame(
+            '-1.5',
+            (new ModOf(new DecimalOf('-7.5'), new DecimalOf('2'), 1))->asString(),
+        );
+    }
+
+    #[Test]
+    public function signFollowsDividendForNegativeDivisor(): void
+    {
+        $this->assertSame(
+            '1.5',
+            (new ModOf(new DecimalOf('7.5'), new DecimalOf('-2'), 1))->asString(),
+        );
+    }
+
+    #[Test]
+    public function zeroDivisorRejectsStringAccess(): void
+    {
+        $this->expectException(DivisionByZeroError::class);
+
+        (new ModOf(new DecimalOf('1'), new DecimalOf('0'), 4))->asString();
+    }
+}


### PR DESCRIPTION
- Added Decimal\DivOf taking two operands and an explicit scale, delegating to bcdiv with truncation toward zero beyond scale
- Added Decimal\ModOf taking two operands and an explicit scale, delegating to bcmod with the remainder sign following the dividend
- Zero divisor raises DivisionByZeroError on first projection for both classes

Part of #192