### PR TITLE
Add Scalar HighestOf for Maximum List Element

### DIFF
--- a/src/Scalar/HighestOf.php
+++ b/src/Scalar/HighestOf.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Scalar;
+
+use Primus\List\List_;
+use UnderflowException;
+
+/**
+ * Greatest element of a {@see List_} of comparable values.
+ *
+ * Walks the list and returns the largest item under PHP's `>` comparison.
+ * The element type must be naturally comparable and homogeneous (int,
+ * float, string, `DateTimeInterface`, etc.) — heterogeneous lists follow
+ * PHP coercion rules (`1 > "a"` etc.) and produce undefined results.
+ * Equal elements resolve to the first match encountered. An empty source
+ * raises {@see UnderflowException} on first projection — there is no
+ * neutral element for "greatest".
+ *
+ * Example:
+ *     $top = new HighestOf(new ListOf(1, 7, 3, 5));
+ *     echo $top->value(); // 7
+ *
+ *     $latest = new HighestOf(new ListOf('apple', 'orange', 'banana'));
+ *     echo $latest->value(); // 'orange'
+ *
+ * @template T
+ * @extends ScalarEnvelope<T>
+ */
+final readonly class HighestOf extends ScalarEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param List_<T> $source The list to scan.
+     */
+    public function __construct(List_ $source)
+    {
+        parent::__construct(
+            new ScalarOf(
+                static function () use ($source) {
+                    $items = iterator_to_array($source, false);
+
+                    if ($items === []) {
+                        throw new UnderflowException('Cannot pick the greatest element from an empty list');
+                    }
+
+                    $best = $items[0];
+
+                    for ($index = 1; $index < count($items); $index++) {
+                        if ($items[$index] > $best) {
+                            $best = $items[$index];
+                        }
+                    }
+
+                    return $best;
+                },
+            ),
+        );
+    }
+}

--- a/tests/Scalar/HighestOfTest.php
+++ b/tests/Scalar/HighestOfTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Scalar;
+
+use Generator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\List\List_;
+use Primus\List\ListOf;
+use Primus\Scalar\HighestOf;
+use UnderflowException;
+
+final class HighestOfTest extends TestCase
+{
+    #[Test]
+    public function returnsLargestIntegerInList(): void
+    {
+        self::assertSame(
+            7,
+            (new HighestOf(new ListOf(1, 7, 3, 5)))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsLargestFloatInList(): void
+    {
+        self::assertSame(
+            3.14,
+            (new HighestOf(new ListOf(1.5, 3.14, 2.0)))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsLexicographicallyLargestString(): void
+    {
+        self::assertSame(
+            'orange',
+            (new HighestOf(new ListOf('apple', 'orange', 'banana')))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsSoleElementForSingleItemList(): void
+    {
+        self::assertSame(
+            42,
+            (new HighestOf(new ListOf(42)))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsValueWhenAllEqual(): void
+    {
+        self::assertSame(
+            5,
+            (new HighestOf(new ListOf(5, 5, 5)))->value(),
+        );
+    }
+
+    #[Test]
+    public function throwsWhenSourceIsEmpty(): void
+    {
+        $this->expectException(UnderflowException::class);
+        (new HighestOf(new ListOf()))->value();
+    }
+
+    #[Test]
+    public function defersTraversalUntilValueCall(): void
+    {
+        $touched = 0;
+        $source = new class ($touched) implements List_ {
+            public function __construct(private int &$touched) {}
+
+            public function value(): array
+            {
+                return iterator_to_array($this->getIterator(), false);
+            }
+
+            public function count(): int
+            {
+                return 3;
+            }
+
+            public function getIterator(): Generator
+            {
+                for ($i = 1; $i <= 3; $i++) {
+                    $this->touched++;
+                    yield $i;
+                }
+            }
+        };
+
+        $top = new HighestOf($source);
+
+        self::assertSame(0, $touched);
+        self::assertSame(3, $top->value());
+        self::assertSame(3, $touched);
+    }
+}


### PR DESCRIPTION
- Added Primus\\Scalar\\HighestOf that returns the largest element from a List_ via native > comparison
- Threw UnderflowException lazily for empty sources, documented heterogeneous-list coercion caveat and first-match-on-equal contract
- Added tests covering int, float, string, single-item, equal-elements, empty-source and deferred traversal via a counting List_ helper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functionality to find the maximum element from a collection with support for comparing various data types and proper error handling for empty collections.

* **Tests**
  * Comprehensive test coverage for the new maximum-finding feature, including validation with integers, floats, strings, single-element lists, duplicate maximum values, and empty collection handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->