### PR TITLE
Accept Callable and Reset State in ThrowsClosure

### DIFF
--- a/tests/Constraint/ThrowsClosure.php
+++ b/tests/Constraint/ThrowsClosure.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace Primus\Tests\Constraint;
 
-use Closure;
 use PHPUnit\Framework\Constraint\Constraint;
 use Throwable;
 
 /**
- * Asserts that invoking a {@see Closure} throws a specific exception type.
+ * Asserts that invoking a zero-argument callable throws a specific exception
+ * type.
+ *
+ * The historic name keeps `Closure` for compatibility, but the contract
+ * accepts any callable (closures, `[$object, 'method']`, invokable objects).
+ * Cached diagnostic fields are reset at the start of every evaluation so a
+ * reused constraint instance never leaks state from a previous match.
  *
  * Example:
  * self::assertThat(
@@ -39,13 +44,18 @@ final class ThrowsClosure extends Constraint
     }
 
     /**
-     * @param Closure $other
+     * @param callable(): mixed $other
      */
     protected function matches($other): bool
     {
+        $this->caughtException = null;
+        $this->exceptionThrown = false;
+        if (!is_callable($other)) {
+            return false;
+        }
+
         try {
             $other();
-            $this->exceptionThrown = false;
             return false;
         } catch (Throwable $e) {
             $this->caughtException = $e;
@@ -57,12 +67,15 @@ final class ThrowsClosure extends Constraint
 
     protected function failureDescription($other): string
     {
-        return "closure {$this->toString()}";
+        return "callable {$this->toString()}";
     }
 
     protected function additionalFailureDescription($other): string
     {
         if (!$this->exceptionThrown) {
+            if ($this->caughtException === null && !is_callable($other)) {
+                return "\nExpected: callable\nBut was:  " . get_debug_type($other);
+            }
             return "\nExpected exception: {$this->expected}\nBut no exception was thrown.";
         }
 


### PR DESCRIPTION
- Updated ThrowsClosure to accept any callable instead of restricting to Closure
- Refactored matches to reset cached state at the start of every evaluation so reused constraint instances never leak diagnostic state from a previous run
- Updated failure description and docblock to reflect the broader callable contract

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test constraint to accept broader types of callables for exception testing
  * Improved diagnostic messaging to clarify test failure scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->