### PR TITLE
Add Decimal Sticky Caching All Projections

### DIFF
--- a/src/Decimal/Sticky.php
+++ b/src/Decimal/Sticky.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Decimal;
+
+use Override;
+use Primus\Number\Sticky as NumberSticky;
+use Primus\Text\Text;
+
+/**
+ * Cached version of a {@see Decimal}.
+ *
+ * Delegates int, float and text caching to {@see NumberSticky} and adds
+ * its own slot for the numeric-string projection so each origin call
+ * happens at most once.
+ *
+ * Example:
+ *     $cached = new Sticky(new SumOf(...));
+ *     $cached->asString(); // computed once, walks the tree
+ *     $cached->asString(); // cached
+ */
+final class Sticky implements Decimal
+{
+    private readonly NumberSticky $delegate;
+
+    /** @phpstan-ignore haspadar.immutable (lazy memoization flag; idempotent externally) */
+    private bool $stringComputed = false;
+
+    /**
+     * @var numeric-string
+     * @phpstan-ignore haspadar.immutable (lazy memoization slot; idempotent externally)
+     */
+    private string $stringStored = '0';
+
+    /**
+     * Ctor.
+     *
+     * @param Decimal $origin The decimal whose projections are cached.
+     */
+    public function __construct(private readonly Decimal $origin)
+    {
+        $this->delegate = new NumberSticky($origin);
+    }
+
+    #[Override]
+    public function asInt(): int
+    {
+        return $this->delegate->asInt();
+    }
+
+    #[Override]
+    public function asFloat(): float
+    {
+        return $this->delegate->asFloat();
+    }
+
+    #[Override]
+    public function asText(): Text
+    {
+        return $this->delegate->asText();
+    }
+
+    #[Override]
+    public function asString(): string
+    {
+        if (!$this->stringComputed) {
+            $this->stringStored = $this->origin->asString();
+            $this->stringComputed = true;
+        }
+
+        return $this->stringStored;
+    }
+}

--- a/tests/Decimal/Fakes/CountingDecimal.php
+++ b/tests/Decimal/Fakes/CountingDecimal.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Decimal\Fakes;
+
+use Override;
+use Primus\Decimal\Decimal;
+use Primus\Text\Text;
+use Primus\Text\TextOf;
+
+/**
+ * Decimal fake that counts how many times asString is invoked.
+ *
+ * Used to verify caching behaviour of {@see \Primus\Decimal\Sticky}.
+ */
+final class CountingDecimal implements Decimal
+{
+    public int $stringCalls = 0;
+
+    /**
+     * Ctor.
+     *
+     * @param numeric-string $value Numeric string returned from every projection.
+     */
+    public function __construct(private readonly string $value) {}
+
+    #[Override]
+    public function asInt(): int
+    {
+        return (int) $this->value;
+    }
+
+    #[Override]
+    public function asFloat(): float
+    {
+        return (float) $this->value;
+    }
+
+    #[Override]
+    public function asText(): Text
+    {
+        return new TextOf($this->value);
+    }
+
+    #[Override]
+    public function asString(): string
+    {
+        ++$this->stringCalls;
+
+        return $this->value;
+    }
+}

--- a/tests/Decimal/StickyTest.php
+++ b/tests/Decimal/StickyTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Primus\Decimal\Decimal;
 use Primus\Decimal\DecimalOf;
 use Primus\Decimal\Sticky;
+use Primus\Tests\Decimal\Fakes\CountingDecimal;
 
 final class StickyTest extends TestCase
 {
@@ -51,5 +52,18 @@ final class StickyTest extends TestCase
         $sticky = new Sticky(new DecimalOf('3.14'));
 
         $this->assertSame($sticky->asText(), $sticky->asText());
+    }
+
+    #[Test]
+    public function callsOriginAsStringAtMostOnce(): void
+    {
+        $origin = new CountingDecimal('3.14');
+        $sticky = new Sticky($origin);
+
+        $sticky->asString();
+        $sticky->asString();
+        $sticky->asString();
+
+        $this->assertSame(1, $origin->stringCalls);
     }
 }

--- a/tests/Decimal/StickyTest.php
+++ b/tests/Decimal/StickyTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Decimal;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Decimal\Decimal;
+use Primus\Decimal\DecimalOf;
+use Primus\Decimal\Sticky;
+
+final class StickyTest extends TestCase
+{
+    #[Test]
+    public function preservesDecimalType(): void
+    {
+        $this->assertInstanceOf(Decimal::class, new Sticky(new DecimalOf('3.14')));
+    }
+
+    #[Test]
+    public function returnsSameIntOnRepeatedCalls(): void
+    {
+        $sticky = new Sticky(new DecimalOf('3.14'));
+
+        $this->assertSame(3, $sticky->asInt());
+        $this->assertSame(3, $sticky->asInt());
+    }
+
+    #[Test]
+    public function returnsSameFloatOnRepeatedCalls(): void
+    {
+        $sticky = new Sticky(new DecimalOf('3.14'));
+
+        $this->assertSame(3.14, $sticky->asFloat());
+        $this->assertSame(3.14, $sticky->asFloat());
+    }
+
+    #[Test]
+    public function returnsSameStringOnRepeatedCalls(): void
+    {
+        $sticky = new Sticky(new DecimalOf('3.14'));
+
+        $this->assertSame('3.14', $sticky->asString());
+        $this->assertSame('3.14', $sticky->asString());
+    }
+
+    #[Test]
+    public function returnsSameTextInstanceOnRepeatedCalls(): void
+    {
+        $sticky = new Sticky(new DecimalOf('3.14'));
+
+        $this->assertSame($sticky->asText(), $sticky->asText());
+    }
+}


### PR DESCRIPTION
- Added Decimal\Sticky composing Number\Sticky for int float text projections and caching numeric-string locally so each origin call happens at most once

Part of #192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced optimized decimal handling with built-in caching of conversion results, improving performance on repeated conversions.

* **Tests**
  * Added test coverage verifying proper caching behavior and conversion stability across repeated calls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->