### PR TITLE
Add Decimal Abs Via bcmul

### DIFF
--- a/src/Decimal/Abs.php
+++ b/src/Decimal/Abs.php
@@ -29,10 +29,11 @@ final readonly class Abs extends DecimalEnvelope
         parent::__construct(new DecimalOfScalar(new ScalarOf(
             static function () use ($origin, $scale): string {
                 $value = $origin->asString();
+                $factor = str_starts_with($value, '-')
+                    ? '-1'
+                    : '1';
 
-                return str_starts_with($value, '-')
-                    ? bcmul($value, '-1', $scale)
-                    : $value;
+                return bcmul($value, $factor, $scale);
             },
         )));
     }

--- a/src/Decimal/Abs.php
+++ b/src/Decimal/Abs.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Decimal;
+
+use Primus\Scalar\ScalarOf;
+
+/**
+ * Absolute value of a Decimal, computed via bcmath at the given scale.
+ *
+ * Negative origins are multiplied by -1 with `bcmul`; positives pass
+ * through unchanged. Digits beyond `$scale` are truncated toward zero.
+ *
+ * Example:
+ *     $abs = new Abs(new DecimalOf('-3.14'), 2);
+ *     $abs->asString(); // "3.14"
+ */
+final readonly class Abs extends DecimalEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Decimal $origin The decimal to take the absolute value of.
+     * @param int $scale Number of digits to keep past the decimal point.
+     */
+    public function __construct(Decimal $origin, int $scale)
+    {
+        parent::__construct(new DecimalOfScalar(new ScalarOf(
+            static function () use ($origin, $scale): string {
+                $value = $origin->asString();
+
+                return str_starts_with($value, '-')
+                    ? bcmul($value, '-1', $scale)
+                    : $value;
+            },
+        )));
+    }
+}

--- a/tests/Decimal/AbsTest.php
+++ b/tests/Decimal/AbsTest.php
@@ -30,11 +30,20 @@ final class AbsTest extends TestCase
     }
 
     #[Test]
-    public function leavesZeroUnchanged(): void
+    public function returnsZeroForZeroSource(): void
     {
         $this->assertSame(
             '0',
             (new Abs(new DecimalOf('0'), 0))->asString(),
+        );
+    }
+
+    #[Test]
+    public function truncatesPositiveBeyondScale(): void
+    {
+        $this->assertSame(
+            '3.1',
+            (new Abs(new DecimalOf('3.14'), 1))->asString(),
         );
     }
 

--- a/tests/Decimal/AbsTest.php
+++ b/tests/Decimal/AbsTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Decimal;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Decimal\Abs;
+use Primus\Decimal\DecimalOf;
+
+final class AbsTest extends TestCase
+{
+    #[Test]
+    public function flipsNegativeSign(): void
+    {
+        $this->assertSame(
+            '3.14',
+            (new Abs(new DecimalOf('-3.14'), 2))->asString(),
+        );
+    }
+
+    #[Test]
+    public function leavesPositiveUnchanged(): void
+    {
+        $this->assertSame(
+            '3.14',
+            (new Abs(new DecimalOf('3.14'), 2))->asString(),
+        );
+    }
+
+    #[Test]
+    public function leavesZeroUnchanged(): void
+    {
+        $this->assertSame(
+            '0',
+            (new Abs(new DecimalOf('0'), 0))->asString(),
+        );
+    }
+
+    #[Test]
+    public function flipsNegativeZeroToPositive(): void
+    {
+        $this->assertSame(
+            '0.00',
+            (new Abs(new DecimalOf('-0.00'), 2))->asString(),
+        );
+    }
+
+    #[Test]
+    public function preservesPrecisionBeyondFloat53AtSufficientScale(): void
+    {
+        $this->assertSame(
+            '100000000000000.000001',
+            (new Abs(new DecimalOf('-100000000000000.000001'), 6))->asString(),
+        );
+    }
+
+    #[Test]
+    public function truncatesNegativeBeyondScale(): void
+    {
+        $this->assertSame(
+            '3.1',
+            (new Abs(new DecimalOf('-3.14'), 1))->asString(),
+        );
+    }
+}


### PR DESCRIPTION
- Added Decimal\Abs taking an origin and an explicit scale, applying bcmul for both signs so the result is normalized to the requested scale either way
- Negative origins flip via bcmul(value, -1, scale); positives pass through bcmul(value, 1, scale) so truncation behavior is symmetric

Part of #192