### PR TITLE
Add Scalar FirstOf for First-Match Lookup

### DIFF
--- a/src/Scalar/FirstOf.php
+++ b/src/Scalar/FirstOf.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Scalar;
+
+use Primus\Func\Func;
+use Primus\List\List_;
+
+/**
+ * First element in a list that satisfies a condition.
+ *
+ * Walks the list lazily and returns the first item for which `$condition`
+ * yields `true`. If no element matches, falls back to `$fallback->value()`.
+ *
+ * Example:
+ *     $first = new FirstOf(
+ *         new FuncOf(fn (int $n): bool => $n > 5),
+ *         new ListOf(1, 3, 7, 10),
+ *         new Constant(0),
+ *     );
+ *     echo $first->value(); // 7
+ *
+ * @template T
+ * @extends ScalarEnvelope<T>
+ */
+final readonly class FirstOf extends ScalarEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Func<T, bool> $condition The predicate that selects the element.
+     * @param List_<T> $source The list to scan.
+     * @param Scalar<T> $fallback The value returned when no element matches.
+     */
+    public function __construct(Func $condition, List_ $source, Scalar $fallback)
+    {
+        parent::__construct(
+            new ScalarOf(
+                static function () use ($condition, $source, $fallback) {
+                    foreach ($source as $item) {
+                        if ($condition->apply($item)) {
+                            return $item;
+                        }
+                    }
+
+                    return $fallback->value();
+                },
+            ),
+        );
+    }
+}

--- a/tests/Scalar/FirstOfTest.php
+++ b/tests/Scalar/FirstOfTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Scalar;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Func\FuncOf;
+use Primus\List\ListOf;
+use Primus\Scalar\Constant;
+use Primus\Scalar\FirstOf;
+
+final class FirstOfTest extends TestCase
+{
+    #[Test]
+    public function returnsFirstMatchingElement(): void
+    {
+        self::assertSame(
+            7,
+            (new FirstOf(
+                new FuncOf(static fn(int $n): bool => $n > 5),
+                new ListOf(1, 3, 7, 10),
+                new Constant(0),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsFirstWhenMultipleMatch(): void
+    {
+        self::assertSame(
+            7,
+            (new FirstOf(
+                new FuncOf(static fn(int $n): bool => $n > 5),
+                new ListOf(7, 10, 20),
+                new Constant(0),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsFallbackWhenNoElementMatches(): void
+    {
+        self::assertSame(
+            -1,
+            (new FirstOf(
+                new FuncOf(static fn(int $n): bool => $n > 100),
+                new ListOf(1, 3, 7, 10),
+                new Constant(-1),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsFallbackForEmptySource(): void
+    {
+        self::assertSame(
+            'none',
+            (new FirstOf(
+                new FuncOf(static fn(string $s): bool => true),
+                new ListOf(),
+                new Constant('none'),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function defersSourceTraversalUntilValueCall(): void
+    {
+        $touched = false;
+        $source = new ListOf(1, 2, 3);
+        $first = new FirstOf(
+            new FuncOf(
+                static function (int $n) use (&$touched): bool {
+                    $touched = true;
+
+                    return $n > 1;
+                },
+            ),
+            $source,
+            new Constant(0),
+        );
+
+        self::assertFalse($touched);
+        self::assertSame(2, $first->value());
+        self::assertTrue($touched);
+    }
+
+    #[Test]
+    public function stopsAtFirstMatchWithoutScanningRemaining(): void
+    {
+        $visited = 0;
+        $first = new FirstOf(
+            new FuncOf(
+                static function (int $n) use (&$visited): bool {
+                    $visited++;
+
+                    return $n === 2;
+                },
+            ),
+            new ListOf(1, 2, 3, 4, 5),
+            new Constant(0),
+        );
+
+        self::assertSame(2, $first->value());
+        self::assertSame(2, $visited);
+    }
+}


### PR DESCRIPTION
- Added Primus\\Scalar\\FirstOf that walks a List_ and returns the first element passing a Func condition, falling back to a Scalar when nothing matches
- Added tests covering match, multiple matches, no match, empty source, deferred evaluation and short-circuit behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new `FirstOf` scalar that scans a list and returns the first element matching a specified condition. Includes fallback support when no matching elements are found.

* **Tests**
  * Added comprehensive test suite for `FirstOf` covering scenarios including matching elements, fallback values, empty lists, lazy evaluation behavior, and early termination after finding first match.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->