### PR TITLE
Shorten TextOf Named Constructors to str and scalar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ These rules describe how Primus objects behave. Code that uses Primus
 must respect them, otherwise it will not type-check, will fail the
 project's lint gates, or will surprise the caller at runtime.
 
-1. **Construction never executes work.** `new Trimmed(TextOf::ofString($s))`
+1. **Construction never executes work.** `new Trimmed(TextOf::str($s))`
    does no string work. Computation happens only when `value()` (or
    `asInt()`/`asFloat()`/`exec()`/etc.) is called.
 
@@ -137,7 +137,7 @@ project's lint gates, or will surprise the caller at runtime.
 Patterns that look reasonable but are wrong for Primus:
 
 - **Do not call computation methods inside a constructor.**
-  `new Trimmed((TextOf::ofString($s))->value())` is wrong — the inner call
+  `new Trimmed((TextOf::str($s))->value())` is wrong — the inner call
   eagerly extracts the value and breaks composition. Pass the decorator
   object, not its result.
 
@@ -154,7 +154,7 @@ Patterns that look reasonable but are wrong for Primus:
 
 - **Static methods are reserved for named constructors.** A class whose
   only static methods return `self` (or `static`) — wrapping different
-  input forms (`TextOf::ofString`, `TextOf::ofScalar`) — is the sanctioned
+  input forms (`TextOf::str`, `TextOf::scalar`) — is the sanctioned
   PHP analogue of overloaded constructors in Cactoos Java. Anything else
   static (helper methods, factories returning unrelated types, `Trimmed::of`)
   is still forbidden.
@@ -215,7 +215,7 @@ use Override;
  * <Optional second paragraph with the "why".>
  *
  * Example:
- *     $value = (new MyDecorator(TextOf::ofString('input')))->value();
+ *     $value = (new MyDecorator(TextOf::str('input')))->value();
  *     // expected output
  */
 final readonly class MyDecorator implements Text
@@ -264,7 +264,7 @@ final class MyDecoratorTest extends TestCase
     {
         $this->assertSame(
             'expected',
-            (new MyDecorator(TextOf::ofString('input')))->value(),
+            (new MyDecorator(TextOf::str('input')))->value(),
         );
     }
 }
@@ -328,8 +328,8 @@ you can argue an exception when it really makes sense.
   Static means "behaviour owned by a class, not an instance". You lose
   substitution: you can't swap `Trimmed::of($s)` for a test double.
   The only sanctioned exception is named constructors — static methods
-  returning `self`/`static` that wrap different input forms (`TextOf::ofString`,
-  `TextOf::ofScalar`), playing the role of overloaded constructors absent
+  returning `self`/`static` that wrap different input forms (`TextOf::str`,
+  `TextOf::scalar`), playing the role of overloaded constructors absent
   from PHP. Any other static is still forbidden.
 
 - **No procedural helpers, no mutable state.**

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ composer require haspadar/primus
   retry/logging — things you can't do with a procedural chain.
 
   ```php
-  $headline = new Lowered(new Trimmed(new TextOf($raw)));
+  $headline = new Lowered(new Trimmed(TextOf::str($raw)));
   $cached   = new Sticky(new ScalarOf(fn () => $headline->value()));
   // No work done yet.
   ```
@@ -100,14 +100,14 @@ composer require haspadar/primus
 To trim and lowercase:
 
 ```php
-$text = (new Lowered(new Trimmed(new TextOf('  Hello  '))))->value();
+$text = (new Lowered(new Trimmed(TextOf::str('  Hello  '))))->value();
 // "hello"
 ```
 
 To take a substring:
 
 ```php
-$text = (new Sub(new TextOf('Hello, world!'), 0, 5))->value();
+$text = (new Sub(TextOf::str('Hello, world!'), 0, 5))->value();
 // "Hello"
 ```
 

--- a/src/Bytes/Base64Decoded.php
+++ b/src/Bytes/Base64Decoded.php
@@ -15,7 +15,7 @@ use Primus\Text\Text;
  * rejects access with InvalidArgumentException.
  *
  * Example:
- *     $bytes = new Base64Decoded(TextOf::ofString("aGVsbG8="));
+ *     $bytes = new Base64Decoded(TextOf::str("aGVsbG8="));
  *     $bytes->value(); // "hello"
  */
 final readonly class Base64Decoded implements Bytes

--- a/src/Bytes/HexDecoded.php
+++ b/src/Bytes/HexDecoded.php
@@ -16,7 +16,7 @@ use Primus\Text\Text;
  * InvalidArgumentException.
  *
  * Example:
- *     $bytes = new HexDecoded(TextOf::ofString("6869"));
+ *     $bytes = new HexDecoded(TextOf::str("6869"));
  *     $bytes->value(); // "hi"
  */
 final readonly class HexDecoded implements Bytes

--- a/src/Decimal/DecimalOf.php
+++ b/src/Decimal/DecimalOf.php
@@ -45,7 +45,7 @@ final readonly class DecimalOf implements Decimal
     #[Override]
     public function asText(): Text
     {
-        return TextOf::ofString($this->value);
+        return TextOf::str($this->value);
     }
 
     #[Override]

--- a/src/Decimal/DecimalOfFloat.php
+++ b/src/Decimal/DecimalOfFloat.php
@@ -49,7 +49,7 @@ final readonly class DecimalOfFloat implements Decimal
     #[Override]
     public function asText(): Text
     {
-        return TextOf::ofString($this->asString());
+        return TextOf::str($this->asString());
     }
 
     #[Override]

--- a/src/Decimal/DecimalOfInt.php
+++ b/src/Decimal/DecimalOfInt.php
@@ -43,7 +43,7 @@ final readonly class DecimalOfInt implements Decimal
     #[Override]
     public function asText(): Text
     {
-        return TextOf::ofString((string) $this->value);
+        return TextOf::str((string) $this->value);
     }
 
     #[Override]

--- a/src/Decimal/DecimalOfScalar.php
+++ b/src/Decimal/DecimalOfScalar.php
@@ -45,7 +45,7 @@ final readonly class DecimalOfScalar implements Decimal
     #[Override]
     public function asText(): Text
     {
-        return TextOf::ofString($this->asString());
+        return TextOf::str($this->asString());
     }
 
     #[Override]

--- a/src/Integer/Abs.php
+++ b/src/Integer/Abs.php
@@ -43,6 +43,6 @@ final readonly class Abs implements Integer
     #[Override]
     public function asText(): Text
     {
-        return TextOf::ofString((string) $this->asInt());
+        return TextOf::str((string) $this->asInt());
     }
 }

--- a/src/Integer/DivOf.php
+++ b/src/Integer/DivOf.php
@@ -42,6 +42,6 @@ final readonly class DivOf implements Integer
     #[Override]
     public function asText(): Text
     {
-        return TextOf::ofString((string) $this->asInt());
+        return TextOf::str((string) $this->asInt());
     }
 }

--- a/src/Integer/IntegerOf.php
+++ b/src/Integer/IntegerOf.php
@@ -41,6 +41,6 @@ final readonly class IntegerOf implements Integer
     #[Override]
     public function asText(): Text
     {
-        return TextOf::ofString((string) $this->value);
+        return TextOf::str((string) $this->value);
     }
 }

--- a/src/Integer/MaxOf.php
+++ b/src/Integer/MaxOf.php
@@ -52,6 +52,6 @@ final readonly class MaxOf implements Integer
     #[Override]
     public function asText(): Text
     {
-        return TextOf::ofString((string) $this->asInt());
+        return TextOf::str((string) $this->asInt());
     }
 }

--- a/src/Integer/MinOf.php
+++ b/src/Integer/MinOf.php
@@ -52,6 +52,6 @@ final readonly class MinOf implements Integer
     #[Override]
     public function asText(): Text
     {
-        return TextOf::ofString((string) $this->asInt());
+        return TextOf::str((string) $this->asInt());
     }
 }

--- a/src/Integer/ModOf.php
+++ b/src/Integer/ModOf.php
@@ -42,6 +42,6 @@ final readonly class ModOf implements Integer
     #[Override]
     public function asText(): Text
     {
-        return TextOf::ofString((string) $this->asInt());
+        return TextOf::str((string) $this->asInt());
     }
 }

--- a/src/Integer/MultOf.php
+++ b/src/Integer/MultOf.php
@@ -56,6 +56,6 @@ final readonly class MultOf implements Integer
     #[Override]
     public function asText(): Text
     {
-        return TextOf::ofString((string) $this->asInt());
+        return TextOf::str((string) $this->asInt());
     }
 }

--- a/src/Integer/SumOf.php
+++ b/src/Integer/SumOf.php
@@ -56,6 +56,6 @@ final readonly class SumOf implements Integer
     #[Override]
     public function asText(): Text
     {
-        return TextOf::ofString((string) $this->asInt());
+        return TextOf::str((string) $this->asInt());
     }
 }

--- a/src/Text/Abbreviated.php
+++ b/src/Text/Abbreviated.php
@@ -13,7 +13,7 @@ use Primus\Scalar\ScalarOf;
  * If the text length does not exceed the limit, it is returned unchanged.
  *
  * Example:
- *     $text = new Abbreviated(TextOf::ofString('Hello, world!'), 8);
+ *     $text = new Abbreviated(TextOf::str('Hello, world!'), 8);
  *     echo $text->value(); // 'Hello, w…'
  */
 final readonly class Abbreviated extends TextEnvelope
@@ -27,7 +27,7 @@ final readonly class Abbreviated extends TextEnvelope
     public function __construct(Text $origin, int $limit = 50)
     {
         parent::__construct(
-            TextOf::ofScalar(
+            TextOf::scalar(
                 new ScalarOf(
                     static function () use ($origin, $limit): string {
                         if ($limit <= 0) {

--- a/src/Text/Capitalized.php
+++ b/src/Text/Capitalized.php
@@ -11,7 +11,7 @@ namespace Primus\Text;
  * and leaves the rest of the text unchanged.
  *
  * Example:
- *     $text = new Capitalized(TextOf::ofString('hello'));
+ *     $text = new Capitalized(TextOf::str('hello'));
  *     echo $text->value(); // 'Hello'
  */
 final readonly class Capitalized extends TextEnvelope

--- a/src/Text/Concatenated.php
+++ b/src/Text/Concatenated.php
@@ -12,8 +12,8 @@ namespace Primus\Text;
  *
  * Example:
  *     $text = new Concatenated(
- *         TextOf::ofString('hello, '),
- *         TextOf::ofString('world'),
+ *         TextOf::str('hello, '),
+ *         TextOf::str('world'),
  *     );
  *     echo $text->value(); // 'hello, world'
  */

--- a/src/Text/Contains.php
+++ b/src/Text/Contains.php
@@ -15,7 +15,7 @@ use Primus\Scalar\ScalarOf;
  * other sequences.
  *
  * Example:
- *     $has = new Contains(TextOf::ofString('hello world'), TextOf::ofString('lo wo'));
+ *     $has = new Contains(TextOf::str('hello world'), TextOf::str('lo wo'));
  *     echo $has->value(); // true
  *
  * @extends ScalarEnvelope<bool>

--- a/src/Text/EndsWith.php
+++ b/src/Text/EndsWith.php
@@ -15,7 +15,7 @@ use Primus\Scalar\ScalarOf;
  * other sequences.
  *
  * Example:
- *     $ends = new EndsWith(TextOf::ofString('hello world'), TextOf::ofString('world'));
+ *     $ends = new EndsWith(TextOf::str('hello world'), TextOf::str('world'));
  *     echo $ends->value(); // true
  *
  * @extends ScalarEnvelope<bool>

--- a/src/Text/FormattedText.php
+++ b/src/Text/FormattedText.php
@@ -23,7 +23,7 @@ use Primus\Func\FuncOf;
  *
  * Example:
  *     $text = new FormattedText(
- *         TextOf::ofString('Hello, %s! You have %d messages.'),
+ *         TextOf::str('Hello, %s! You have %d messages.'),
  *         'world',
  *         5,
  *     );

--- a/src/Text/HtmlEscaped.php
+++ b/src/Text/HtmlEscaped.php
@@ -10,7 +10,7 @@ use Primus\Func\FuncOf;
  * Escaped {@see Text} safe for HTML rendering.
  *
  * Example:
- *     $text = new HtmlEscaped(TextOf::ofString('<b>"A & B"</b>'));
+ *     $text = new HtmlEscaped(TextOf::str('<b>"A & B"</b>'));
  *     echo $text->value(); // &lt;b&gt;&quot;A &amp; B&quot;&lt;/b&gt;
  */
 final readonly class HtmlEscaped extends TextEnvelope

--- a/src/Text/IsBlank.php
+++ b/src/Text/IsBlank.php
@@ -14,7 +14,7 @@ use Primus\Scalar\ScalarOf;
  * non-breaking spaces, line/paragraph separators, etc.) as blank.
  *
  * Example:
- *     $blank = new IsBlank(TextOf::ofString(" \t\n"));
+ *     $blank = new IsBlank(TextOf::str(" \t\n"));
  *     echo $blank->value(); // true
  *
  * @extends ScalarEnvelope<bool>

--- a/src/Text/IsEmpty.php
+++ b/src/Text/IsEmpty.php
@@ -14,7 +14,7 @@ use Primus\Scalar\ScalarOf;
  * namely '' and '0'. Any other string yields false.
  *
  * Example:
- *     $empty = new IsEmpty(TextOf::ofString('0'));
+ *     $empty = new IsEmpty(TextOf::str('0'));
  *     echo $empty->value(); // true
  *
  * @extends ScalarEnvelope<bool>

--- a/src/Text/Joined.php
+++ b/src/Text/Joined.php
@@ -10,7 +10,7 @@ use Primus\Scalar\ScalarOf;
  * Text joined from multiple Text parts with a separator.
  *
  * Example:
- *     $text = new Joined(', ', [TextOf::ofString('a'), TextOf::ofString('b'), TextOf::ofString('c')]);
+ *     $text = new Joined(', ', [TextOf::str('a'), TextOf::str('b'), TextOf::str('c')]);
  *     echo $text->value(); // 'a, b, c'
  */
 final readonly class Joined extends TextEnvelope
@@ -24,7 +24,7 @@ final readonly class Joined extends TextEnvelope
     public function __construct(string $separator, array $parts)
     {
         parent::__construct(
-            TextOf::ofScalar(
+            TextOf::scalar(
                 new ScalarOf(static fn(): string => implode(
                     $separator,
                     array_map(

--- a/src/Text/LeftPadded.php
+++ b/src/Text/LeftPadded.php
@@ -13,7 +13,7 @@ use Primus\Func\FuncOf;
  * with the given character using {@see str_pad()}.
  *
  * Example:
- *     $text = new LeftPadded(TextOf::ofString('foo'), 6, '.');
+ *     $text = new LeftPadded(TextOf::str('foo'), 6, '.');
  *     echo $text->value(); // '...foo'
  */
 final readonly class LeftPadded extends TextEnvelope

--- a/src/Text/LengthOfText.php
+++ b/src/Text/LengthOfText.php
@@ -11,7 +11,7 @@ use Primus\Scalar\ScalarOf;
  * Length of {@see Text}, measured in multibyte characters.
  *
  * Example:
- *     $length = new LengthOfText(TextOf::ofString('Café Noël'));
+ *     $length = new LengthOfText(TextOf::str('Café Noël'));
  *     echo $length->value(); // 9
  *
  * @extends ScalarEnvelope<int>

--- a/src/Text/Lowered.php
+++ b/src/Text/Lowered.php
@@ -12,7 +12,7 @@ use Primus\Func\FuncOf;
  * Converts the given text to lowercase using multibyte support.
  *
  * Example:
- *     $text = new Lowered(TextOf::ofString('CAFÉ & TÜRKİYE'));
+ *     $text = new Lowered(TextOf::str('CAFÉ & TÜRKİYE'));
  *     echo $text->value(); // 'café & türkiye'
  */
 final readonly class Lowered extends TextEnvelope

--- a/src/Text/Mapped.php
+++ b/src/Text/Mapped.php
@@ -15,7 +15,7 @@ use Primus\Scalar\ScalarOf;
  *
  * Example:
  *     $text = new Mapped(
- *         TextOf::ofString('hello'),
+ *         TextOf::str('hello'),
  *         new FuncOf(strtoupper(...)),
  *     );
  *     echo $text->value(); // 'HELLO'
@@ -31,7 +31,7 @@ final readonly class Mapped extends TextEnvelope
     public function __construct(Text $origin, Func $func)
     {
         parent::__construct(
-            TextOf::ofScalar(
+            TextOf::scalar(
                 new ScalarOf(static fn(): string => $func->apply($origin->value())),
             ),
         );

--- a/src/Text/Normalized.php
+++ b/src/Text/Normalized.php
@@ -14,7 +14,7 @@ use Primus\Scalar\ScalarOf;
  * with a single space and trims leading/trailing whitespace.
  *
  * Example:
- *     $text = new Normalized(TextOf::ofString(" Hello \n\t world "));
+ *     $text = new Normalized(TextOf::str(" Hello \n\t world "));
  *     echo $text->value(); // 'Hello world'
  */
 final readonly class Normalized extends TextEnvelope
@@ -27,7 +27,7 @@ final readonly class Normalized extends TextEnvelope
     public function __construct(Text $origin)
     {
         parent::__construct(
-            TextOf::ofScalar(
+            TextOf::scalar(
                 new ScalarOf(
                     static fn(): string => preg_replace('/\s+/u', ' ', trim($origin->value()))
                         ?? throw new InvalidArgumentException('Malformed UTF-8 input'),

--- a/src/Text/PrefixOf.php
+++ b/src/Text/PrefixOf.php
@@ -16,8 +16,8 @@ use Primus\Func\FuncOf;
  *
  * Example:
  *     $login = new PrefixOf(
- *         TextOf::ofString('user@example.com'),
- *         TextOf::ofString('@'),
+ *         TextOf::str('user@example.com'),
+ *         TextOf::str('@'),
  *     );
  *     echo $login->value(); // 'user'
  */

--- a/src/Text/RandomText.php
+++ b/src/Text/RandomText.php
@@ -30,7 +30,7 @@ final readonly class RandomText extends TextEnvelope
         string $alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
     ) {
         parent::__construct(
-            TextOf::ofScalar(
+            TextOf::scalar(
                 new Sticky(
                     new ScalarOf(
                         static function () use ($length, $alphabet): string {

--- a/src/Text/Repeated.php
+++ b/src/Text/Repeated.php
@@ -10,7 +10,7 @@ use Primus\Func\FuncOf;
  * Text repeated multiple times.
  *
  * Example:
- *     $text = new Repeated(TextOf::ofString('xo'), 3);
+ *     $text = new Repeated(TextOf::str('xo'), 3);
  *     echo $text->value(); // 'xoxoxo'
  */
 final readonly class Repeated extends TextEnvelope

--- a/src/Text/Replaced.php
+++ b/src/Text/Replaced.php
@@ -13,7 +13,7 @@ use Primus\Func\FuncOf;
  *
  * Example:
  *     $text = new Replaced(
- *         TextOf::ofString('<b>Hello & bye</b>'),
+ *         TextOf::str('<b>Hello & bye</b>'),
  *         ['<b>', '</b>', '&'],
  *         ['', '', 'and']
  *     );

--- a/src/Text/Reversed.php
+++ b/src/Text/Reversed.php
@@ -17,7 +17,7 @@ use Primus\Func\FuncOf;
  * character. Pre-normalize to NFC if grapheme stability is required.
  *
  * Example:
- *     $text = new Reversed(TextOf::ofString('café'));
+ *     $text = new Reversed(TextOf::str('café'));
  *     echo $text->value(); // 'éfac'
  */
 final readonly class Reversed extends TextEnvelope

--- a/src/Text/RightPadded.php
+++ b/src/Text/RightPadded.php
@@ -12,7 +12,7 @@ use Primus\Func\FuncOf;
  * Pads the text to the specified length with the given character using {@see str_pad()}.
  *
  * Example:
- *     $text = new RightPadded(TextOf::ofString('foo'), 6, '.');
+ *     $text = new RightPadded(TextOf::str('foo'), 6, '.');
  *     echo $text->value(); // 'foo...'
  */
 final readonly class RightPadded extends TextEnvelope

--- a/src/Text/Split.php
+++ b/src/Text/Split.php
@@ -13,7 +13,7 @@ use Primus\Scalar\Scalar;
  * Produces an iterable of {@see Text} segments separated by the given delimiter.
  *
  * Example:
- *     $parts = new Split(',', TextOf::ofString('a,b,c'));
+ *     $parts = new Split(',', TextOf::str('a,b,c'));
  *     foreach ($parts->value() as $text) {
  *         echo $text->value(); // a, b, c
  *     }
@@ -34,7 +34,7 @@ final readonly class Split implements Scalar
     public function value(): iterable
     {
         foreach (explode($this->delimiter, $this->origin->value()) as $part) {
-            yield TextOf::ofString($part);
+            yield TextOf::str($part);
         }
     }
 }

--- a/src/Text/StartsWith.php
+++ b/src/Text/StartsWith.php
@@ -15,7 +15,7 @@ use Primus\Scalar\ScalarOf;
  * other sequences.
  *
  * Example:
- *     $starts = new StartsWith(TextOf::ofString('hello world'), TextOf::ofString('hello'));
+ *     $starts = new StartsWith(TextOf::str('hello world'), TextOf::str('hello'));
  *     echo $starts->value(); // true
  *
  * @extends ScalarEnvelope<bool>

--- a/src/Text/Sub.php
+++ b/src/Text/Sub.php
@@ -13,7 +13,7 @@ use Primus\Func\FuncOf;
  * Equivalent to {@see mb_substr($text, $start, PHP_INT_MAX, 'UTF-8')}.
  *
  * Example:
- *     $text = new Sub(TextOf::ofString('hello world'), 0, 5);
+ *     $text = new Sub(TextOf::str('hello world'), 0, 5);
  *     echo $text->value(); // 'hello'
  */
 final readonly class Sub extends TextEnvelope

--- a/src/Text/SuffixOf.php
+++ b/src/Text/SuffixOf.php
@@ -16,8 +16,8 @@ use Primus\Func\FuncOf;
  *
  * Example:
  *     $domain = new SuffixOf(
- *         TextOf::ofString('user@example.com'),
- *         TextOf::ofString('@'),
+ *         TextOf::str('user@example.com'),
+ *         TextOf::str('@'),
  *     );
  *     echo $domain->value(); // 'example.com'
  */

--- a/src/Text/TextOf.php
+++ b/src/Text/TextOf.php
@@ -15,8 +15,8 @@ use Primus\Scalar\ScalarOf;
  * the same delegate.
  *
  * Example:
- *     TextOf::ofString('hello'); // eager string
- *     TextOf::ofScalar(new ScalarOf(fn() => 'hello')); // deferred
+ *     TextOf::str('hello'); // eager string
+ *     TextOf::scalar(new ScalarOf(fn() => 'hello')); // deferred
  */
 final readonly class TextOf extends TextEnvelope
 {
@@ -35,7 +35,7 @@ final readonly class TextOf extends TextEnvelope
      *
      * @param string $value The string to wrap.
      */
-    public static function ofString(string $value): self
+    public static function str(string $value): self
     {
         return new self(new TextOfScalar(new ScalarOf(static fn(): string => $value)));
     }
@@ -45,7 +45,7 @@ final readonly class TextOf extends TextEnvelope
      *
      * @param Scalar<string> $scalar The deferred string source.
      */
-    public static function ofScalar(Scalar $scalar): self
+    public static function scalar(Scalar $scalar): self
     {
         return new self(new TextOfScalar($scalar));
     }

--- a/src/Text/Trimmed.php
+++ b/src/Text/Trimmed.php
@@ -12,7 +12,7 @@ use Primus\Func\FuncOf;
  * Applies {@see trim()} to the original text.
  *
  * Example:
- *     $text = new Trimmed(TextOf::ofString(' hello '));
+ *     $text = new Trimmed(TextOf::str(' hello '));
  *     echo $text->value(); // 'hello'
  */
 final readonly class Trimmed extends TextEnvelope

--- a/src/Text/TrimmedLeft.php
+++ b/src/Text/TrimmedLeft.php
@@ -11,7 +11,7 @@ use Primus\Func\FuncOf;
  * Text with whitespace removed from the left side.
  *
  * Example:
- *     $text = new TrimmedLeft(TextOf::ofString(" hello "));
+ *     $text = new TrimmedLeft(TextOf::str(" hello "));
  *     echo $text->value(); // 'hello '
  */
 final readonly class TrimmedLeft extends TextEnvelope

--- a/src/Text/TrimmedRight.php
+++ b/src/Text/TrimmedRight.php
@@ -11,7 +11,7 @@ use Primus\Func\FuncOf;
  * Text with whitespace removed from the right side.
  *
  * Example:
- *     $text = new TrimmedRight(TextOf::ofString(" hello "));
+ *     $text = new TrimmedRight(TextOf::str(" hello "));
  *     echo $text->value(); // ' hello'
  */
 final readonly class TrimmedRight extends TextEnvelope

--- a/src/Text/Uppered.php
+++ b/src/Text/Uppered.php
@@ -12,7 +12,7 @@ use Primus\Func\FuncOf;
  * Converts the given text to uppercase using multibyte support.
  *
  * Example:
- *     $text = new Uppered(TextOf::ofString('touché résumé'));
+ *     $text = new Uppered(TextOf::str('touché résumé'));
  *     echo $text->value(); // 'TOUCHÉ RÉSUMÉ'
  */
 final readonly class Uppered extends TextEnvelope

--- a/src/Text/WithoutTags.php
+++ b/src/Text/WithoutTags.php
@@ -12,7 +12,7 @@ use Primus\Func\FuncOf;
  * Strips all HTML tags from the origin text using {@see strip_tags()}.
  *
  * Example:
- *     $text = new WithoutTags(TextOf::ofString('<b>John & "Jane"</b>'));
+ *     $text = new WithoutTags(TextOf::str('<b>John & "Jane"</b>'));
  *     echo $text->value(); // 'John & "Jane"'
  */
 final readonly class WithoutTags extends TextEnvelope

--- a/tests/Bytes/Base64Test.php
+++ b/tests/Bytes/Base64Test.php
@@ -29,13 +29,13 @@ final class Base64Test extends TestCase
     #[Test]
     public function decodesBase64BackToOriginal(): void
     {
-        $this->assertSame('hello', (new Base64Decoded(TextOf::ofString('aGVsbG8=')))->value());
+        $this->assertSame('hello', (new Base64Decoded(TextOf::str('aGVsbG8=')))->value());
     }
 
     #[Test]
     public function decodesEmptyStringToEmptyBytes(): void
     {
-        $this->assertSame('', (new Base64Decoded(TextOf::ofString('')))->value());
+        $this->assertSame('', (new Base64Decoded(TextOf::str('')))->value());
     }
 
     #[Test]
@@ -44,7 +44,7 @@ final class Base64Test extends TestCase
         $bytes = "\x00\x01\xff\xfe";
         $this->assertSame(
             $bytes,
-            (new Base64Decoded(TextOf::ofString((new Base64Encoded(new BytesOf($bytes)))->value())))->value(),
+            (new Base64Decoded(TextOf::str((new Base64Encoded(new BytesOf($bytes)))->value())))->value(),
         );
     }
 
@@ -53,6 +53,6 @@ final class Base64Test extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        (new Base64Decoded(TextOf::ofString('not_valid!!!')))->value();
+        (new Base64Decoded(TextOf::str('not_valid!!!')))->value();
     }
 }

--- a/tests/Bytes/HexTest.php
+++ b/tests/Bytes/HexTest.php
@@ -35,13 +35,13 @@ final class HexTest extends TestCase
     #[Test]
     public function decodesHexBackToOriginal(): void
     {
-        $this->assertSame('hi', (new HexDecoded(TextOf::ofString('6869')))->value());
+        $this->assertSame('hi', (new HexDecoded(TextOf::str('6869')))->value());
     }
 
     #[Test]
     public function decodesEmptyStringToEmptyBytes(): void
     {
-        $this->assertSame('', (new HexDecoded(TextOf::ofString('')))->value());
+        $this->assertSame('', (new HexDecoded(TextOf::str('')))->value());
     }
 
     #[Test]
@@ -50,7 +50,7 @@ final class HexTest extends TestCase
         $bytes = "\x00\x01\xff\xfe";
         $this->assertSame(
             $bytes,
-            (new HexDecoded(TextOf::ofString((new HexEncoded(new BytesOf($bytes)))->value())))->value(),
+            (new HexDecoded(TextOf::str((new HexEncoded(new BytesOf($bytes)))->value())))->value(),
         );
     }
 
@@ -59,7 +59,7 @@ final class HexTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        (new HexDecoded(TextOf::ofString('abc')))->value();
+        (new HexDecoded(TextOf::str('abc')))->value();
     }
 
     #[Test]
@@ -67,6 +67,6 @@ final class HexTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        (new HexDecoded(TextOf::ofString('zz')))->value();
+        (new HexDecoded(TextOf::str('zz')))->value();
     }
 }

--- a/tests/Constraint/HasSize.php
+++ b/tests/Constraint/HasSize.php
@@ -12,7 +12,7 @@ use Primus\Text\Text;
  * Asserts that a {@see Text} has the expected length.
  *
  * Example:
- * self::assertThat(TextOf::ofString('abc'), new HasSize(3));
+ * self::assertThat(TextOf::str('abc'), new HasSize(3));
  *
  * Output on failure:
  * Failed asserting that text has length 5

--- a/tests/Constraint/HasTextValue.php
+++ b/tests/Constraint/HasTextValue.php
@@ -11,7 +11,7 @@ use Primus\Text\Text;
  * Asserts that {@see Text} has the expected string value.
  *
  * Example:
- * self::assertThat(TextOf::ofString('foo'), new HasTextValue('foo'));
+ * self::assertThat(TextOf::str('foo'), new HasTextValue('foo'));
  *
  */
 final class HasTextValue extends Constraint

--- a/tests/Constraint/HasTextValues.php
+++ b/tests/Constraint/HasTextValues.php
@@ -12,7 +12,7 @@ use Primus\Text\Text;
  *
  * Example:
  * self::assertThat(
- *     [TextOf::ofString('a'), TextOf::ofString('b')],
+ *     [TextOf::str('a'), TextOf::str('b')],
  *     new HasTextValues(['a', 'b'])
  * );
  *

--- a/tests/Constraint/MatchesPattern.php
+++ b/tests/Constraint/MatchesPattern.php
@@ -13,7 +13,7 @@ use Primus\Text\Text;
  *
  * Example:
  * self::assertThat(
- *     TextOf::ofString('hello'),
+ *     TextOf::str('hello'),
  *     new MatchesPattern('/^h.*o$/')
  * );
  *

--- a/tests/Decimal/Fakes/CountingDecimal.php
+++ b/tests/Decimal/Fakes/CountingDecimal.php
@@ -40,7 +40,7 @@ final class CountingDecimal implements Decimal
     #[Override]
     public function asText(): Text
     {
-        return TextOf::ofString($this->value);
+        return TextOf::str($this->value);
     }
 
     #[Override]

--- a/tests/Number/Fakes/CountingNumber.php
+++ b/tests/Number/Fakes/CountingNumber.php
@@ -47,6 +47,6 @@ final class CountingNumber implements Number
     {
         ++$this->textCalls;
 
-        return TextOf::ofString($this->textValue);
+        return TextOf::str($this->textValue);
     }
 }

--- a/tests/Text/AbbreviatedTest.php
+++ b/tests/Text/AbbreviatedTest.php
@@ -18,7 +18,7 @@ final class AbbreviatedTest extends TestCase
     public function returnsOriginalTextWhenLengthIsLessThanLimit(): void
     {
         self::assertThat(
-            new Abbreviated(TextOf::ofString('short'), 10),
+            new Abbreviated(TextOf::str('short'), 10),
             new HasTextValue('short'),
             'Abbreviated must return the original text when the length is less than the limit'
         );
@@ -28,7 +28,7 @@ final class AbbreviatedTest extends TestCase
     public function returnsOriginalTextWhenLengthEqualsLimit(): void
     {
         self::assertThat(
-            new Abbreviated(TextOf::ofString('exactly10!'), 10),
+            new Abbreviated(TextOf::str('exactly10!'), 10),
             new HasTextValue('exactly10!'),
             'Abbreviated must return the original text when the length equals the limit'
         );
@@ -38,7 +38,7 @@ final class AbbreviatedTest extends TestCase
     public function returnsTruncatedTextWithEllipsisWhenTextExceedsLimit(): void
     {
         self::assertThat(
-            new Abbreviated(TextOf::ofString('this is a long string'), 10),
+            new Abbreviated(TextOf::str('this is a long string'), 10),
             new HasTextValue('this is a…'),
             'Abbreviated must return truncated text with ellipsis when the text exceeds the limit'
         );
@@ -48,7 +48,7 @@ final class AbbreviatedTest extends TestCase
     public function returnsTruncatedTextWithEllipsisWhenTextContainsMultibyteCharacters(): void
     {
         self::assertThat(
-            new Abbreviated(TextOf::ofString('emoji 😊 test ok'), 8),
+            new Abbreviated(TextOf::str('emoji 😊 test ok'), 8),
             new HasTextValue('emoji 😊…'),
             'Abbreviated must return truncated text with ellipsis when the text contains multibyte characters'
         );
@@ -58,7 +58,7 @@ final class AbbreviatedTest extends TestCase
     public function returnsTruncatedTextWithEllipsisWhenDefaultLimitIsApplied(): void
     {
         self::assertThat(
-            new Abbreviated(TextOf::ofString(str_repeat('a', 100))),
+            new Abbreviated(TextOf::str(str_repeat('a', 100))),
             new HasTextValue(str_repeat('a', 49) . '…'),
             'Abbreviated must return truncated text with ellipsis when the default limit is applied'
         );
@@ -68,7 +68,7 @@ final class AbbreviatedTest extends TestCase
     public function returnsOnlyEllipsisWhenLimitIsOne(): void
     {
         self::assertThat(
-            new Abbreviated(TextOf::ofString('abcdef'), 1),
+            new Abbreviated(TextOf::str('abcdef'), 1),
             new HasTextValue('…'),
             'Abbreviated must return only ellipsis when the limit is one'
         );
@@ -78,7 +78,7 @@ final class AbbreviatedTest extends TestCase
     public function returnsEmptyStringWhenLimitIsZero(): void
     {
         self::assertThat(
-            new Abbreviated(TextOf::ofString('abcdef'), 0),
+            new Abbreviated(TextOf::str('abcdef'), 0),
             new HasTextValue(''),
             'Abbreviated must return an empty string when the limit is zero'
         );

--- a/tests/Text/CapitalizedTest.php
+++ b/tests/Text/CapitalizedTest.php
@@ -18,7 +18,7 @@ final class CapitalizedTest extends TestCase
     public function capitalizesFirstCharacter(): void
     {
         self::assertThat(
-            new Capitalized(TextOf::ofString('hello')),
+            new Capitalized(TextOf::str('hello')),
             new HasTextValue('Hello'),
             'Capitalized must capitalize the first character'
         );
@@ -28,7 +28,7 @@ final class CapitalizedTest extends TestCase
     public function leavesAlreadyCapitalizedTextUnchanged(): void
     {
         self::assertThat(
-            new Capitalized(TextOf::ofString('World')),
+            new Capitalized(TextOf::str('World')),
             new HasTextValue('World'),
             'Capitalized must leave already capitalized text unchanged'
         );
@@ -38,7 +38,7 @@ final class CapitalizedTest extends TestCase
     public function worksWithMultibyteCharacters(): void
     {
         self::assertThat(
-            new Capitalized(TextOf::ofString('ёлка')),
+            new Capitalized(TextOf::str('ёлка')),
             new HasTextValue('Ёлка'),
             'Capitalized must work with multibyte characters'
         );
@@ -48,7 +48,7 @@ final class CapitalizedTest extends TestCase
     public function returnsEmptyStringWhenInputIsEmpty(): void
     {
         self::assertThat(
-            new Capitalized(TextOf::ofString('')),
+            new Capitalized(TextOf::str('')),
             new HasTextValue(''),
             'Capitalized must return an empty string when the input is empty'
         );
@@ -58,7 +58,7 @@ final class CapitalizedTest extends TestCase
     public function capitalizesOnlyFirstCharacter(): void
     {
         self::assertThat(
-            new Capitalized(TextOf::ofString('hello WORLD')),
+            new Capitalized(TextOf::str('hello WORLD')),
             new HasTextValue('Hello WORLD'),
             'Capitalized must capitalize only the first character'
         );

--- a/tests/Text/ConcatenatedTest.php
+++ b/tests/Text/ConcatenatedTest.php
@@ -17,8 +17,8 @@ final class ConcatenatedTest extends TestCase
     {
         self::assertThat(
             new Concatenated(
-                TextOf::ofString('hello, '),
-                TextOf::ofString('world'),
+                TextOf::str('hello, '),
+                TextOf::str('world'),
             ),
             new HasTextValue('hello, world')
         );
@@ -29,9 +29,9 @@ final class ConcatenatedTest extends TestCase
     {
         self::assertThat(
             new Concatenated(
-                TextOf::ofString('a'),
-                TextOf::ofString('b'),
-                TextOf::ofString('c'),
+                TextOf::str('a'),
+                TextOf::str('b'),
+                TextOf::str('c'),
             ),
             new HasTextValue('abc')
         );
@@ -51,9 +51,9 @@ final class ConcatenatedTest extends TestCase
     {
         self::assertThat(
             new Concatenated(
-                TextOf::ofString('café'),
-                TextOf::ofString(' & '),
-                TextOf::ofString('привет'),
+                TextOf::str('café'),
+                TextOf::str(' & '),
+                TextOf::str('привет'),
             ),
             new HasTextValue('café & привет')
         );
@@ -63,7 +63,7 @@ final class ConcatenatedTest extends TestCase
     public function joinsSingleTextUnchanged(): void
     {
         self::assertThat(
-            new Concatenated(TextOf::ofString('only')),
+            new Concatenated(TextOf::str('only')),
             new HasTextValue('only')
         );
     }

--- a/tests/Text/ContainsTest.php
+++ b/tests/Text/ContainsTest.php
@@ -15,7 +15,7 @@ final class ContainsTest extends TestCase
     public function returnsTrueWhenNeedleIsInside(): void
     {
         self::assertTrue(
-            (new Contains(TextOf::ofString('hello world'), TextOf::ofString('lo wo')))->value(),
+            (new Contains(TextOf::str('hello world'), TextOf::str('lo wo')))->value(),
         );
     }
 
@@ -23,7 +23,7 @@ final class ContainsTest extends TestCase
     public function returnsTrueWhenNeedleIsAtStart(): void
     {
         self::assertTrue(
-            (new Contains(TextOf::ofString('hello world'), TextOf::ofString('hello')))->value(),
+            (new Contains(TextOf::str('hello world'), TextOf::str('hello')))->value(),
         );
     }
 
@@ -31,7 +31,7 @@ final class ContainsTest extends TestCase
     public function returnsTrueWhenNeedleIsAtEnd(): void
     {
         self::assertTrue(
-            (new Contains(TextOf::ofString('hello world'), TextOf::ofString('world')))->value(),
+            (new Contains(TextOf::str('hello world'), TextOf::str('world')))->value(),
         );
     }
 
@@ -39,7 +39,7 @@ final class ContainsTest extends TestCase
     public function returnsFalseWhenNeedleIsAbsent(): void
     {
         self::assertFalse(
-            (new Contains(TextOf::ofString('hello world'), TextOf::ofString('xyz')))->value(),
+            (new Contains(TextOf::str('hello world'), TextOf::str('xyz')))->value(),
         );
     }
 
@@ -47,7 +47,7 @@ final class ContainsTest extends TestCase
     public function returnsTrueWhenNeedleIsEmpty(): void
     {
         self::assertTrue(
-            (new Contains(TextOf::ofString('hello'), TextOf::ofString('')))->value(),
+            (new Contains(TextOf::str('hello'), TextOf::str('')))->value(),
         );
     }
 
@@ -55,7 +55,7 @@ final class ContainsTest extends TestCase
     public function respectsUtf8MultibyteCharacters(): void
     {
         self::assertTrue(
-            (new Contains(TextOf::ofString('привет мир'), TextOf::ofString('ет ми')))->value(),
+            (new Contains(TextOf::str('привет мир'), TextOf::str('ет ми')))->value(),
         );
     }
 }

--- a/tests/Text/EndsWithTest.php
+++ b/tests/Text/EndsWithTest.php
@@ -15,7 +15,7 @@ final class EndsWithTest extends TestCase
     public function returnsTrueWhenHaystackEndsWithNeedle(): void
     {
         self::assertTrue(
-            (new EndsWith(TextOf::ofString('hello world'), TextOf::ofString('world')))->value(),
+            (new EndsWith(TextOf::str('hello world'), TextOf::str('world')))->value(),
         );
     }
 
@@ -23,7 +23,7 @@ final class EndsWithTest extends TestCase
     public function returnsFalseWhenHaystackDoesNotEndWithNeedle(): void
     {
         self::assertFalse(
-            (new EndsWith(TextOf::ofString('hello world'), TextOf::ofString('hello')))->value(),
+            (new EndsWith(TextOf::str('hello world'), TextOf::str('hello')))->value(),
         );
     }
 
@@ -31,7 +31,7 @@ final class EndsWithTest extends TestCase
     public function returnsTrueWhenNeedleIsEmpty(): void
     {
         self::assertTrue(
-            (new EndsWith(TextOf::ofString('hello'), TextOf::ofString('')))->value(),
+            (new EndsWith(TextOf::str('hello'), TextOf::str('')))->value(),
         );
     }
 
@@ -39,7 +39,7 @@ final class EndsWithTest extends TestCase
     public function returnsFalseWhenNeedleIsLongerThanHaystack(): void
     {
         self::assertFalse(
-            (new EndsWith(TextOf::ofString('hi'), TextOf::ofString('hello')))->value(),
+            (new EndsWith(TextOf::str('hi'), TextOf::str('hello')))->value(),
         );
     }
 
@@ -47,7 +47,7 @@ final class EndsWithTest extends TestCase
     public function returnsTrueOnExactMatch(): void
     {
         self::assertTrue(
-            (new EndsWith(TextOf::ofString('abc'), TextOf::ofString('abc')))->value(),
+            (new EndsWith(TextOf::str('abc'), TextOf::str('abc')))->value(),
         );
     }
 
@@ -55,7 +55,7 @@ final class EndsWithTest extends TestCase
     public function respectsUtf8MultibyteCharacters(): void
     {
         self::assertTrue(
-            (new EndsWith(TextOf::ofString('привет мир'), TextOf::ofString('мир')))->value(),
+            (new EndsWith(TextOf::str('привет мир'), TextOf::str('мир')))->value(),
         );
     }
 }

--- a/tests/Text/FormattedTextTest.php
+++ b/tests/Text/FormattedTextTest.php
@@ -16,7 +16,7 @@ final class FormattedTextTest extends TestCase
     public function substitutesStringArgument(): void
     {
         self::assertThat(
-            new FormattedText(TextOf::ofString('Hello, %s!'), 'world'),
+            new FormattedText(TextOf::str('Hello, %s!'), 'world'),
             new HasTextValue('Hello, world!')
         );
     }
@@ -25,7 +25,7 @@ final class FormattedTextTest extends TestCase
     public function substitutesIntAndFloatArguments(): void
     {
         self::assertThat(
-            new FormattedText(TextOf::ofString('%d items at %.2f each'), 5, 3.5),
+            new FormattedText(TextOf::str('%d items at %.2f each'), 5, 3.5),
             new HasTextValue('5 items at 3.50 each')
         );
     }
@@ -34,7 +34,7 @@ final class FormattedTextTest extends TestCase
     public function returnsPatternUnchangedWhenNoPlaceholders(): void
     {
         self::assertThat(
-            new FormattedText(TextOf::ofString('no placeholders here')),
+            new FormattedText(TextOf::str('no placeholders here')),
             new HasTextValue('no placeholders here')
         );
     }
@@ -43,7 +43,7 @@ final class FormattedTextTest extends TestCase
     public function honoursPositionalSpecifiers(): void
     {
         self::assertThat(
-            new FormattedText(TextOf::ofString('%2$s %1$s'), 'world', 'hello'),
+            new FormattedText(TextOf::str('%2$s %1$s'), 'world', 'hello'),
             new HasTextValue('hello world')
         );
     }
@@ -52,7 +52,7 @@ final class FormattedTextTest extends TestCase
     public function preservesMultibyteCharactersInPatternAndArguments(): void
     {
         self::assertThat(
-            new FormattedText(TextOf::ofString('café %s'), 'привет'),
+            new FormattedText(TextOf::str('café %s'), 'привет'),
             new HasTextValue('café привет')
         );
     }

--- a/tests/Text/HtmlEscapedTest.php
+++ b/tests/Text/HtmlEscapedTest.php
@@ -18,7 +18,7 @@ final class HtmlEscapedTest extends TestCase
     public function escapesSpecialCharacters(): void
     {
         self::assertThat(
-            new HtmlEscaped(TextOf::ofString('<b>John & "Jane"</b>')),
+            new HtmlEscaped(TextOf::str('<b>John & "Jane"</b>')),
             new HasTextValue('&lt;b&gt;John &amp; &quot;Jane&quot;&lt;/b&gt;')
         );
     }
@@ -27,7 +27,7 @@ final class HtmlEscapedTest extends TestCase
     public function leavesPlainTextUntouched(): void
     {
         self::assertThat(
-            new HtmlEscaped(TextOf::ofString('Hello world')),
+            new HtmlEscaped(TextOf::str('Hello world')),
             new HasTextValue('Hello world')
         );
     }
@@ -36,7 +36,7 @@ final class HtmlEscapedTest extends TestCase
     public function handlesEmptyString(): void
     {
         self::assertThat(
-            new HtmlEscaped(TextOf::ofString('')),
+            new HtmlEscaped(TextOf::str('')),
             new HasTextValue('')
         );
     }

--- a/tests/Text/IsBlankTest.php
+++ b/tests/Text/IsBlankTest.php
@@ -14,48 +14,48 @@ final class IsBlankTest extends TestCase
     #[Test]
     public function returnsTrueForEmptyString(): void
     {
-        self::assertTrue((new IsBlank(TextOf::ofString('')))->value());
+        self::assertTrue((new IsBlank(TextOf::str('')))->value());
     }
 
     #[Test]
     public function returnsTrueForAsciiSpacesOnly(): void
     {
-        self::assertTrue((new IsBlank(TextOf::ofString('   ')))->value());
+        self::assertTrue((new IsBlank(TextOf::str('   ')))->value());
     }
 
     #[Test]
     public function returnsTrueForMixedAsciiWhitespace(): void
     {
-        self::assertTrue((new IsBlank(TextOf::ofString(" \t\n\r")))->value());
+        self::assertTrue((new IsBlank(TextOf::str(" \t\n\r")))->value());
     }
 
     #[Test]
     public function returnsTrueForUnicodeNonBreakingSpace(): void
     {
-        self::assertTrue((new IsBlank(TextOf::ofString("\u{00A0}\u{2003}")))->value());
+        self::assertTrue((new IsBlank(TextOf::str("\u{00A0}\u{2003}")))->value());
     }
 
     #[Test]
     public function returnsTrueForUnicodeLineAndParagraphSeparators(): void
     {
-        self::assertTrue((new IsBlank(TextOf::ofString("\u{2028}\u{2029}")))->value());
+        self::assertTrue((new IsBlank(TextOf::str("\u{2028}\u{2029}")))->value());
     }
 
     #[Test]
     public function returnsFalseForNonBlankString(): void
     {
-        self::assertFalse((new IsBlank(TextOf::ofString('hello')))->value());
+        self::assertFalse((new IsBlank(TextOf::str('hello')))->value());
     }
 
     #[Test]
     public function returnsFalseWhenContentSurroundedByWhitespace(): void
     {
-        self::assertFalse((new IsBlank(TextOf::ofString('  x  ')))->value());
+        self::assertFalse((new IsBlank(TextOf::str('  x  ')))->value());
     }
 
     #[Test]
     public function returnsFalseForVisibleUtf8(): void
     {
-        self::assertFalse((new IsBlank(TextOf::ofString('привет')))->value());
+        self::assertFalse((new IsBlank(TextOf::str('привет')))->value());
     }
 }

--- a/tests/Text/IsEmptyTest.php
+++ b/tests/Text/IsEmptyTest.php
@@ -17,7 +17,7 @@ final class IsEmptyTest extends TestCase
     public function returnsTrueWhenTextIsFalsy(string $input): void
     {
         $this->assertTrue(
-            (new IsEmpty(TextOf::ofString($input)))->value(),
+            (new IsEmpty(TextOf::str($input)))->value(),
             'Expected true for PHP-falsy string: "' . $input . '"'
         );
     }
@@ -27,7 +27,7 @@ final class IsEmptyTest extends TestCase
     public function returnsFalseWhenTextIsTruthy(string $input): void
     {
         $this->assertFalse(
-            (new IsEmpty(TextOf::ofString($input)))->value(),
+            (new IsEmpty(TextOf::str($input)))->value(),
             'Expected false for PHP-truthy string: "' . \addcslashes($input, "\t\n\r") . '"'
         );
     }

--- a/tests/Text/JoinedTest.php
+++ b/tests/Text/JoinedTest.php
@@ -19,7 +19,7 @@ final class JoinedTest extends TestCase
     public function joinsTextsWithSeparator(): void
     {
         self::assertThat(
-            new Joined(', ', [TextOf::ofString('a'), TextOf::ofString('b'), TextOf::ofString('c')]),
+            new Joined(', ', [TextOf::str('a'), TextOf::str('b'), TextOf::str('c')]),
             new HasTextValue('a, b, c')
         );
     }
@@ -28,7 +28,7 @@ final class JoinedTest extends TestCase
     public function joinsWithoutSeparator(): void
     {
         self::assertThat(
-            new Joined('', [TextOf::ofString('a'), TextOf::ofString('b'), TextOf::ofString('c')]),
+            new Joined('', [TextOf::str('a'), TextOf::str('b'), TextOf::str('c')]),
             new HasTextValue('abc')
         );
     }
@@ -37,7 +37,7 @@ final class JoinedTest extends TestCase
     public function joinsSingleText(): void
     {
         self::assertThat(
-            new Joined(', ', [TextOf::ofString('solo')]),
+            new Joined(', ', [TextOf::str('solo')]),
             new HasTextValue('solo')
         );
     }

--- a/tests/Text/LeftPaddedTest.php
+++ b/tests/Text/LeftPaddedTest.php
@@ -18,7 +18,7 @@ final class LeftPaddedTest extends TestCase
     public function padsTextOnLeft(): void
     {
         self::assertThat(
-            new LeftPadded(TextOf::ofString('foo'), 6, '.'),
+            new LeftPadded(TextOf::str('foo'), 6, '.'),
             new HasTextValue('...foo')
         );
     }
@@ -27,7 +27,7 @@ final class LeftPaddedTest extends TestCase
     public function returnsOriginalWhenLengthIsShorter(): void
     {
         self::assertThat(
-            new LeftPadded(TextOf::ofString('foobar'), 3, '.'),
+            new LeftPadded(TextOf::str('foobar'), 3, '.'),
             new HasTextValue('foobar')
         );
     }
@@ -36,7 +36,7 @@ final class LeftPaddedTest extends TestCase
     public function padsWithSpacesByDefault(): void
     {
         self::assertThat(
-            new LeftPadded(TextOf::ofString('bar'), 6, ' '),
+            new LeftPadded(TextOf::str('bar'), 6, ' '),
             new HasTextValue('   bar')
         );
     }
@@ -45,7 +45,7 @@ final class LeftPaddedTest extends TestCase
     public function handlesEmptyText(): void
     {
         self::assertThat(
-            new LeftPadded(TextOf::ofString(''), 6, '.'),
+            new LeftPadded(TextOf::str(''), 6, '.'),
             new HasTextValue('......')
         );
     }

--- a/tests/Text/LengthOfTextTest.php
+++ b/tests/Text/LengthOfTextTest.php
@@ -17,7 +17,7 @@ final class LengthOfTextTest extends TestCase
     public function returnsLengthFiveWhenTextIsAscii(): void
     {
         self::assertThat(
-            TextOf::ofString('hello'),
+            TextOf::str('hello'),
             new HasSize(5)
         );
     }
@@ -26,7 +26,7 @@ final class LengthOfTextTest extends TestCase
     public function returnsLengthFiveWhenTextContainsDiacritics(): void
     {
         self::assertThat(
-            TextOf::ofString('àéîöü'),
+            TextOf::str('àéîöü'),
             new HasSize(5)
         );
     }
@@ -35,7 +35,7 @@ final class LengthOfTextTest extends TestCase
     public function returnsZeroWhenTextIsEmpty(): void
     {
         self::assertThat(
-            TextOf::ofString(''),
+            TextOf::str(''),
             new HasSize(0)
         );
     }

--- a/tests/Text/LoweredTest.php
+++ b/tests/Text/LoweredTest.php
@@ -18,7 +18,7 @@ final class LoweredTest extends TestCase
     public function returnsLowercaseWhenTextIsUppercase(): void
     {
         self::assertThat(
-            new Lowered(TextOf::ofString('HELLO')),
+            new Lowered(TextOf::str('HELLO')),
             new HasTextValue('hello')
         );
     }
@@ -27,7 +27,7 @@ final class LoweredTest extends TestCase
     public function returnsLowercaseWhenTextIsMixedCase(): void
     {
         self::assertThat(
-            new Lowered(TextOf::ofString('HeLLo WoRLD')),
+            new Lowered(TextOf::str('HeLLo WoRLD')),
             new HasTextValue('hello world')
         );
     }
@@ -36,7 +36,7 @@ final class LoweredTest extends TestCase
     public function returnsLowercaseWhenTextContainsDiacritics(): void
     {
         self::assertThat(
-            new Lowered(TextOf::ofString('ÀÉÎÖÜ')),
+            new Lowered(TextOf::str('ÀÉÎÖÜ')),
             new HasTextValue('àéîöü')
         );
     }

--- a/tests/Text/MappedTest.php
+++ b/tests/Text/MappedTest.php
@@ -19,7 +19,7 @@ final class MappedTest extends TestCase
     public function appliesFunctionToOriginValue(): void
     {
         self::assertThat(
-            new Mapped(TextOf::ofString('hello'), new FuncOf(strtoupper(...))),
+            new Mapped(TextOf::str('hello'), new FuncOf(strtoupper(...))),
             new HasTextValue('HELLO'),
         );
     }
@@ -29,7 +29,7 @@ final class MappedTest extends TestCase
     {
         $calls = 0;
         new Mapped( // NOSONAR — instantiation is the subject under test for the lazy contract
-            TextOf::ofString('x'),
+            TextOf::str('x'),
             new FuncOf(static function (string $s) use (&$calls): string {
                 $calls++;
 
@@ -45,7 +45,7 @@ final class MappedTest extends TestCase
     {
         $calls = 0;
         $mapped = new Mapped(
-            TextOf::ofString('x'),
+            TextOf::str('x'),
             new FuncOf(static function (string $s) use (&$calls): string {
                 $calls++;
 

--- a/tests/Text/NormalizedTest.php
+++ b/tests/Text/NormalizedTest.php
@@ -20,7 +20,7 @@ final class NormalizedTest extends TestCase
     public function replacesMultipleSpacesWithSingleOne(): void
     {
         self::assertThat(
-            new Normalized(TextOf::ofString('Hello   world')),
+            new Normalized(TextOf::str('Hello   world')),
             new HasTextValue('Hello world'),
             'Normalized must replace multiple spaces with a single one'
         );
@@ -30,7 +30,7 @@ final class NormalizedTest extends TestCase
     public function replacesTabsAndNewlinesWithSingleSpace(): void
     {
         self::assertThat(
-            new Normalized(TextOf::ofString("A\tB\nC")),
+            new Normalized(TextOf::str("A\tB\nC")),
             new HasTextValue('A B C'),
             'Normalized must replace tabs and newlines with a single space'
         );
@@ -40,7 +40,7 @@ final class NormalizedTest extends TestCase
     public function trimsLeadingAndTrailingSpaces(): void
     {
         self::assertThat(
-            new Normalized(TextOf::ofString("   Hello world   ")),
+            new Normalized(TextOf::str("   Hello world   ")),
             new HasTextValue('Hello world'),
             'Normalized must trim leading and trailing spaces'
         );
@@ -50,7 +50,7 @@ final class NormalizedTest extends TestCase
     public function worksWithUnicodeWhitespace(): void
     {
         self::assertThat(
-            new Normalized(TextOf::ofString("α β  γ")),
+            new Normalized(TextOf::str("α β  γ")),
             new HasTextValue('α β γ'),
             'Normalized must work with unicode whitespace'
         );
@@ -60,7 +60,7 @@ final class NormalizedTest extends TestCase
     public function returnsEmptyStringWhenOnlyWhitespace(): void
     {
         self::assertThat(
-            new Normalized(TextOf::ofString(" \n\t ")),
+            new Normalized(TextOf::str(" \n\t ")),
             new HasTextValue(''),
             'Normalized must return an empty string when the original text consists only of whitespace'
         );
@@ -70,7 +70,7 @@ final class NormalizedTest extends TestCase
     public function throwsExceptionOnMalformedUtf8(): void
     {
         self::assertThat(
-            new Normalized(TextOf::ofString("\xC3")),
+            new Normalized(TextOf::str("\xC3")),
             new ThrowsValue(InvalidArgumentException::class),
             'Normalized must throw an exception on malformed UTF-8 input'
         );

--- a/tests/Text/PrefixOfTest.php
+++ b/tests/Text/PrefixOfTest.php
@@ -17,8 +17,8 @@ final class PrefixOfTest extends TestCase
     {
         self::assertThat(
             new PrefixOf(
-                TextOf::ofString('user@example.com'),
-                TextOf::ofString('@'),
+                TextOf::str('user@example.com'),
+                TextOf::str('@'),
             ),
             new HasTextValue('user')
         );
@@ -29,8 +29,8 @@ final class PrefixOfTest extends TestCase
     {
         self::assertThat(
             new PrefixOf(
-                TextOf::ofString('plainstring'),
-                TextOf::ofString('@'),
+                TextOf::str('plainstring'),
+                TextOf::str('@'),
             ),
             new HasTextValue('plainstring')
         );
@@ -41,8 +41,8 @@ final class PrefixOfTest extends TestCase
     {
         self::assertThat(
             new PrefixOf(
-                TextOf::ofString('@tail'),
-                TextOf::ofString('@'),
+                TextOf::str('@tail'),
+                TextOf::str('@'),
             ),
             new HasTextValue('')
         );
@@ -53,8 +53,8 @@ final class PrefixOfTest extends TestCase
     {
         self::assertThat(
             new PrefixOf(
-                TextOf::ofString('a/b/c'),
-                TextOf::ofString('/'),
+                TextOf::str('a/b/c'),
+                TextOf::str('/'),
             ),
             new HasTextValue('a')
         );
@@ -65,8 +65,8 @@ final class PrefixOfTest extends TestCase
     {
         self::assertThat(
             new PrefixOf(
-                TextOf::ofString('café/мир'),
-                TextOf::ofString('/'),
+                TextOf::str('café/мир'),
+                TextOf::str('/'),
             ),
             new HasTextValue('café')
         );
@@ -77,8 +77,8 @@ final class PrefixOfTest extends TestCase
     {
         self::assertThat(
             new PrefixOf(
-                TextOf::ofString('helloпривет'),
-                TextOf::ofString('п'),
+                TextOf::str('helloпривет'),
+                TextOf::str('п'),
             ),
             new HasTextValue('hello')
         );
@@ -89,8 +89,8 @@ final class PrefixOfTest extends TestCase
     {
         self::assertThat(
             new PrefixOf(
-                TextOf::ofString(''),
-                TextOf::ofString('@'),
+                TextOf::str(''),
+                TextOf::str('@'),
             ),
             new HasTextValue('')
         );

--- a/tests/Text/RepeatedTest.php
+++ b/tests/Text/RepeatedTest.php
@@ -18,7 +18,7 @@ final class RepeatedTest extends TestCase
     public function repeatsTextMultipleTimes(): void
     {
         self::assertThat(
-            new Repeated(TextOf::ofString('xo'), 3),
+            new Repeated(TextOf::str('xo'), 3),
             new HasTextValue('xoxoxo')
         );
     }
@@ -27,7 +27,7 @@ final class RepeatedTest extends TestCase
     public function returnsEmptyWhenCountIsZero(): void
     {
         self::assertThat(
-            new Repeated(TextOf::ofString('abc'), 0),
+            new Repeated(TextOf::str('abc'), 0),
             new HasTextValue('')
         );
     }
@@ -36,7 +36,7 @@ final class RepeatedTest extends TestCase
     public function returnsEmptyWhenCountIsNegative(): void
     {
         self::assertThat(
-            new Repeated(TextOf::ofString('abc'), -2),
+            new Repeated(TextOf::str('abc'), -2),
             new HasTextValue('')
         );
     }
@@ -45,7 +45,7 @@ final class RepeatedTest extends TestCase
     public function repeatsEmptyText(): void
     {
         self::assertThat(
-            new Repeated(TextOf::ofString(''), 5),
+            new Repeated(TextOf::str(''), 5),
             new HasTextValue('')
         );
     }
@@ -54,7 +54,7 @@ final class RepeatedTest extends TestCase
     public function repeatsSingleCharacter(): void
     {
         self::assertThat(
-            new Repeated(TextOf::ofString('a'), 5),
+            new Repeated(TextOf::str('a'), 5),
             new HasTextValue('aaaaa')
         );
     }
@@ -63,7 +63,7 @@ final class RepeatedTest extends TestCase
     public function repeatsUnicodeText(): void
     {
         self::assertThat(
-            new Repeated(TextOf::ofString('🔥'), 3),
+            new Repeated(TextOf::str('🔥'), 3),
             new HasTextValue('🔥🔥🔥')
         );
     }

--- a/tests/Text/ReplacedTest.php
+++ b/tests/Text/ReplacedTest.php
@@ -18,7 +18,7 @@ final class ReplacedTest extends TestCase
     public function replacesSingleSubstring(): void
     {
         self::assertThat(
-            new Replaced(TextOf::ofString('Hello, world!'), 'world', 'friend'),
+            new Replaced(TextOf::str('Hello, world!'), 'world', 'friend'),
             new HasTextValue('Hello, friend!')
         );
     }
@@ -28,7 +28,7 @@ final class ReplacedTest extends TestCase
     {
         self::assertThat(
             new Replaced(
-                TextOf::ofString('<b>Hello & bye</b>'),
+                TextOf::str('<b>Hello & bye</b>'),
                 ['<b>', '</b>', '&'],
                 ['', '', 'and']
             ),
@@ -40,7 +40,7 @@ final class ReplacedTest extends TestCase
     public function returnsOriginalTextWhenNoMatches(): void
     {
         self::assertThat(
-            new Replaced(TextOf::ofString('unchanged'), 'zzz', 'xxx'),
+            new Replaced(TextOf::str('unchanged'), 'zzz', 'xxx'),
             new HasTextValue('unchanged')
         );
     }
@@ -49,7 +49,7 @@ final class ReplacedTest extends TestCase
     public function handlesEmptyText(): void
     {
         self::assertThat(
-            new Replaced(TextOf::ofString(''), 'a', 'b'),
+            new Replaced(TextOf::str(''), 'a', 'b'),
             new HasTextValue('')
         );
     }

--- a/tests/Text/ReversedTest.php
+++ b/tests/Text/ReversedTest.php
@@ -16,7 +16,7 @@ final class ReversedTest extends TestCase
     public function returnsCharactersInReverseOrder(): void
     {
         self::assertThat(
-            new Reversed(TextOf::ofString('hello')),
+            new Reversed(TextOf::str('hello')),
             new HasTextValue('olleh')
         );
     }
@@ -25,7 +25,7 @@ final class ReversedTest extends TestCase
     public function returnsEmptyForEmptyText(): void
     {
         self::assertThat(
-            new Reversed(TextOf::ofString('')),
+            new Reversed(TextOf::str('')),
             new HasTextValue('')
         );
     }
@@ -34,7 +34,7 @@ final class ReversedTest extends TestCase
     public function preservesMultibyteCharactersAsWholeUnits(): void
     {
         self::assertThat(
-            new Reversed(TextOf::ofString('café')),
+            new Reversed(TextOf::str('café')),
             new HasTextValue('éfac')
         );
     }
@@ -43,7 +43,7 @@ final class ReversedTest extends TestCase
     public function reversesCyrillicTextByCodepoint(): void
     {
         self::assertThat(
-            new Reversed(TextOf::ofString('привет')),
+            new Reversed(TextOf::str('привет')),
             new HasTextValue('тевирп')
         );
     }
@@ -52,7 +52,7 @@ final class ReversedTest extends TestCase
     public function reversesByCodepointNotGraphemeCluster(): void
     {
         self::assertThat(
-            new Reversed(TextOf::ofString("cafe\u{0301}")),
+            new Reversed(TextOf::str("cafe\u{0301}")),
             new HasTextValue("\u{0301}efac")
         );
     }

--- a/tests/Text/RightPaddedTest.php
+++ b/tests/Text/RightPaddedTest.php
@@ -18,7 +18,7 @@ final class RightPaddedTest extends TestCase
     public function returnsTextPaddedWithZerosToRight(): void
     {
         self::assertThat(
-            new RightPadded(TextOf::ofString('12'), 5, '0'),
+            new RightPadded(TextOf::str('12'), 5, '0'),
             new HasTextValue('12000')
         );
     }
@@ -27,7 +27,7 @@ final class RightPaddedTest extends TestCase
     public function returnsTextPaddedWithSpacesToRight(): void
     {
         self::assertThat(
-            new RightPadded(TextOf::ofString('abc'), 6, ' '),
+            new RightPadded(TextOf::str('abc'), 6, ' '),
             new HasTextValue('abc   ')
         );
     }
@@ -36,7 +36,7 @@ final class RightPaddedTest extends TestCase
     public function returnsSameTextWhenLengthExceedsPadding(): void
     {
         self::assertThat(
-            new RightPadded(TextOf::ofString('foobar'), 4, '*'),
+            new RightPadded(TextOf::str('foobar'), 4, '*'),
             new HasTextValue('foobar')
         );
     }
@@ -45,7 +45,7 @@ final class RightPaddedTest extends TestCase
     public function returnsPaddingOnlyWhenTextIsEmpty(): void
     {
         self::assertThat(
-            new RightPadded(TextOf::ofString(''), 3, '.'),
+            new RightPadded(TextOf::str(''), 3, '.'),
             new HasTextValue('...')
         );
     }

--- a/tests/Text/SplitTest.php
+++ b/tests/Text/SplitTest.php
@@ -18,7 +18,7 @@ final class SplitTest extends TestCase
     public function splitsTextByDelimiter(): void
     {
         self::assertThat(
-            (new Split(',', TextOf::ofString('a,b,c')))->value(),
+            (new Split(',', TextOf::str('a,b,c')))->value(),
             new HasTextValues(['a', 'b', 'c'])
         );
     }
@@ -27,7 +27,7 @@ final class SplitTest extends TestCase
     public function returnsSinglePartWhenDelimiterNotFound(): void
     {
         self::assertThat(
-            (new Split(',', TextOf::ofString('abc')))->value(),
+            (new Split(',', TextOf::str('abc')))->value(),
             new HasTextValues(['abc'])
         );
     }
@@ -36,7 +36,7 @@ final class SplitTest extends TestCase
     public function handlesEmptyString(): void
     {
         self::assertThat(
-            (new Split(',', TextOf::ofString('')))->value(),
+            (new Split(',', TextOf::str('')))->value(),
             new HasTextValues([''])
         );
     }
@@ -45,7 +45,7 @@ final class SplitTest extends TestCase
     public function worksWithMultibyteDelimiter(): void
     {
         self::assertThat(
-            (new Split('—', TextOf::ofString('a—b—c')))->value(),
+            (new Split('—', TextOf::str('a—b—c')))->value(),
             new HasTextValues(['a', 'b', 'c'])
         );
     }
@@ -54,7 +54,7 @@ final class SplitTest extends TestCase
     public function consecutiveDelimitersProduceEmptyParts(): void
     {
         self::assertThat(
-            (new Split(',', TextOf::ofString('a,,b,')))->value(),
+            (new Split(',', TextOf::str('a,,b,')))->value(),
             new HasTextValues(['a', '', 'b', ''])
         );
     }

--- a/tests/Text/StartsWithTest.php
+++ b/tests/Text/StartsWithTest.php
@@ -15,7 +15,7 @@ final class StartsWithTest extends TestCase
     public function returnsTrueWhenHaystackStartsWithNeedle(): void
     {
         self::assertTrue(
-            (new StartsWith(TextOf::ofString('hello world'), TextOf::ofString('hello')))->value(),
+            (new StartsWith(TextOf::str('hello world'), TextOf::str('hello')))->value(),
         );
     }
 
@@ -23,7 +23,7 @@ final class StartsWithTest extends TestCase
     public function returnsFalseWhenHaystackDoesNotStartWithNeedle(): void
     {
         self::assertFalse(
-            (new StartsWith(TextOf::ofString('hello world'), TextOf::ofString('world')))->value(),
+            (new StartsWith(TextOf::str('hello world'), TextOf::str('world')))->value(),
         );
     }
 
@@ -31,7 +31,7 @@ final class StartsWithTest extends TestCase
     public function returnsTrueWhenNeedleIsEmpty(): void
     {
         self::assertTrue(
-            (new StartsWith(TextOf::ofString('hello'), TextOf::ofString('')))->value(),
+            (new StartsWith(TextOf::str('hello'), TextOf::str('')))->value(),
         );
     }
 
@@ -39,7 +39,7 @@ final class StartsWithTest extends TestCase
     public function returnsFalseWhenNeedleIsLongerThanHaystack(): void
     {
         self::assertFalse(
-            (new StartsWith(TextOf::ofString('hi'), TextOf::ofString('hello')))->value(),
+            (new StartsWith(TextOf::str('hi'), TextOf::str('hello')))->value(),
         );
     }
 
@@ -47,7 +47,7 @@ final class StartsWithTest extends TestCase
     public function returnsTrueOnExactMatch(): void
     {
         self::assertTrue(
-            (new StartsWith(TextOf::ofString('abc'), TextOf::ofString('abc')))->value(),
+            (new StartsWith(TextOf::str('abc'), TextOf::str('abc')))->value(),
         );
     }
 
@@ -55,7 +55,7 @@ final class StartsWithTest extends TestCase
     public function respectsUtf8MultibyteCharacters(): void
     {
         self::assertTrue(
-            (new StartsWith(TextOf::ofString('привет мир'), TextOf::ofString('привет')))->value(),
+            (new StartsWith(TextOf::str('привет мир'), TextOf::str('привет')))->value(),
         );
     }
 }

--- a/tests/Text/SubTest.php
+++ b/tests/Text/SubTest.php
@@ -18,7 +18,7 @@ final class SubTest extends TestCase
     public function returnsSubstringWithinRange(): void
     {
         self::assertThat(
-            new Sub(TextOf::ofString('abcdefg'), 2, 3),
+            new Sub(TextOf::str('abcdefg'), 2, 3),
             new HasTextValue('cde')
         );
     }
@@ -27,7 +27,7 @@ final class SubTest extends TestCase
     public function returnsSubstringToEndWhenLengthNotLimited(): void
     {
         self::assertThat(
-            new Sub(TextOf::ofString('abcdefg'), 3),
+            new Sub(TextOf::str('abcdefg'), 3),
             new HasTextValue('defg')
         );
     }
@@ -36,7 +36,7 @@ final class SubTest extends TestCase
     public function handlesMultibyteEmojiCorrectly(): void
     {
         self::assertThat(
-            new Sub(TextOf::ofString('😀bcdef'), 0, 2),
+            new Sub(TextOf::str('😀bcdef'), 0, 2),
             new HasTextValue('😀b')
         );
     }

--- a/tests/Text/SuffixOfTest.php
+++ b/tests/Text/SuffixOfTest.php
@@ -17,8 +17,8 @@ final class SuffixOfTest extends TestCase
     {
         self::assertThat(
             new SuffixOf(
-                TextOf::ofString('user@example.com'),
-                TextOf::ofString('@'),
+                TextOf::str('user@example.com'),
+                TextOf::str('@'),
             ),
             new HasTextValue('example.com')
         );
@@ -29,8 +29,8 @@ final class SuffixOfTest extends TestCase
     {
         self::assertThat(
             new SuffixOf(
-                TextOf::ofString('plainstring'),
-                TextOf::ofString('@'),
+                TextOf::str('plainstring'),
+                TextOf::str('@'),
             ),
             new HasTextValue('')
         );
@@ -41,8 +41,8 @@ final class SuffixOfTest extends TestCase
     {
         self::assertThat(
             new SuffixOf(
-                TextOf::ofString('head@'),
-                TextOf::ofString('@'),
+                TextOf::str('head@'),
+                TextOf::str('@'),
             ),
             new HasTextValue('')
         );
@@ -53,8 +53,8 @@ final class SuffixOfTest extends TestCase
     {
         self::assertThat(
             new SuffixOf(
-                TextOf::ofString('a/b/c'),
-                TextOf::ofString('/'),
+                TextOf::str('a/b/c'),
+                TextOf::str('/'),
             ),
             new HasTextValue('b/c')
         );
@@ -65,8 +65,8 @@ final class SuffixOfTest extends TestCase
     {
         self::assertThat(
             new SuffixOf(
-                TextOf::ofString('café/мир'),
-                TextOf::ofString('/'),
+                TextOf::str('café/мир'),
+                TextOf::str('/'),
             ),
             new HasTextValue('мир')
         );
@@ -77,8 +77,8 @@ final class SuffixOfTest extends TestCase
     {
         self::assertThat(
             new SuffixOf(
-                TextOf::ofString('helloпривет'),
-                TextOf::ofString('п'),
+                TextOf::str('helloпривет'),
+                TextOf::str('п'),
             ),
             new HasTextValue('ривет')
         );
@@ -89,8 +89,8 @@ final class SuffixOfTest extends TestCase
     {
         self::assertThat(
             new SuffixOf(
-                TextOf::ofString(''),
-                TextOf::ofString('@'),
+                TextOf::str(''),
+                TextOf::str('@'),
             ),
             new HasTextValue('')
         );

--- a/tests/Text/TextOfTest.php
+++ b/tests/Text/TextOfTest.php
@@ -13,28 +13,28 @@ use Primus\Text\TextOf;
 final class TextOfTest extends TestCase
 {
     #[Test]
-    public function ofStringExposesPlainStringAsTextValue(): void
+    public function strExposesPlainStringAsTextValue(): void
     {
         self::assertThat(
-            TextOf::ofString('hello'),
+            TextOf::str('hello'),
             new HasTextValue('hello'),
         );
     }
 
     #[Test]
-    public function ofStringPreservesArbitraryStringContent(): void
+    public function strPreservesArbitraryStringContent(): void
     {
         self::assertThat(
-            TextOf::ofString('world'),
+            TextOf::str('world'),
             new HasTextValue('world'),
         );
     }
 
     #[Test]
-    public function ofScalarDefersStringResolutionUntilValueCall(): void
+    public function scalarDefersStringResolutionUntilValueCall(): void
     {
         $resolved = false;
-        $text = TextOf::ofScalar(
+        $text = TextOf::scalar(
             new ScalarOf(
                 static function () use (&$resolved): string {
                     $resolved = true;

--- a/tests/Text/TrimmedLeftTest.php
+++ b/tests/Text/TrimmedLeftTest.php
@@ -18,7 +18,7 @@ final class TrimmedLeftTest extends TestCase
     public function removesLeadingSpacesOnly(): void
     {
         self::assertThat(
-            new TrimmedLeft(TextOf::ofString('   hello world  ')),
+            new TrimmedLeft(TextOf::str('   hello world  ')),
             new HasTextValue('hello world  '),
             'TrimmedLeft must remove leading spaces only'
         );
@@ -28,7 +28,7 @@ final class TrimmedLeftTest extends TestCase
     public function returnsSameTextWhenNoLeadingSpaces(): void
     {
         self::assertThat(
-            new TrimmedLeft(TextOf::ofString('hello')),
+            new TrimmedLeft(TextOf::str('hello')),
             new HasTextValue('hello'),
             'TrimmedLeft must return the same text when there are no leading spaces'
         );
@@ -38,7 +38,7 @@ final class TrimmedLeftTest extends TestCase
     public function removesUnicodeWhitespace(): void
     {
         self::assertThat(
-            new TrimmedLeft(TextOf::ofString("  Hello")), // em spaces (U+2003)
+            new TrimmedLeft(TextOf::str("  Hello")), // em spaces (U+2003)
             new HasTextValue('Hello'),
             'TrimmedLeft must remove unicode whitespace'
         );
@@ -48,7 +48,7 @@ final class TrimmedLeftTest extends TestCase
     public function returnsEmptyWhenOnlySpaces(): void
     {
         self::assertThat(
-            new TrimmedLeft(TextOf::ofString('   ')),
+            new TrimmedLeft(TextOf::str('   ')),
             new HasTextValue(''),
             'TrimmedLeft must return an empty string when the original text consists only of spaces'
         );
@@ -58,7 +58,7 @@ final class TrimmedLeftTest extends TestCase
     public function keepsTrailingSpacesIntact(): void
     {
         self::assertThat(
-            new TrimmedLeft(TextOf::ofString(' hi  ')),
+            new TrimmedLeft(TextOf::str(' hi  ')),
             new HasTextValue('hi  '),
             'TrimmedLeft must keep trailing spaces intact'
         );

--- a/tests/Text/TrimmedRightTest.php
+++ b/tests/Text/TrimmedRightTest.php
@@ -20,7 +20,7 @@ final class TrimmedRightTest extends TestCase
     public function removesTrailingSpacesOnly(): void
     {
         self::assertThat(
-            new TrimmedRight(TextOf::ofString('  hello world   ')),
+            new TrimmedRight(TextOf::str('  hello world   ')),
             new HasTextValue('  hello world'),
             'TrimmedRight must remove trailing spaces only'
         );
@@ -30,7 +30,7 @@ final class TrimmedRightTest extends TestCase
     public function returnsSameTextWhenNoTrailingSpaces(): void
     {
         self::assertThat(
-            new TrimmedRight(TextOf::ofString('world')),
+            new TrimmedRight(TextOf::str('world')),
             new HasTextValue('world'),
             'TrimmedRight must return the same text when there are no trailing spaces'
         );
@@ -40,7 +40,7 @@ final class TrimmedRightTest extends TestCase
     public function removesUnicodeWhitespace(): void
     {
         self::assertThat(
-            new TrimmedRight(TextOf::ofString("Hello  ")),
+            new TrimmedRight(TextOf::str("Hello  ")),
             new HasTextValue('Hello'),
             'TrimmedRight must remove unicode whitespace'
         );
@@ -50,7 +50,7 @@ final class TrimmedRightTest extends TestCase
     public function returnsEmptyWhenOnlySpaces(): void
     {
         self::assertThat(
-            new TrimmedRight(TextOf::ofString('   ')),
+            new TrimmedRight(TextOf::str('   ')),
             new HasTextValue(''),
             'TrimmedRight must return an empty string when the original text consists only of spaces'
         );
@@ -60,7 +60,7 @@ final class TrimmedRightTest extends TestCase
     public function keepsLeadingSpacesIntact(): void
     {
         self::assertThat(
-            new TrimmedRight(TextOf::ofString('  hi')),
+            new TrimmedRight(TextOf::str('  hi')),
             new HasTextValue('  hi'),
             'TrimmedRight must keep leading spaces intact'
         );
@@ -70,7 +70,7 @@ final class TrimmedRightTest extends TestCase
     public function throwsExceptionOnMalformedUtf8(): void
     {
         self::assertThat(
-            (new TrimmedRight(TextOf::ofString("\xC3"))),
+            (new TrimmedRight(TextOf::str("\xC3"))),
             new ThrowsValue(InvalidArgumentException::class),
             'TrimmedRight must throw an exception on malformed UTF-8 input'
         );

--- a/tests/Text/TrimmedTest.php
+++ b/tests/Text/TrimmedTest.php
@@ -18,7 +18,7 @@ final class TrimmedTest extends TestCase
     public function returnsTextWithoutLeadingAndTrailingSpaces(): void
     {
         self::assertThat(
-            new Trimmed(TextOf::ofString('  hello  world  ')),
+            new Trimmed(TextOf::str('  hello  world  ')),
             new HasTextValue('hello  world')
         );
     }
@@ -27,7 +27,7 @@ final class TrimmedTest extends TestCase
     public function returnsEmptyStringWhenInputIsWhitespaceOnly(): void
     {
         self::assertThat(
-            new Trimmed(TextOf::ofString('   ')),
+            new Trimmed(TextOf::str('   ')),
             new HasTextValue('')
         );
     }

--- a/tests/Text/UpperedTest.php
+++ b/tests/Text/UpperedTest.php
@@ -18,7 +18,7 @@ final class UpperedTest extends TestCase
     public function returnsUppercaseWhenTextIsLowercase(): void
     {
         self::assertThat(
-            new Uppered(TextOf::ofString('hello')),
+            new Uppered(TextOf::str('hello')),
             new HasTextValue('HELLO')
         );
     }
@@ -27,7 +27,7 @@ final class UpperedTest extends TestCase
     public function returnsUppercaseWhenTextIsMixedCase(): void
     {
         self::assertThat(
-            new Uppered(TextOf::ofString('HeLLo WoRLD')),
+            new Uppered(TextOf::str('HeLLo WoRLD')),
             new HasTextValue('HELLO WORLD')
         );
     }
@@ -36,7 +36,7 @@ final class UpperedTest extends TestCase
     public function returnsUppercaseWhenTextContainsDiacritics(): void
     {
         self::assertThat(
-            new Uppered(TextOf::ofString('àéîöü')),
+            new Uppered(TextOf::str('àéîöü')),
             new HasTextValue('ÀÉÎÖÜ')
         );
     }
@@ -45,7 +45,7 @@ final class UpperedTest extends TestCase
     public function returnsEmptyStringWhenInputIsEmpty(): void
     {
         self::assertThat(
-            new Uppered(TextOf::ofString('')),
+            new Uppered(TextOf::str('')),
             new HasTextValue('')
         );
     }
@@ -54,7 +54,7 @@ final class UpperedTest extends TestCase
     public function returnsSameTextWhenAlreadyUppercase(): void
     {
         self::assertThat(
-            new Uppered(TextOf::ofString('ALREADY')),
+            new Uppered(TextOf::str('ALREADY')),
             new HasTextValue('ALREADY')
         );
     }
@@ -63,7 +63,7 @@ final class UpperedTest extends TestCase
     public function leavesSpecialCharactersUnchanged(): void
     {
         self::assertThat(
-            new Uppered(TextOf::ofString('test@123!')),
+            new Uppered(TextOf::str('test@123!')),
             new HasTextValue('TEST@123!')
         );
     }
@@ -72,7 +72,7 @@ final class UpperedTest extends TestCase
     public function returnsSameWhenTextContainsOnlyWhitespace(): void
     {
         self::assertThat(
-            new Uppered(TextOf::ofString('   ')),
+            new Uppered(TextOf::str('   ')),
             new HasTextValue('   ')
         );
     }

--- a/tests/Text/WithoutTagsTest.php
+++ b/tests/Text/WithoutTagsTest.php
@@ -18,7 +18,7 @@ final class WithoutTagsTest extends TestCase
     public function returnsSanitizedTextWhenHtmlTagsArePresent(): void
     {
         self::assertThat(
-            new WithoutTags(TextOf::ofString('<script>alert("XSS")</script><b>bold</b> & "quote"')),
+            new WithoutTags(TextOf::str('<script>alert("XSS")</script><b>bold</b> & "quote"')),
             new HasTextValue('alert("XSS")bold & "quote"')
         );
     }
@@ -27,7 +27,7 @@ final class WithoutTagsTest extends TestCase
     public function returnsSameTextWhenInputIsPlain(): void
     {
         self::assertThat(
-            new WithoutTags(TextOf::ofString('safe text 123')),
+            new WithoutTags(TextOf::str('safe text 123')),
             new HasTextValue('safe text 123')
         );
     }


### PR DESCRIPTION
- Renamed TextOf::ofString to TextOf::str and TextOf::ofScalar to TextOf::scalar across the codebase
- Updated all callsites in src, tests, AGENTS.md and README.md
- Renamed three TextOf test methods to match the new constructor names
- Fixed README examples that referenced the now-private TextOf default constructor

No issue (drop-in rename refactor).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * The `TextOf` factory methods have been renamed: `ofString()` → `str()` and `ofScalar()` → `scalar()`. Applications using these methods directly must update their calls accordingly.

* **Documentation**
  * All documentation and code examples have been updated to use the new factory method names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->