### PR TITLE
Mark TextOfScalar Adapter Internal Instead of Dropping It

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,12 +37,17 @@ for the full inventory and read the PHPDoc on each class. Most namespaces
 also have an `<Namespace>Envelope` abstract class that simplifies writing
 new decorators — extend it to inherit interface compliance for free.
 
+Classes marked `@internal` in PHPDoc (e.g. delegates of named-constructor
+factories) are reachable via autoload but are not part of the public API.
+They are omitted from the lists below and may change without a deprecation
+cycle. Compose through the documented public surface instead.
+
 - **`Primus\Text`** — string operations.
   `TextOf`, `Trimmed`, `TrimmedLeft`, `TrimmedRight`, `Lowered`, `Uppered`,
   `Sub`, `HtmlEscaped`, `WithoutTags`, `Mapped` (string→string transform),
   `Joined`, `Repeated`, `Replaced`, `Split`, `Capitalized`, `Normalized`,
   `Abbreviated`, `LeftPadded`, `RightPadded`, `IsEmpty`, `LengthOfText`,
-  `RandomText`, `TextOfScalar`, `TextEnvelope`.
+  `RandomText`, `TextEnvelope`.
 
 - **`Primus\List`** — ordered list operations over `List_<T>` (the
   trailing underscore avoids the reserved keyword).

--- a/src/Text/TextOfScalar.php
+++ b/src/Text/TextOfScalar.php
@@ -16,6 +16,10 @@ use Primus\Scalar\Scalar;
  *     equivalent publicly to support value equality through `equals()`;
  *     Primus does not model Text identity, so a public surface here would
  *     be redundant.
+ *
+ * Example:
+ *     $text = TextOf::scalar(new ScalarOf(static fn(): string => 'hello'));
+ *     echo $text->value(); // 'hello'
  */
 final readonly class TextOfScalar implements Text
 {

--- a/src/Text/TextOfScalar.php
+++ b/src/Text/TextOfScalar.php
@@ -9,6 +9,13 @@ use Primus\Scalar\Scalar;
 
 /**
  * Text based on a scalar producing a string.
+ *
+ * @internal Internal delegate of {@see TextOf::scalar()}. Callers should
+ *     compose text from a {@see Scalar} through `TextOf::scalar(...)`
+ *     instead of instantiating this class directly. Cactoos exposes its
+ *     equivalent publicly to support value equality through `equals()`;
+ *     Primus does not model Text identity, so a public surface here would
+ *     be redundant.
  */
 final readonly class TextOfScalar implements Text
 {


### PR DESCRIPTION
- Scope changed: original intent was to drop TextOfScalar entirely; two phpstan rules (haspadar.constructorInit in Number\Sticky placeholder slot and haspadar.namedConstructorBody in TextOf::str) made inlining impractical without rewriting unrelated cache-slot semantics
- Added @internal PHPDoc on TextOfScalar pointing callers to TextOf::scalar()
- Updated AGENTS.md namespace overview to document the @internal convention and removed TextOfScalar from the public Text class list

Cactoos exposes its TextOfScalar publicly to support value equality; Primus does not model Text identity, so the public surface here would be redundant.

No issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API guidance recommending use of `TextOf::scalar(...)` for text composition instead of direct class instantiation.
  * Clarified that internal implementation classes may change without deprecation warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->