### PR TITLE
Replace Single-Arg Closures With First-Class Callable In Text Decorators

### DIFF
--- a/src/Text/Trimmed.php
+++ b/src/Text/Trimmed.php
@@ -27,7 +27,7 @@ final readonly class Trimmed extends TextEnvelope
         parent::__construct(
             new Mapped(
                 $origin,
-                new FuncOf(static fn(string $s): string => trim($s)),
+                new FuncOf(trim(...)),
             ),
         );
     }

--- a/src/Text/WithoutTags.php
+++ b/src/Text/WithoutTags.php
@@ -27,7 +27,7 @@ final readonly class WithoutTags extends TextEnvelope
         parent::__construct(
             new Mapped(
                 $origin,
-                new FuncOf(static fn(string $s): string => strip_tags($s)),
+                new FuncOf(strip_tags(...)),
             ),
         );
     }


### PR DESCRIPTION
- Switched Trimmed and WithoutTags to FuncOf(trim(...)) and FuncOf(strip_tags(...)) since both wrap a single-arg native function with no captured state
- Other Text decorators keep their closures because they pass extra arguments (charset, padding, count) or normalize null returns through a throw