### PR TITLE
Add Text Contains And IsBlank Predicates

### DIFF
--- a/src/Text/Contains.php
+++ b/src/Text/Contains.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Text;
+
+use Primus\Scalar\ScalarEnvelope;
+use Primus\Scalar\ScalarOf;
+
+/**
+ * Checks whether one text contains another.
+ *
+ * Delegates to {@see str_contains()}; byte-level search is safe for
+ * UTF-8 because UTF-8 sequences cannot overlap byte boundaries of
+ * other sequences.
+ *
+ * Example:
+ *     $has = new Contains(TextOf::ofString('hello world'), TextOf::ofString('lo wo'));
+ *     echo $has->value(); // true
+ *
+ * @extends ScalarEnvelope<bool>
+ */
+final readonly class Contains extends ScalarEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Text $haystack The text to search within.
+     * @param Text $needle The substring to look for.
+     */
+    public function __construct(Text $haystack, Text $needle)
+    {
+        parent::__construct(
+            new ScalarOf(
+                static fn(): bool => str_contains($haystack->value(), $needle->value()),
+            ),
+        );
+    }
+}

--- a/src/Text/IsBlank.php
+++ b/src/Text/IsBlank.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Text;
+
+use Primus\Scalar\ScalarEnvelope;
+use Primus\Scalar\ScalarOf;
+
+/**
+ * Checks whether the text is empty or contains only Unicode whitespace.
+ *
+ * Treats both ASCII whitespace and Unicode whitespace (including
+ * non-breaking spaces, line/paragraph separators, etc.) as blank.
+ *
+ * Example:
+ *     $blank = new IsBlank(TextOf::ofString(" \t\n"));
+ *     echo $blank->value(); // true
+ *
+ * @extends ScalarEnvelope<bool>
+ */
+final readonly class IsBlank extends ScalarEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Text $text The text to check.
+     */
+    public function __construct(Text $text)
+    {
+        parent::__construct(
+            new ScalarOf(
+                static fn(): bool => preg_match('/^\s*$/u', $text->value()) === 1,
+            ),
+        );
+    }
+}

--- a/src/Text/IsBlank.php
+++ b/src/Text/IsBlank.php
@@ -21,6 +21,8 @@ use Primus\Scalar\ScalarOf;
  */
 final readonly class IsBlank extends ScalarEnvelope
 {
+    private const string BLANK_PATTERN = '/(*UCP)^\s*$/u';
+
     /**
      * Ctor.
      *
@@ -30,7 +32,7 @@ final readonly class IsBlank extends ScalarEnvelope
     {
         parent::__construct(
             new ScalarOf(
-                static fn(): bool => preg_match('/^\s*$/u', $text->value()) === 1,
+                static fn(): bool => preg_match(self::BLANK_PATTERN, $text->value()) === 1,
             ),
         );
     }

--- a/tests/Text/ContainsTest.php
+++ b/tests/Text/ContainsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Text;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Text\Contains;
+use Primus\Text\TextOf;
+
+final class ContainsTest extends TestCase
+{
+    #[Test]
+    public function returnsTrueWhenNeedleIsInside(): void
+    {
+        self::assertTrue(
+            (new Contains(TextOf::ofString('hello world'), TextOf::ofString('lo wo')))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsTrueWhenNeedleIsAtStart(): void
+    {
+        self::assertTrue(
+            (new Contains(TextOf::ofString('hello world'), TextOf::ofString('hello')))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsTrueWhenNeedleIsAtEnd(): void
+    {
+        self::assertTrue(
+            (new Contains(TextOf::ofString('hello world'), TextOf::ofString('world')))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsFalseWhenNeedleIsAbsent(): void
+    {
+        self::assertFalse(
+            (new Contains(TextOf::ofString('hello world'), TextOf::ofString('xyz')))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsTrueWhenNeedleIsEmpty(): void
+    {
+        self::assertTrue(
+            (new Contains(TextOf::ofString('hello'), TextOf::ofString('')))->value(),
+        );
+    }
+
+    #[Test]
+    public function respectsUtf8MultibyteCharacters(): void
+    {
+        self::assertTrue(
+            (new Contains(TextOf::ofString('привет мир'), TextOf::ofString('ет ми')))->value(),
+        );
+    }
+}

--- a/tests/Text/IsBlankTest.php
+++ b/tests/Text/IsBlankTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Text;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Text\IsBlank;
+use Primus\Text\TextOf;
+
+final class IsBlankTest extends TestCase
+{
+    #[Test]
+    public function returnsTrueForEmptyString(): void
+    {
+        self::assertTrue((new IsBlank(TextOf::ofString('')))->value());
+    }
+
+    #[Test]
+    public function returnsTrueForAsciiSpacesOnly(): void
+    {
+        self::assertTrue((new IsBlank(TextOf::ofString('   ')))->value());
+    }
+
+    #[Test]
+    public function returnsTrueForMixedAsciiWhitespace(): void
+    {
+        self::assertTrue((new IsBlank(TextOf::ofString(" \t\n\r")))->value());
+    }
+
+    #[Test]
+    public function returnsTrueForUnicodeNonBreakingSpace(): void
+    {
+        self::assertTrue((new IsBlank(TextOf::ofString("\u{00A0}\u{2003}")))->value());
+    }
+
+    #[Test]
+    public function returnsFalseForNonBlankString(): void
+    {
+        self::assertFalse((new IsBlank(TextOf::ofString('hello')))->value());
+    }
+
+    #[Test]
+    public function returnsFalseWhenContentSurroundedByWhitespace(): void
+    {
+        self::assertFalse((new IsBlank(TextOf::ofString('  x  ')))->value());
+    }
+
+    #[Test]
+    public function returnsFalseForVisibleUtf8(): void
+    {
+        self::assertFalse((new IsBlank(TextOf::ofString('привет')))->value());
+    }
+}

--- a/tests/Text/IsBlankTest.php
+++ b/tests/Text/IsBlankTest.php
@@ -36,6 +36,12 @@ final class IsBlankTest extends TestCase
     }
 
     #[Test]
+    public function returnsTrueForUnicodeLineAndParagraphSeparators(): void
+    {
+        self::assertTrue((new IsBlank(TextOf::ofString("\u{2028}\u{2029}")))->value());
+    }
+
+    #[Test]
     public function returnsFalseForNonBlankString(): void
     {
         self::assertFalse((new IsBlank(TextOf::ofString('hello')))->value());


### PR DESCRIPTION
- Added Text\Contains as Scalar<bool> wrapping PHP str_contains, byte-safe for UTF-8 because UTF-8 sequences cannot overlap byte boundaries
- Added Text\IsBlank as Scalar<bool> matching empty strings and Unicode whitespace via the /^\s*$/u regex, so non-breaking spaces and other Unicode separators count as blank

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added substring detection capability with Unicode multibyte character support
  - Added whitespace validation utility supporting ASCII and Unicode whitespace characters

* **Tests**
  - Comprehensive test coverage for substring detection including edge cases and UTF-8 handling
  - Full test suite for whitespace validation across various whitespace types

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->