### PR TITLE
Document Decimal Namespace In README And AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,16 @@ new decorators — extend it to inherit interface compliance for free.
   `IntegerOf`, `SumOf`, `MultOf`, `MaxOf`, `MinOf`, `DivOf` (truncating),
   `ModOf`, `Abs`, `Sticky` (delegates caching to `Number\Sticky`).
 
+- **`Primus\Decimal`** — arbitrary-precision decimal primitives backed
+  by bcmath. `Decimal` interface (marker extending `Number`) with a
+  fourth projection `asString(): numeric-string` ready for bcmath
+  consumption. Wrappers `DecimalOf`, `DecimalOfFloat`, `DecimalOfInt`,
+  `DecimalOfScalar` (lazy from a `Scalar<numeric-string>`). Binary
+  aggregates `SumOf`, `MultOf`, `MaxOf`, `MinOf`, `DivOf`, `ModOf`, and
+  unary `Abs` take an explicit `int $scale`. `DecimalEnvelope` base class
+  removes projection boilerplate from aggregates. `Sticky` composes
+  `Number\Sticky` and adds a numeric-string slot.
+
 - **`Primus\Time`** — `DateTimeImmutable` wrappers.
   `Time` interface, `TimeOf` (wrap a string or `DateTimeImmutable`),
   `Iso` (format as ISO 8601 string). Sources of the current moment stay

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ new decorators — extend it to inherit interface compliance for free.
   consumption. Wrappers `DecimalOf`, `DecimalOfFloat`, `DecimalOfInt`,
   `DecimalOfScalar` (lazy from a `Scalar<numeric-string>`). Binary
   aggregates `SumOf`, `MultOf`, `MaxOf`, `MinOf`, `DivOf`, `ModOf`, and
-  unary `Abs` take an explicit `int $scale`. `DecimalEnvelope` base class
+  unary `Abs` each take an explicit `int $scale`. `DecimalEnvelope` base class
   removes projection boilerplate from aggregates. `Sticky` composes
   `Number\Sticky` and adds a numeric-string slot.
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,37 @@ $total = (new SumOf(
 // 42
 ```
 
+## Decimals
+
+To wrap an arbitrary-precision decimal value:
+
+```php
+$d = new DecimalOf('100000000000000.000001');
+$d->asString(); // "100000000000000.000001" — exact, beyond float53
+$d->asText()->value(); // "100000000000000.000001"
+```
+
+Float and int sources stay exact at their own precision:
+
+```php
+(new DecimalOfFloat(0.3))->asString(); // "0.3"
+(new DecimalOfInt(42))->asString();    // "42"
+```
+
+To do bcmath arithmetic at a chosen scale (digits past the decimal point):
+
+```php
+$sum = new SumOf(
+    new DecimalOf('0.1'),
+    new DecimalOf('0.2'),
+    1,
+);
+$sum->asString(); // "0.3"
+
+$ratio = new DivOf(new DecimalOf('1'), new DecimalOf('3'), 4);
+$ratio->asString(); // "0.3333"
+```
+
 ## Time
 
 To wrap an existing timestamp and format it:


### PR DESCRIPTION
- Added a Decimals section to README showing DecimalOf precision past float53 and bcmath-backed arithmetic at an explicit scale
- Added the Decimal namespace entry to AGENTS so agents discover the new family alongside Number and Integer

Closes #192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for arbitrary-precision decimal operations, including examples for handling decimal values from different sources and performing arithmetic with customizable scales.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->