### PR TITLE
Add IsIdempotent Test Constraint

### DIFF
--- a/tests/Constraint/IsIdempotent.php
+++ b/tests/Constraint/IsIdempotent.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Primus\Tests\Constraint;
 
-use Closure;
 use PHPUnit\Framework\Constraint\Constraint;
 
 /**
- * Asserts that a zero-argument {@see Closure} returns the expected value on
- * each of two consecutive invocations.
+ * Asserts that a zero-argument callable returns the expected value on each
+ * of two consecutive invocations.
  *
  * Captures the «one-assert-per-test» Angry Tests rule for memoization-style
  * checks where the SUT must produce the same value across repeated calls
@@ -17,7 +16,7 @@ use PHPUnit\Framework\Constraint\Constraint;
  *
  * Comparison is strict identity (`===`). Beware that `NAN === NAN` is
  * `false` and that two distinct value-objects with equal contents compare
- * unequal — supply a Closure that returns the same instance/scalar both
+ * unequal — supply a callable that returns the same instance/scalar both
  * times.
  *
  * Example:
@@ -34,7 +33,7 @@ final class IsIdempotent extends Constraint
     /** @var mixed The value produced by the second invocation. */
     private mixed $second = null;
 
-    /** @var bool Whether the Closure was actually invoked (i.e. it had the right type). */
+    /** @var bool Whether the callable was actually invoked (i.e. it had the right type). */
     private bool $invoked = false;
 
     public function __construct(private readonly mixed $expected) {}
@@ -48,11 +47,14 @@ final class IsIdempotent extends Constraint
     }
 
     /**
-     * @param Closure(): mixed $other
+     * @param callable(): mixed $other
      */
     protected function matches($other): bool
     {
-        if (!$other instanceof Closure) {
+        $this->first = null;
+        $this->second = null;
+        $this->invoked = false;
+        if (!is_callable($other)) {
             return false;
         }
         $this->first = $other();
@@ -64,13 +66,13 @@ final class IsIdempotent extends Constraint
 
     protected function failureDescription($other): string
     {
-        return 'closure ' . $this->toString();
+        return 'callable ' . $this->toString();
     }
 
     protected function additionalFailureDescription($other): string
     {
         if (!$this->invoked) {
-            return "\nExpected: Closure\nBut was:  " . get_debug_type($other);
+            return "\nExpected: callable\nBut was:  " . get_debug_type($other);
         }
         $expectedRepr = $this->exporter()->export($this->expected);
         $firstRepr = $this->exporter()->export($this->first);

--- a/tests/Constraint/IsIdempotent.php
+++ b/tests/Constraint/IsIdempotent.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Constraint;
+
+use Closure;
+use PHPUnit\Framework\Constraint\Constraint;
+
+/**
+ * Asserts that a zero-argument {@see Closure} returns the expected value on
+ * each of two consecutive invocations.
+ *
+ * Captures the «one-assert-per-test» Angry Tests rule for memoization-style
+ * checks where the SUT must produce the same value across repeated calls
+ * (caching decorators, Sticky variants, idempotent factories).
+ *
+ * Comparison is strict identity (`===`). Beware that `NAN === NAN` is
+ * `false` and that two distinct value-objects with equal contents compare
+ * unequal — supply a Closure that returns the same instance/scalar both
+ * times.
+ *
+ * Example:
+ *     self::assertThat(
+ *         fn(): int => $sticky->asInt(),
+ *         new IsIdempotent(42),
+ *     );
+ */
+final class IsIdempotent extends Constraint
+{
+    /** @var mixed The value produced by the first invocation. */
+    private mixed $first = null;
+
+    /** @var mixed The value produced by the second invocation. */
+    private mixed $second = null;
+
+    /** @var bool Whether the Closure was actually invoked (i.e. it had the right type). */
+    private bool $invoked = false;
+
+    public function __construct(private readonly mixed $expected) {}
+
+    public function toString(): string
+    {
+        return sprintf(
+            'yields %s on two consecutive invocations',
+            $this->exporter()->export($this->expected),
+        );
+    }
+
+    /**
+     * @param Closure(): mixed $other
+     */
+    protected function matches($other): bool
+    {
+        if (!$other instanceof Closure) {
+            return false;
+        }
+        $this->first = $other();
+        $this->second = $other();
+        $this->invoked = true;
+
+        return $this->first === $this->expected && $this->second === $this->expected;
+    }
+
+    protected function failureDescription($other): string
+    {
+        return 'closure ' . $this->toString();
+    }
+
+    protected function additionalFailureDescription($other): string
+    {
+        if (!$this->invoked) {
+            return "\nExpected: Closure\nBut was:  " . get_debug_type($other);
+        }
+        $expectedRepr = $this->exporter()->export($this->expected);
+        $firstRepr = $this->exporter()->export($this->first);
+        $secondRepr = $this->exporter()->export($this->second);
+
+        return "\nExpected (both calls): $expectedRepr"
+            . "\n1st invocation:        $firstRepr"
+            . "\n2nd invocation:        $secondRepr";
+    }
+}

--- a/tests/Decimal/StickyTest.php
+++ b/tests/Decimal/StickyTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Primus\Decimal\DecimalOf;
 use Primus\Decimal\Sticky;
+use Primus\Tests\Constraint\IsIdempotent;
 use Primus\Tests\Decimal\Fakes\CountingDecimal;
 
 final class StickyTest extends TestCase
@@ -17,8 +18,10 @@ final class StickyTest extends TestCase
     {
         $sticky = new Sticky(new DecimalOf('3.14'));
 
-        $this->assertSame(3, $sticky->asInt());
-        $this->assertSame(3, $sticky->asInt());
+        self::assertThat(
+            static fn(): int => $sticky->asInt(),
+            new IsIdempotent(3),
+        );
     }
 
     #[Test]
@@ -26,8 +29,10 @@ final class StickyTest extends TestCase
     {
         $sticky = new Sticky(new DecimalOf('3.14'));
 
-        $this->assertSame(3.14, $sticky->asFloat());
-        $this->assertSame(3.14, $sticky->asFloat());
+        self::assertThat(
+            static fn(): float => $sticky->asFloat(),
+            new IsIdempotent(3.14),
+        );
     }
 
     #[Test]
@@ -35,8 +40,10 @@ final class StickyTest extends TestCase
     {
         $sticky = new Sticky(new DecimalOf('3.14'));
 
-        $this->assertSame('3.14', $sticky->asString());
-        $this->assertSame('3.14', $sticky->asString());
+        self::assertThat(
+            static fn(): string => $sticky->asString(),
+            new IsIdempotent('3.14'),
+        );
     }
 
     #[Test]
@@ -49,6 +56,6 @@ final class StickyTest extends TestCase
         $sticky->asString();
         $sticky->asString();
 
-        $this->assertSame(1, $origin->stringCalls);
+        self::assertSame(1, $origin->stringCalls);
     }
 }

--- a/tests/Integer/StickyTest.php
+++ b/tests/Integer/StickyTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Primus\Integer\IntegerOf;
 use Primus\Integer\Sticky;
+use Primus\Tests\Constraint\IsIdempotent;
 
 final class StickyTest extends TestCase
 {
@@ -16,8 +17,10 @@ final class StickyTest extends TestCase
     {
         $sticky = new Sticky(new IntegerOf(42));
 
-        $this->assertSame(42, $sticky->asInt());
-        $this->assertSame(42, $sticky->asInt());
+        self::assertThat(
+            static fn(): int => $sticky->asInt(),
+            new IsIdempotent(42),
+        );
     }
 
     #[Test]
@@ -25,8 +28,9 @@ final class StickyTest extends TestCase
     {
         $sticky = new Sticky(new IntegerOf(42));
 
-        $this->assertSame(42.0, $sticky->asFloat());
-        $this->assertSame(42.0, $sticky->asFloat());
+        self::assertThat(
+            static fn(): float => $sticky->asFloat(),
+            new IsIdempotent(42.0),
+        );
     }
-
 }


### PR DESCRIPTION
- Added a test constraint that asserts a Closure yields the expected value on each of two consecutive invocations
- Updated Integer Sticky and Decimal Sticky test suites to express idempotence through the new constraint
- Refactored failure diagnostics to reuse the cached invocations so the Closure is never re-evaluated for reporting

Closes #228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new PHPUnit constraint to assert strict identity across repeated invocations.
  * Updated decimal and integer sticky tests to use the new constraint, consolidating duplicated assertions.
  * Switched assertion style consistency in one test to a static/self form and added the new import.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->