### PR TITLE
Add Text StartsWith And EndsWith Predicates

### DIFF
--- a/.sheriff.yaml
+++ b/.sheriff.yaml
@@ -12,6 +12,7 @@ override:
             afferentCoupling:
                 maxAfferent: 10
                 ignoreInterfaces: true
+                ignoreAbstract: true
                 excludedClasses:
                     - Primus\Text\TextOf
                     - Primus\Text\Mapped

--- a/.sheriff/phpstan/phpstan.neon
+++ b/.sheriff/phpstan/phpstan.neon
@@ -26,5 +26,6 @@ parameters:
                 - Primus\Func\FuncOf
                 - Primus\Scalar\ScalarOf
             maxAfferent: 10
+            ignoreAbstract: true
         prohibitStaticMethods:
             allowNamedConstructors: true

--- a/src/Text/EndsWith.php
+++ b/src/Text/EndsWith.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Text;
+
+use Primus\Scalar\ScalarEnvelope;
+use Primus\Scalar\ScalarOf;
+
+/**
+ * Checks whether one text ends with another.
+ *
+ * Delegates to {@see str_ends_with()}; byte-level comparison is safe
+ * for UTF-8 because UTF-8 sequences cannot overlap byte boundaries of
+ * other sequences.
+ *
+ * Example:
+ *     $ends = new EndsWith(TextOf::ofString('hello world'), TextOf::ofString('world'));
+ *     echo $ends->value(); // true
+ *
+ * @extends ScalarEnvelope<bool>
+ */
+final readonly class EndsWith extends ScalarEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Text $haystack The text to inspect.
+     * @param Text $needle The suffix to look for.
+     */
+    public function __construct(Text $haystack, Text $needle)
+    {
+        parent::__construct(
+            new ScalarOf(
+                static fn(): bool => str_ends_with($haystack->value(), $needle->value()),
+            ),
+        );
+    }
+}

--- a/src/Text/StartsWith.php
+++ b/src/Text/StartsWith.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Text;
+
+use Primus\Scalar\ScalarEnvelope;
+use Primus\Scalar\ScalarOf;
+
+/**
+ * Checks whether one text starts with another.
+ *
+ * Delegates to {@see str_starts_with()}; byte-level comparison is safe
+ * for UTF-8 because UTF-8 sequences cannot overlap byte boundaries of
+ * other sequences.
+ *
+ * Example:
+ *     $starts = new StartsWith(TextOf::ofString('hello world'), TextOf::ofString('hello'));
+ *     echo $starts->value(); // true
+ *
+ * @extends ScalarEnvelope<bool>
+ */
+final readonly class StartsWith extends ScalarEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Text $haystack The text to inspect.
+     * @param Text $needle The prefix to look for.
+     */
+    public function __construct(Text $haystack, Text $needle)
+    {
+        parent::__construct(
+            new ScalarOf(
+                static fn(): bool => str_starts_with($haystack->value(), $needle->value()),
+            ),
+        );
+    }
+}

--- a/src/Text/TextEnvelope.php
+++ b/src/Text/TextEnvelope.php
@@ -8,8 +8,6 @@ use Override;
 
 /**
  * Envelope for {@see Text}, delegating all calls to the origin.
- *
- * @phpstan-ignore haspadar.afferentCoupling (base for every Text decorator; high coupling is intrinsic to the Envelope pattern)
  */
 abstract readonly class TextEnvelope implements Text
 {

--- a/tests/Text/EndsWithTest.php
+++ b/tests/Text/EndsWithTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Text;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Text\EndsWith;
+use Primus\Text\TextOf;
+
+final class EndsWithTest extends TestCase
+{
+    #[Test]
+    public function returnsTrueWhenHaystackEndsWithNeedle(): void
+    {
+        self::assertTrue(
+            (new EndsWith(TextOf::ofString('hello world'), TextOf::ofString('world')))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsFalseWhenHaystackDoesNotEndWithNeedle(): void
+    {
+        self::assertFalse(
+            (new EndsWith(TextOf::ofString('hello world'), TextOf::ofString('hello')))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsTrueWhenNeedleIsEmpty(): void
+    {
+        self::assertTrue(
+            (new EndsWith(TextOf::ofString('hello'), TextOf::ofString('')))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsFalseWhenNeedleIsLongerThanHaystack(): void
+    {
+        self::assertFalse(
+            (new EndsWith(TextOf::ofString('hi'), TextOf::ofString('hello')))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsTrueOnExactMatch(): void
+    {
+        self::assertTrue(
+            (new EndsWith(TextOf::ofString('abc'), TextOf::ofString('abc')))->value(),
+        );
+    }
+
+    #[Test]
+    public function respectsUtf8MultibyteCharacters(): void
+    {
+        self::assertTrue(
+            (new EndsWith(TextOf::ofString('привет мир'), TextOf::ofString('мир')))->value(),
+        );
+    }
+}

--- a/tests/Text/StartsWithTest.php
+++ b/tests/Text/StartsWithTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Text;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Text\StartsWith;
+use Primus\Text\TextOf;
+
+final class StartsWithTest extends TestCase
+{
+    #[Test]
+    public function returnsTrueWhenHaystackStartsWithNeedle(): void
+    {
+        self::assertTrue(
+            (new StartsWith(TextOf::ofString('hello world'), TextOf::ofString('hello')))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsFalseWhenHaystackDoesNotStartWithNeedle(): void
+    {
+        self::assertFalse(
+            (new StartsWith(TextOf::ofString('hello world'), TextOf::ofString('world')))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsTrueWhenNeedleIsEmpty(): void
+    {
+        self::assertTrue(
+            (new StartsWith(TextOf::ofString('hello'), TextOf::ofString('')))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsFalseWhenNeedleIsLongerThanHaystack(): void
+    {
+        self::assertFalse(
+            (new StartsWith(TextOf::ofString('hi'), TextOf::ofString('hello')))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsTrueOnExactMatch(): void
+    {
+        self::assertTrue(
+            (new StartsWith(TextOf::ofString('abc'), TextOf::ofString('abc')))->value(),
+        );
+    }
+
+    #[Test]
+    public function respectsUtf8MultibyteCharacters(): void
+    {
+        self::assertTrue(
+            (new StartsWith(TextOf::ofString('привет мир'), TextOf::ofString('привет')))->value(),
+        );
+    }
+}


### PR DESCRIPTION
- Added Text\StartsWith and Text\EndsWith as Scalar<bool> predicates delegating to PHP str_starts_with and str_ends_with
- Tests cover empty needle, exact match, needle longer than haystack and UTF-8 multibyte input
- Switched the PHPStan afferent-coupling rule to ignoreAbstract, retiring the per-class inline suppression on TextEnvelope and the ScalarEnvelope entry from excludedClasses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `StartsWith` utility to check if text begins with a specified substring
  * Introduced `EndsWith` utility to check if text ends with a specified substring
  * Both utilities include comprehensive UTF-8 multibyte character support for global text operations

* **Tests**
  * Added test coverage for new text utilities, including edge cases and UTF-8 character handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->