### PR TITLE
Add Text Reversed Codepoint-Safe Decorator

### DIFF
--- a/src/Text/Reversed.php
+++ b/src/Text/Reversed.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Text;
+
+use Primus\Func\FuncOf;
+
+/**
+ * Text with its characters in reverse order.
+ *
+ * Reverses by Unicode codepoints via {@see mb_str_split()}, so multibyte
+ * characters are preserved as whole units instead of being split into bytes.
+ *
+ * Note: reversal is by codepoint, not by grapheme cluster. Combining marks
+ * (NFD form, e.g. "e" + U+0301) are reordered separately from their base
+ * character. Pre-normalize to NFC if grapheme stability is required.
+ *
+ * Example:
+ *     $text = new Reversed(TextOf::ofString('café'));
+ *     echo $text->value(); // 'éfac'
+ */
+final readonly class Reversed extends TextEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Text $origin The text to reverse.
+     */
+    public function __construct(Text $origin)
+    {
+        parent::__construct(
+            new Mapped(
+                $origin,
+                new FuncOf(
+                    static fn(string $s): string => implode('', array_reverse(mb_str_split($s, 1, 'UTF-8'))),
+                ),
+            ),
+        );
+    }
+}

--- a/tests/Text/ReversedTest.php
+++ b/tests/Text/ReversedTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Text;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Tests\Constraint\HasTextValue;
+use Primus\Text\Reversed;
+use Primus\Text\TextOf;
+
+final class ReversedTest extends TestCase
+{
+    #[Test]
+    public function returnsCharactersInReverseOrder(): void
+    {
+        self::assertThat(
+            new Reversed(TextOf::ofString('hello')),
+            new HasTextValue('olleh')
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyForEmptyText(): void
+    {
+        self::assertThat(
+            new Reversed(TextOf::ofString('')),
+            new HasTextValue('')
+        );
+    }
+
+    #[Test]
+    public function preservesMultibyteCharactersAsWholeUnits(): void
+    {
+        self::assertThat(
+            new Reversed(TextOf::ofString('café')),
+            new HasTextValue('éfac')
+        );
+    }
+
+    #[Test]
+    public function reversesCyrillicTextByCodepoint(): void
+    {
+        self::assertThat(
+            new Reversed(TextOf::ofString('привет')),
+            new HasTextValue('тевирп')
+        );
+    }
+
+    #[Test]
+    public function reversesByCodepointNotGraphemeCluster(): void
+    {
+        self::assertThat(
+            new Reversed(TextOf::ofString("cafe\u{0301}")),
+            new HasTextValue("\u{0301}efac")
+        );
+    }
+}


### PR DESCRIPTION
- Added Text Reversed that reverses input by Unicode codepoints via mb_str_split
- Added tests covering ASCII, empty, multibyte Latin, Cyrillic, and NFD documenting case

Part of #209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added text reversal functionality that reverses characters by Unicode codepoint order with proper support for multibyte characters and international text.

* **Tests**
  * Comprehensive test coverage validates text reversal across ASCII, empty strings, multibyte characters, Cyrillic text, and grapheme cluster scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->