### PR TITLE
Add Scalar Folded for Seed-Based Left Fold

### DIFF
--- a/src/Scalar/Folded.php
+++ b/src/Scalar/Folded.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Scalar;
+
+use Primus\Func\BiFunc;
+use Primus\List\List_;
+
+/**
+ * Left-fold of a {@see List_} with an explicit seed accumulator.
+ *
+ * Walks the source applying `$reducer->apply($accumulator, $next)` to every
+ * element, starting from `$seed`. On an empty list returns the seed value
+ * unchanged — there is no exception because the seed itself acts as the
+ * neutral element. Use {@see Reduced} when no seed is available and the
+ * accumulator must match the element type.
+ *
+ * Example:
+ *     $totalLength = new Folded(
+ *         new Constant(0),
+ *         new ListOf('hello', 'world'),
+ *         new BiFuncOf(static fn(int $sum, string $s): int => $sum + strlen($s)),
+ *     );
+ *     echo $totalLength->value(); // 10
+ *
+ *     $emptyDefaultsToSeed = new Folded(
+ *         new Constant(42),
+ *         new ListOf(),
+ *         new BiFuncOf(static fn(int $a, int $b): int => $a + $b),
+ *     );
+ *     echo $emptyDefaultsToSeed->value(); // 42
+ *
+ * @template X
+ * @template T
+ * @extends ScalarEnvelope<X>
+ */
+final readonly class Folded extends ScalarEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Scalar<X> $seed The initial accumulator value.
+     * @param List_<T> $source The list to fold.
+     * @param BiFunc<X, T, X> $reducer The accumulator function.
+     */
+    public function __construct(Scalar $seed, List_ $source, BiFunc $reducer)
+    {
+        parent::__construct(
+            new ScalarOf(
+                static function () use ($seed, $source, $reducer) {
+                    $accumulator = $seed->value();
+
+                    foreach ($source as $item) {
+                        $accumulator = $reducer->apply($accumulator, $item);
+                    }
+
+                    return $accumulator;
+                },
+            ),
+        );
+    }
+}

--- a/tests/Scalar/FoldedTest.php
+++ b/tests/Scalar/FoldedTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Scalar;
+
+use Generator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Func\BiFuncOf;
+use Primus\List\List_;
+use Primus\List\ListOf;
+use Primus\Scalar\Constant;
+use Primus\Scalar\Folded;
+
+final class FoldedTest extends TestCase
+{
+    #[Test]
+    public function sumsIntegersStartingFromSeed(): void
+    {
+        self::assertSame(
+            16,
+            (new Folded(
+                new Constant(10),
+                new ListOf(1, 2, 3),
+                new BiFuncOf(static fn(int $a, int $b): int => $a + $b),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsSeedForEmptySource(): void
+    {
+        self::assertSame(
+            42,
+            (new Folded(
+                new Constant(42),
+                new ListOf(),
+                new BiFuncOf(static fn(int $a, int $b): int => $a + $b),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function foldsHeterogeneousAccumulatorIntoIntFromStrings(): void
+    {
+        self::assertSame(
+            10,
+            (new Folded(
+                new Constant(0),
+                new ListOf('hello', 'world'),
+                new BiFuncOf(static fn(int $sum, string $s): int => $sum + strlen($s)),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function foldsHeterogeneousAccumulatorIntoStringFromInts(): void
+    {
+        self::assertSame(
+            'init:1:2:3',
+            (new Folded(
+                new Constant('init'),
+                new ListOf(1, 2, 3),
+                new BiFuncOf(static fn(string $acc, int $n): string => $acc . ':' . $n),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function appliesReducerLeftToRight(): void
+    {
+        // (((10 - 1) - 2) - 3) = 4, would be 10 if right-to-left
+        self::assertSame(
+            4,
+            (new Folded(
+                new Constant(10),
+                new ListOf(1, 2, 3),
+                new BiFuncOf(static fn(int $a, int $b): int => $a - $b),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function defersTraversalUntilValueCall(): void
+    {
+        $touched = 0;
+        $source = new class ($touched) implements List_ {
+            public function __construct(private int &$touched) {}
+
+            public function value(): array
+            {
+                return iterator_to_array($this->getIterator(), false);
+            }
+
+            public function count(): int
+            {
+                return 3;
+            }
+
+            public function getIterator(): Generator
+            {
+                for ($i = 1; $i <= 3; $i++) {
+                    $this->touched++;
+                    yield $i;
+                }
+            }
+        };
+
+        $folded = new Folded(
+            new Constant(0),
+            $source,
+            new BiFuncOf(static fn(int $a, int $b): int => $a + $b),
+        );
+
+        self::assertSame(0, $touched);
+        self::assertSame(6, $folded->value());
+        self::assertSame(3, $touched);
+    }
+}


### PR DESCRIPTION
- Added Primus\\Scalar\\Folded that left-folds a List_ starting from an explicit Scalar seed accumulator
- Returns the seed on empty sources without throwing, complementing Reduced which requires non-empty input
- Added tests covering homogeneous sum, heterogeneous int-from-strings, string-from-ints, empty source, left-to-right order and deferred traversal via a counting List_ helper