### PR TITLE
Add Text Concatenated Variadic Decorator

### DIFF
--- a/src/Text/Concatenated.php
+++ b/src/Text/Concatenated.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Text;
+
+/**
+ * Text concatenated from multiple {@see Text} parts without a separator.
+ *
+ * Equivalent to {@see Joined} with an empty separator. Parts are concatenated
+ * in argument order.
+ *
+ * Example:
+ *     $text = new Concatenated(
+ *         TextOf::ofString('hello, '),
+ *         TextOf::ofString('world'),
+ *     );
+ *     echo $text->value(); // 'hello, world'
+ */
+final readonly class Concatenated extends TextEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Text ...$parts The texts to concatenate.
+     */
+    public function __construct(Text ...$parts)
+    {
+        parent::__construct(new Joined('', array_values($parts)));
+    }
+}

--- a/src/Text/Concatenated.php
+++ b/src/Text/Concatenated.php
@@ -19,6 +19,8 @@ namespace Primus\Text;
  */
 final readonly class Concatenated extends TextEnvelope
 {
+    private const string SEPARATOR = '';
+
     /**
      * Ctor.
      *
@@ -26,6 +28,6 @@ final readonly class Concatenated extends TextEnvelope
      */
     public function __construct(Text ...$parts)
     {
-        parent::__construct(new Joined('', array_values($parts)));
+        parent::__construct(new Joined(self::SEPARATOR, array_values($parts)));
     }
 }

--- a/tests/Text/ConcatenatedTest.php
+++ b/tests/Text/ConcatenatedTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Text;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Tests\Constraint\HasTextValue;
+use Primus\Text\Concatenated;
+use Primus\Text\TextOf;
+
+final class ConcatenatedTest extends TestCase
+{
+    #[Test]
+    public function joinsTwoTextsInArgumentOrder(): void
+    {
+        self::assertThat(
+            new Concatenated(
+                TextOf::ofString('hello, '),
+                TextOf::ofString('world'),
+            ),
+            new HasTextValue('hello, world')
+        );
+    }
+
+    #[Test]
+    public function joinsThreeTextsWithoutSeparator(): void
+    {
+        self::assertThat(
+            new Concatenated(
+                TextOf::ofString('a'),
+                TextOf::ofString('b'),
+                TextOf::ofString('c'),
+            ),
+            new HasTextValue('abc')
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyForNoArguments(): void
+    {
+        self::assertThat(
+            new Concatenated(),
+            new HasTextValue('')
+        );
+    }
+
+    #[Test]
+    public function preservesMultibyteCharactersAcrossParts(): void
+    {
+        self::assertThat(
+            new Concatenated(
+                TextOf::ofString('café'),
+                TextOf::ofString(' & '),
+                TextOf::ofString('привет'),
+            ),
+            new HasTextValue('café & привет')
+        );
+    }
+
+    #[Test]
+    public function joinsSingleTextUnchanged(): void
+    {
+        self::assertThat(
+            new Concatenated(TextOf::ofString('only')),
+            new HasTextValue('only')
+        );
+    }
+}


### PR DESCRIPTION
- Added Text Concatenated decorator providing variadic sugar over Joined with empty separator
- Added tests covering zero, one, two, three parts and multibyte content

Part of #209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a text concatenation capability that seamlessly combines multiple text parts into a single value, preserving order and character integrity throughout the process.

* **Tests**
  * Added comprehensive test coverage to verify concatenation behavior, including proper handling of multibyte characters, empty input scenarios, and edge cases with single text inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->