### PR TITLE
Add Text FormattedText Sprintf Decorator

### DIFF
--- a/src/Text/FormattedText.php
+++ b/src/Text/FormattedText.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Text;
+
+use Primus\Func\FuncOf;
+
+/**
+ * Text formatted from a {@see Text} pattern via {@see sprintf()}.
+ *
+ * The pattern uses the PHP sprintf specification (`%s`, `%d`, `%f`,
+ * positional `%1$s`, etc.). Arguments are restricted to int, float and
+ * string; bool and null are intentionally rejected to keep the format
+ * call type-safe.
+ *
+ * Width and precision specifiers (`%5s`, `%.3s`) count bytes, not
+ * Unicode codepoints — multibyte values may pad or truncate at byte
+ * boundaries. The pattern itself is byte-safe for plain `%s` placeholders.
+ *
+ * Do not pass untrusted patterns: a hostile precision such as
+ * `%.999999999s` can allocate a large buffer.
+ *
+ * Example:
+ *     $text = new FormattedText(
+ *         TextOf::ofString('Hello, %s! You have %d messages.'),
+ *         'world',
+ *         5,
+ *     );
+ *     echo $text->value(); // 'Hello, world! You have 5 messages.'
+ */
+final readonly class FormattedText extends TextEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Text $pattern The sprintf pattern.
+     * @param int|float|string ...$arguments The values substituted into the pattern.
+     */
+    public function __construct(Text $pattern, int|float|string ...$arguments)
+    {
+        parent::__construct(
+            new Mapped(
+                $pattern,
+                new FuncOf(static fn(string $p): string => sprintf($p, ...$arguments)),
+            ),
+        );
+    }
+}

--- a/tests/Text/FormattedTextTest.php
+++ b/tests/Text/FormattedTextTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Text;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Tests\Constraint\HasTextValue;
+use Primus\Text\FormattedText;
+use Primus\Text\TextOf;
+
+final class FormattedTextTest extends TestCase
+{
+    #[Test]
+    public function substitutesStringArgument(): void
+    {
+        self::assertThat(
+            new FormattedText(TextOf::ofString('Hello, %s!'), 'world'),
+            new HasTextValue('Hello, world!')
+        );
+    }
+
+    #[Test]
+    public function substitutesIntAndFloatArguments(): void
+    {
+        self::assertThat(
+            new FormattedText(TextOf::ofString('%d items at %.2f each'), 5, 3.5),
+            new HasTextValue('5 items at 3.50 each')
+        );
+    }
+
+    #[Test]
+    public function returnsPatternUnchangedWhenNoPlaceholders(): void
+    {
+        self::assertThat(
+            new FormattedText(TextOf::ofString('no placeholders here')),
+            new HasTextValue('no placeholders here')
+        );
+    }
+
+    #[Test]
+    public function honoursPositionalSpecifiers(): void
+    {
+        self::assertThat(
+            new FormattedText(TextOf::ofString('%2$s %1$s'), 'world', 'hello'),
+            new HasTextValue('hello world')
+        );
+    }
+
+    #[Test]
+    public function preservesMultibyteCharactersInPatternAndArguments(): void
+    {
+        self::assertThat(
+            new FormattedText(TextOf::ofString('café %s'), 'привет'),
+            new HasTextValue('café привет')
+        );
+    }
+}


### PR DESCRIPTION
- Added Text FormattedText decorator wrapping sprintf with int/float/string variadic arguments
- Added tests covering single string, int+float, no placeholders, positional specifiers and multibyte content
- Documented byte semantics of width and precision specifiers and rejection of untrusted patterns

Part of #209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced text string formatting capability enabling safe substitution of values (strings, integers, floats) into text patterns while preserving unicode and multibyte characters.

* **Tests**
  * Added comprehensive test suite validating formatting behavior including substitutions, positional specifiers, and unicode character handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->