### PR TITLE
Add Scalar ItemAt for Positional List Lookup

### DIFF
--- a/src/Scalar/ItemAt.php
+++ b/src/Scalar/ItemAt.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Scalar;
+
+use InvalidArgumentException;
+use Primus\List\List_;
+
+/**
+ * Element at a given position in a {@see List_}.
+ *
+ * Walks the list and returns the item whose zero-based index equals
+ * `$position`. If the list is shorter than `$position + 1` elements, the
+ * fallback `Scalar` provides the value instead. A negative position is
+ * rejected with {@see InvalidArgumentException} — use an explicit
+ * `count(...) - n` expression if "from the end" is intended.
+ *
+ * Example:
+ *     $second = new ItemAt(
+ *         1,
+ *         new ListOf('a', 'b', 'c'),
+ *         new Constant('-'),
+ *     );
+ *     echo $second->value(); // 'b'
+ *
+ *     $tenth = new ItemAt(
+ *         10,
+ *         new ListOf('a', 'b'),
+ *         new Constant('-'),
+ *     );
+ *     echo $tenth->value(); // '-'
+ *
+ * @template T
+ * @extends ScalarEnvelope<T>
+ */
+final readonly class ItemAt extends ScalarEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param int $position The zero-based index of the element to return.
+     * @param List_<T> $source The list to look up the element in.
+     * @param Scalar<T> $fallback The value returned when the position is missing.
+     */
+    public function __construct(int $position, List_ $source, Scalar $fallback)
+    {
+        parent::__construct(
+            new ScalarOf(
+                static function () use ($position, $source, $fallback) {
+                    if ($position < 0) {
+                        throw new InvalidArgumentException(
+                            sprintf('ItemAt position must be non-negative, %d given', $position),
+                        );
+                    }
+
+                    $cursor = 0;
+
+                    foreach ($source as $item) {
+                        if ($cursor === $position) {
+                            return $item;
+                        }
+
+                        $cursor++;
+                    }
+
+                    return $fallback->value();
+                },
+            ),
+        );
+    }
+}

--- a/tests/Scalar/ItemAtTest.php
+++ b/tests/Scalar/ItemAtTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Scalar;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\List\ListOf;
+use Primus\Scalar\Constant;
+use Primus\Scalar\ItemAt;
+use Primus\Scalar\Scalar;
+
+final class ItemAtTest extends TestCase
+{
+    #[Test]
+    public function returnsElementAtRequestedPosition(): void
+    {
+        self::assertSame(
+            'b',
+            (new ItemAt(
+                1,
+                new ListOf('a', 'b', 'c'),
+                new Constant('-'),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsFirstElementForZeroPosition(): void
+    {
+        self::assertSame(
+            'a',
+            (new ItemAt(
+                0,
+                new ListOf('a', 'b', 'c'),
+                new Constant('-'),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsFallbackWhenPositionExceedsLength(): void
+    {
+        self::assertSame(
+            '-',
+            (new ItemAt(
+                10,
+                new ListOf('a', 'b'),
+                new Constant('-'),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsFallbackWhenPositionEqualsLength(): void
+    {
+        self::assertSame(
+            '-',
+            (new ItemAt(
+                2,
+                new ListOf('a', 'b'),
+                new Constant('-'),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsFallbackForEmptySource(): void
+    {
+        self::assertSame(
+            'none',
+            (new ItemAt(
+                0,
+                new ListOf(),
+                new Constant('none'),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function rejectsNegativePosition(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        (new ItemAt(
+            -1,
+            new ListOf('a', 'b'),
+            new Constant('-'),
+        ))->value();
+    }
+
+    #[Test]
+    public function defersTraversalUntilValueCall(): void
+    {
+        $touched = false;
+        $fallback = new class ($touched) implements Scalar {
+            public function __construct(private bool &$touched) {}
+
+            public function value(): mixed
+            {
+                $this->touched = true;
+
+                return 'fallback';
+            }
+        };
+        $item = new ItemAt(5, new ListOf('a', 'b'), $fallback);
+
+        self::assertFalse($touched);
+        self::assertSame('fallback', $item->value());
+        self::assertTrue($touched);
+    }
+
+}


### PR DESCRIPTION
- Added Primus\\Scalar\\ItemAt that walks a List_ and returns the element at the requested zero-based position, falling back to a Scalar when the position is missing
- Rejected negative positions through a lazy InvalidArgumentException raised on first value() call, matching the EO lazy-validation pattern already used by DecimalOfFloat and Base64Decoded
- Added tests covering matched position, zero position, position past length, exact length boundary, empty source, negative position rejection and deferred traversal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added functionality to retrieve elements at a specific position within a list, with fallback support for out-of-range indices.

* **Tests**
  * Added comprehensive test coverage for position-based element access and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->