### PR TITLE
Add TextOf::bytes Factory Reinterpreting Bytes as Text

### DIFF
--- a/src/Text/TextOf.php
+++ b/src/Text/TextOf.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Primus\Text;
 
+use Primus\Bytes\Bytes;
 use Primus\Scalar\Scalar;
 use Primus\Scalar\ScalarOf;
 
@@ -12,11 +13,17 @@ use Primus\Scalar\ScalarOf;
  *
  * Each named constructor reduces its input to a {@see TextOfScalar} and
  * passes it to the envelope, so every form is lazy and composable through
- * the same delegate.
+ * the same delegate. None of the named constructors memoize the source —
+ * every {@see Text::value()} call re-evaluates the wrapped scalar or bytes.
+ * Wrap in {@see \Primus\Scalar\Sticky} (or compose through it) to freeze
+ * the result.
  *
  * Example:
+ *     use Primus\Bytes\BytesOf;
+ *     use Primus\Scalar\ScalarOf;
  *     TextOf::str('hello'); // eager string
  *     TextOf::scalar(new ScalarOf(fn() => 'hello')); // deferred
+ *     TextOf::bytes(new BytesOf('hello')); // bytes wrapped as text
  */
 final readonly class TextOf extends TextEnvelope
 {
@@ -48,5 +55,23 @@ final readonly class TextOf extends TextEnvelope
     public static function scalar(Scalar $scalar): self
     {
         return new self(new TextOfScalar($scalar));
+    }
+
+    /**
+     * Wraps a {@see Bytes} sequence as Text without altering its raw bytes.
+     *
+     * The byte sequence is delegated lazily — the source is touched only when
+     * {@see Text::value()} is called. Multibyte-aware Text decorators (length,
+     * substring, ...) assume UTF-8; pass non-UTF-8 only into byte-oriented
+     * consumers.
+     *
+     * @param Bytes $bytes The byte sequence to wrap as text.
+     * @psalm-api Public factory; psalm currently scans only src/, so this
+     *     annotation suppresses PossiblyUnusedMethod until an in-src consumer
+     *     (e.g. a future Base64-decoded Text decorator) replaces it.
+     */
+    public static function bytes(Bytes $bytes): self
+    {
+        return new self(new TextOfScalar(new ScalarOf(static fn(): string => $bytes->value())));
     }
 }

--- a/tests/Text/TextOfTest.php
+++ b/tests/Text/TextOfTest.php
@@ -6,6 +6,8 @@ namespace Primus\Tests\Text;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Primus\Bytes\Bytes;
+use Primus\Bytes\BytesOf;
 use Primus\Scalar\ScalarOf;
 use Primus\Tests\Constraint\HasTextValue;
 use Primus\Text\TextOf;
@@ -46,6 +48,55 @@ final class TextOfTest extends TestCase
 
         self::assertFalse($resolved);
         self::assertThat($text, new HasTextValue('lazy'));
+        self::assertTrue($resolved);
+    }
+
+    #[Test]
+    public function bytesExposesByteSequenceAsTextValue(): void
+    {
+        self::assertThat(
+            TextOf::bytes(new BytesOf('hello')),
+            new HasTextValue('hello'),
+        );
+    }
+
+    #[Test]
+    public function bytesPreservesMultibyteContent(): void
+    {
+        self::assertThat(
+            TextOf::bytes(new BytesOf('café привет')),
+            new HasTextValue('café привет'),
+        );
+    }
+
+    #[Test]
+    public function bytesAcceptsEmptyByteSequence(): void
+    {
+        self::assertThat(
+            TextOf::bytes(new BytesOf('')),
+            new HasTextValue(''),
+        );
+    }
+
+    #[Test]
+    public function bytesDefersByteResolutionUntilValueCall(): void
+    {
+        $resolved = false;
+        $text = TextOf::bytes(
+            new class ($resolved) implements Bytes {
+                public function __construct(private bool &$resolved) {}
+
+                public function value(): string
+                {
+                    $this->resolved = true;
+
+                    return 'late';
+                }
+            },
+        );
+
+        self::assertFalse($resolved);
+        self::assertThat($text, new HasTextValue('late'));
         self::assertTrue($resolved);
     }
 }


### PR DESCRIPTION
- Added TextOf::bytes named constructor that wraps a Bytes sequence as a lazy Text without copying or normalizing
- Added tests covering plain content, multibyte content, empty sequence and deferred byte resolution
- Updated TextOf class docblock to document the lack of memoization across factories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for converting byte sequences into text with deferred processing, ensuring efficient handling of byte data.

* **Tests**
  * Added comprehensive test coverage for byte-to-text conversion, including multibyte characters and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->