### PR TITLE
Add Text PrefixOf and SuffixOf Boundary Split Decorators

### DIFF
--- a/src/Text/PrefixOf.php
+++ b/src/Text/PrefixOf.php
@@ -23,6 +23,8 @@ use Primus\Func\FuncOf;
  */
 final readonly class PrefixOf extends TextEnvelope
 {
+    private const string ENCODING = 'UTF-8';
+
     /**
      * Ctor.
      *
@@ -36,10 +38,10 @@ final readonly class PrefixOf extends TextEnvelope
                 $origin,
                 new FuncOf(
                     static function (string $s) use ($boundary): string {
-                        $position = mb_strpos($s, $boundary->value(), 0, 'UTF-8');
+                        $position = mb_strpos($s, $boundary->value(), 0, self::ENCODING);
 
                         return is_int($position)
-                            ? mb_substr($s, 0, $position, 'UTF-8')
+                            ? mb_substr($s, 0, $position, self::ENCODING)
                             : $s;
                     },
                 ),

--- a/src/Text/PrefixOf.php
+++ b/src/Text/PrefixOf.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Text;
+
+use Primus\Func\FuncOf;
+
+/**
+ * Text segment before the first occurrence of a boundary.
+ *
+ * Returns everything in `$origin` up to (and excluding) the first match of
+ * `$boundary`. If the boundary is absent, returns the full origin text.
+ * Position lookup and slicing use {@see mb_strpos()} and {@see mb_substr()},
+ * so multibyte characters are preserved as whole units.
+ *
+ * Example:
+ *     $login = new PrefixOf(
+ *         TextOf::ofString('user@example.com'),
+ *         TextOf::ofString('@'),
+ *     );
+ *     echo $login->value(); // 'user'
+ */
+final readonly class PrefixOf extends TextEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Text $origin The text to split.
+     * @param Text $boundary The text that marks the split point.
+     */
+    public function __construct(Text $origin, Text $boundary)
+    {
+        parent::__construct(
+            new Mapped(
+                $origin,
+                new FuncOf(
+                    static function (string $s) use ($boundary): string {
+                        $position = mb_strpos($s, $boundary->value(), 0, 'UTF-8');
+
+                        return is_int($position)
+                            ? mb_substr($s, 0, $position, 'UTF-8')
+                            : $s;
+                    },
+                ),
+            ),
+        );
+    }
+}

--- a/src/Text/SuffixOf.php
+++ b/src/Text/SuffixOf.php
@@ -23,6 +23,9 @@ use Primus\Func\FuncOf;
  */
 final readonly class SuffixOf extends TextEnvelope
 {
+    private const string ENCODING = 'UTF-8';
+    private const string EMPTY = '';
+
     /**
      * Ctor.
      *
@@ -37,17 +40,17 @@ final readonly class SuffixOf extends TextEnvelope
                 new FuncOf(
                     static function (string $s) use ($boundary): string {
                         $boundaryValue = $boundary->value();
-                        $position = mb_strpos($s, $boundaryValue, 0, 'UTF-8');
+                        $position = mb_strpos($s, $boundaryValue, 0, self::ENCODING);
 
                         if (!is_int($position)) {
-                            return '';
+                            return self::EMPTY;
                         }
 
                         return mb_substr(
                             $s,
-                            $position + mb_strlen($boundaryValue, 'UTF-8'),
+                            $position + mb_strlen($boundaryValue, self::ENCODING),
                             null,
-                            'UTF-8',
+                            self::ENCODING,
                         );
                     },
                 ),

--- a/src/Text/SuffixOf.php
+++ b/src/Text/SuffixOf.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Text;
+
+use Primus\Func\FuncOf;
+
+/**
+ * Text segment after the first occurrence of a boundary.
+ *
+ * Returns everything in `$origin` after the first match of `$boundary`. If
+ * the boundary is absent, returns an empty text. Position lookup and slicing
+ * use {@see mb_strpos()} and {@see mb_substr()}, so multibyte characters are
+ * preserved as whole units.
+ *
+ * Example:
+ *     $domain = new SuffixOf(
+ *         TextOf::ofString('user@example.com'),
+ *         TextOf::ofString('@'),
+ *     );
+ *     echo $domain->value(); // 'example.com'
+ */
+final readonly class SuffixOf extends TextEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Text $origin The text to split.
+     * @param Text $boundary The text that marks the split point.
+     */
+    public function __construct(Text $origin, Text $boundary)
+    {
+        parent::__construct(
+            new Mapped(
+                $origin,
+                new FuncOf(
+                    static function (string $s) use ($boundary): string {
+                        $boundaryValue = $boundary->value();
+                        $position = mb_strpos($s, $boundaryValue, 0, 'UTF-8');
+
+                        if (!is_int($position)) {
+                            return '';
+                        }
+
+                        return mb_substr(
+                            $s,
+                            $position + mb_strlen($boundaryValue, 'UTF-8'),
+                            null,
+                            'UTF-8',
+                        );
+                    },
+                ),
+            ),
+        );
+    }
+}

--- a/tests/Text/PrefixOfTest.php
+++ b/tests/Text/PrefixOfTest.php
@@ -83,4 +83,16 @@ final class PrefixOfTest extends TestCase
             new HasTextValue('hello')
         );
     }
+
+    #[Test]
+    public function returnsEmptyForEmptyOrigin(): void
+    {
+        self::assertThat(
+            new PrefixOf(
+                TextOf::ofString(''),
+                TextOf::ofString('@'),
+            ),
+            new HasTextValue('')
+        );
+    }
 }

--- a/tests/Text/PrefixOfTest.php
+++ b/tests/Text/PrefixOfTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Text;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Tests\Constraint\HasTextValue;
+use Primus\Text\PrefixOf;
+use Primus\Text\TextOf;
+
+final class PrefixOfTest extends TestCase
+{
+    #[Test]
+    public function returnsSegmentBeforeBoundary(): void
+    {
+        self::assertThat(
+            new PrefixOf(
+                TextOf::ofString('user@example.com'),
+                TextOf::ofString('@'),
+            ),
+            new HasTextValue('user')
+        );
+    }
+
+    #[Test]
+    public function returnsOriginWhenBoundaryAbsent(): void
+    {
+        self::assertThat(
+            new PrefixOf(
+                TextOf::ofString('plainstring'),
+                TextOf::ofString('@'),
+            ),
+            new HasTextValue('plainstring')
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyWhenBoundaryAtStart(): void
+    {
+        self::assertThat(
+            new PrefixOf(
+                TextOf::ofString('@tail'),
+                TextOf::ofString('@'),
+            ),
+            new HasTextValue('')
+        );
+    }
+
+    #[Test]
+    public function stopsAtFirstBoundaryWhenMultiplePresent(): void
+    {
+        self::assertThat(
+            new PrefixOf(
+                TextOf::ofString('a/b/c'),
+                TextOf::ofString('/'),
+            ),
+            new HasTextValue('a')
+        );
+    }
+
+    #[Test]
+    public function preservesMultibyteCharactersBeforeBoundary(): void
+    {
+        self::assertThat(
+            new PrefixOf(
+                TextOf::ofString('café/мир'),
+                TextOf::ofString('/'),
+            ),
+            new HasTextValue('café')
+        );
+    }
+
+    #[Test]
+    public function findsMultibyteBoundary(): void
+    {
+        self::assertThat(
+            new PrefixOf(
+                TextOf::ofString('helloпривет'),
+                TextOf::ofString('п'),
+            ),
+            new HasTextValue('hello')
+        );
+    }
+}

--- a/tests/Text/SuffixOfTest.php
+++ b/tests/Text/SuffixOfTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Text;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Tests\Constraint\HasTextValue;
+use Primus\Text\SuffixOf;
+use Primus\Text\TextOf;
+
+final class SuffixOfTest extends TestCase
+{
+    #[Test]
+    public function returnsSegmentAfterBoundary(): void
+    {
+        self::assertThat(
+            new SuffixOf(
+                TextOf::ofString('user@example.com'),
+                TextOf::ofString('@'),
+            ),
+            new HasTextValue('example.com')
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyWhenBoundaryAbsent(): void
+    {
+        self::assertThat(
+            new SuffixOf(
+                TextOf::ofString('plainstring'),
+                TextOf::ofString('@'),
+            ),
+            new HasTextValue('')
+        );
+    }
+
+    #[Test]
+    public function returnsEmptyWhenBoundaryAtEnd(): void
+    {
+        self::assertThat(
+            new SuffixOf(
+                TextOf::ofString('head@'),
+                TextOf::ofString('@'),
+            ),
+            new HasTextValue('')
+        );
+    }
+
+    #[Test]
+    public function startsAfterFirstBoundaryWhenMultiplePresent(): void
+    {
+        self::assertThat(
+            new SuffixOf(
+                TextOf::ofString('a/b/c'),
+                TextOf::ofString('/'),
+            ),
+            new HasTextValue('b/c')
+        );
+    }
+
+    #[Test]
+    public function preservesMultibyteCharactersAfterBoundary(): void
+    {
+        self::assertThat(
+            new SuffixOf(
+                TextOf::ofString('café/мир'),
+                TextOf::ofString('/'),
+            ),
+            new HasTextValue('мир')
+        );
+    }
+
+    #[Test]
+    public function findsMultibyteBoundaryAndAdvancesPastItByCodepoint(): void
+    {
+        self::assertThat(
+            new SuffixOf(
+                TextOf::ofString('helloпривет'),
+                TextOf::ofString('п'),
+            ),
+            new HasTextValue('ривет')
+        );
+    }
+}

--- a/tests/Text/SuffixOfTest.php
+++ b/tests/Text/SuffixOfTest.php
@@ -83,4 +83,16 @@ final class SuffixOfTest extends TestCase
             new HasTextValue('ривет')
         );
     }
+
+    #[Test]
+    public function returnsEmptyForEmptyOrigin(): void
+    {
+        self::assertThat(
+            new SuffixOf(
+                TextOf::ofString(''),
+                TextOf::ofString('@'),
+            ),
+            new HasTextValue('')
+        );
+    }
 }


### PR DESCRIPTION
- Added Text PrefixOf decorator returning the segment before the first occurrence of a boundary
- Added Text SuffixOf decorator returning the segment after the first occurrence of a boundary
- Added tests covering present, absent, leading and trailing boundaries plus multibyte content and multibyte boundaries

Closes #209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `PrefixOf` utility: Extract the portion of text before a specified boundary
  * `SuffixOf` utility: Extract the portion of text after a specified boundary
  * Full support for multibyte characters (UTF-8) in both utilities

* **Tests**
  * Added comprehensive test coverage for the new text utilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->