### PR TITLE
Add TextOf::throwable Factory Serializing Exceptions

### DIFF
--- a/src/Text/TextOf.php
+++ b/src/Text/TextOf.php
@@ -7,6 +7,7 @@ namespace Primus\Text;
 use Primus\Bytes\Bytes;
 use Primus\Scalar\Scalar;
 use Primus\Scalar\ScalarOf;
+use Throwable;
 
 /**
  * Convenience factory wrapping different sources as Text.
@@ -24,6 +25,7 @@ use Primus\Scalar\ScalarOf;
  *     TextOf::str('hello'); // eager string
  *     TextOf::scalar(new ScalarOf(fn() => 'hello')); // deferred
  *     TextOf::bytes(new BytesOf('hello')); // bytes wrapped as text
+ *     TextOf::throwable(new RuntimeException('boom')); // exception serialized
  */
 final readonly class TextOf extends TextEnvelope
 {
@@ -66,12 +68,32 @@ final readonly class TextOf extends TextEnvelope
      * consumers.
      *
      * @param Bytes $bytes The byte sequence to wrap as text.
-     * @psalm-api Public factory; psalm currently scans only src/, so this
-     *     annotation suppresses PossiblyUnusedMethod until an in-src consumer
-     *     (e.g. a future Base64-decoded Text decorator) replaces it.
+     * @psalm-api Public factory; psalm scans only src/, so this annotation
+     *     suppresses PossiblyUnusedMethod until an in-src consumer (e.g.
+     *     a future Base64-decoded Text decorator) replaces it.
      */
     public static function bytes(Bytes $bytes): self
     {
         return new self(new TextOfScalar(new ScalarOf(static fn(): string => $bytes->value())));
+    }
+
+    /**
+     * Wraps a {@see Throwable} as Text via its default string representation.
+     *
+     * The throwable is serialized through PHP's `(string)` cast on first
+     * {@see Text::value()} call, yielding the throwable's class, message,
+     * origin file:line at throw time and the full stack trace. Useful for
+     * logging or composing error messages without manually formatting.
+     *
+     * Note: the resulting string contains the full stack trace including
+     * absolute file paths and frame arguments. Do not expose it on
+     * user-visible surfaces — it is intended for server-side logs only.
+     *
+     * @param Throwable $error The exception or error to serialize.
+     * @psalm-api Public factory (see bytes()).
+     */
+    public static function throwable(Throwable $error): self
+    {
+        return new self(new TextOfScalar(new ScalarOf(static fn(): string => (string) $error)));
     }
 }

--- a/tests/Text/TextOfTest.php
+++ b/tests/Text/TextOfTest.php
@@ -10,7 +10,9 @@ use Primus\Bytes\Bytes;
 use Primus\Bytes\BytesOf;
 use Primus\Scalar\ScalarOf;
 use Primus\Tests\Constraint\HasTextValue;
+use Error;
 use Primus\Text\TextOf;
+use RuntimeException;
 
 final class TextOfTest extends TestCase
 {
@@ -98,5 +100,45 @@ final class TextOfTest extends TestCase
         self::assertFalse($resolved);
         self::assertThat($text, new HasTextValue('late'));
         self::assertTrue($resolved);
+    }
+
+    #[Test]
+    public function throwableValueContainsExceptionClassName(): void
+    {
+        $error = new RuntimeException('boom');
+
+        self::assertStringContainsString('RuntimeException', TextOf::throwable($error)->value());
+    }
+
+    #[Test]
+    public function throwableValueContainsExceptionMessage(): void
+    {
+        $error = new RuntimeException('boom: details');
+
+        self::assertStringContainsString('boom: details', TextOf::throwable($error)->value());
+    }
+
+    #[Test]
+    public function throwableValueContainsStackTraceHeader(): void
+    {
+        $error = new RuntimeException('boom');
+
+        self::assertStringContainsString('Stack trace', TextOf::throwable($error)->value());
+    }
+
+    #[Test]
+    public function throwableValueContainsOriginFile(): void
+    {
+        $error = new RuntimeException('boom');
+
+        self::assertStringContainsString(__FILE__, TextOf::throwable($error)->value());
+    }
+
+    #[Test]
+    public function throwableValueAcceptsNonExceptionErrors(): void
+    {
+        $error = new Error('boom');
+
+        self::assertStringContainsString('Error', TextOf::throwable($error)->value());
     }
 }


### PR DESCRIPTION
- Added TextOf::throwable named constructor that wraps a Throwable as a lazy Text via PHP string cast
- Added tests covering class name, message, stack trace header, origin file and non-Exception Error throwables
- Documented the security caveat that the serialized string is intended for server-side logs only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for converting exceptions and errors to text format, including error class names, messages, and stack trace information.

* **Tests**
  * Added comprehensive test coverage for exception and error text conversion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->