### PR TITLE
Add Scalar BoolOf Parsing Text to Boolean

### DIFF
--- a/src/Scalar/BoolOf.php
+++ b/src/Scalar/BoolOf.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Scalar;
+
+use Primus\Text\Text;
+
+/**
+ * Boolean parsed from a {@see Text} value.
+ *
+ * Delegates parsing to {@see filter_var()} with `FILTER_VALIDATE_BOOLEAN`,
+ * which accepts the common truthy/falsy spellings: `true`, `false`, `yes`,
+ * `no`, `on`, `off`, `1`, `0` (case-insensitive, surrounding whitespace is
+ * tolerated). Any other input is treated as `false`.
+ *
+ * The accepted vocabulary is wider than Cactoos `BoolOf` (which only
+ * matches `Boolean.valueOf` semantics — `true` literal vs everything else) —
+ * the extra spellings reflect typical PHP config and env-var conventions.
+ *
+ * Useful for reading boolean flags from configuration files or environment
+ * variables and composing the result with other {@see Scalar} primitives
+ * (`Ternary`, `And_`, `Or_`).
+ *
+ * Example:
+ *     $enabled = new BoolOf(TextOf::str('yes'));
+ *     echo $enabled->value() ? 'on' : 'off'; // 'on'
+ *
+ *     $padded = new BoolOf(TextOf::str(' true '));
+ *     echo $padded->value() ? 'on' : 'off'; // 'on' — surrounding whitespace tolerated
+ *
+ *     $disabled = new BoolOf(TextOf::str('garbage'));
+ *     echo $disabled->value() ? 'on' : 'off'; // 'off'
+ *
+ * @extends ScalarEnvelope<bool>
+ */
+final readonly class BoolOf extends ScalarEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Text $origin The text to parse.
+     */
+    public function __construct(Text $origin)
+    {
+        parent::__construct(
+            new ScalarOf(
+                static fn(): bool => filter_var(
+                    $origin->value(),
+                    FILTER_VALIDATE_BOOLEAN,
+                ),
+            ),
+        );
+    }
+}

--- a/tests/Scalar/BoolOfTest.php
+++ b/tests/Scalar/BoolOfTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Scalar;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Primus\Scalar\BoolOf;
+use Primus\Scalar\ScalarOf;
+use Primus\Text\TextOf;
+
+final class BoolOfTest extends TestCase
+{
+    #[Test]
+    #[TestWith(['true'])]
+    #[TestWith(['TRUE'])]
+    #[TestWith(['yes'])]
+    #[TestWith(['YES'])]
+    #[TestWith(['on'])]
+    #[TestWith(['ON'])]
+    #[TestWith(['1'])]
+    public function parsesCanonicalTrueLiterals(string $input): void
+    {
+        self::assertTrue(
+            (new BoolOf(TextOf::str($input)))->value(),
+        );
+    }
+
+    #[Test]
+    #[TestWith(['false'])]
+    #[TestWith(['FALSE'])]
+    #[TestWith(['no'])]
+    #[TestWith(['NO'])]
+    #[TestWith(['off'])]
+    #[TestWith(['OFF'])]
+    #[TestWith(['0'])]
+    public function parsesCanonicalFalseLiterals(string $input): void
+    {
+        self::assertFalse(
+            (new BoolOf(TextOf::str($input)))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsFalseForArbitraryNonBooleanText(): void
+    {
+        self::assertFalse(
+            (new BoolOf(TextOf::str('garbage')))->value(),
+        );
+    }
+
+    #[Test]
+    public function returnsFalseForEmptyText(): void
+    {
+        self::assertFalse(
+            (new BoolOf(TextOf::str('')))->value(),
+        );
+    }
+
+    #[Test]
+    public function toleratesSurroundingWhitespace(): void
+    {
+        self::assertTrue(
+            (new BoolOf(TextOf::str(' true ')))->value(),
+        );
+    }
+
+    #[Test]
+    public function defersTextResolutionUntilValueCall(): void
+    {
+        $resolved = false;
+        $text = TextOf::scalar(
+            new ScalarOf(
+                static function () use (&$resolved): string {
+                    $resolved = true;
+
+                    return 'true';
+                },
+            ),
+        );
+        $flag = new BoolOf($text);
+
+        self::assertFalse($resolved);
+        self::assertTrue($flag->value());
+        self::assertTrue($resolved);
+    }
+}


### PR DESCRIPTION
- Added Primus\\Scalar\\BoolOf that parses a Text value into Scalar<bool> via filter_var FILTER_VALIDATE_BOOLEAN
- Accepts the common PHP boolean spellings (true/false/yes/no/on/off/1/0, case-insensitive, surrounding whitespace tolerated) and falls back to false on anything else
- Documented the wider vocabulary versus Cactoos BoolOf and the whitespace tolerance with explicit examples
- Added tests covering canonical truthy/falsy literals (TestWith), arbitrary non-boolean input, empty text, padded whitespace and deferred source resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a boolean scalar type that parses text input as boolean values, supporting common true/false spellings (true/false, yes/no, on/off, 1/0) and tolerating surrounding whitespace.

* **Tests**
  * Added comprehensive test coverage for the new boolean parsing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->