### PR TITLE
Short-Circuit Scalar And Or Xor With Identity For Empty Input

### DIFF
--- a/src/Scalar/And_.php
+++ b/src/Scalar/And_.php
@@ -4,16 +4,22 @@ declare(strict_types=1);
 
 namespace Primus\Scalar;
 
-use InvalidArgumentException;
-
 /**
  * Logical AND over multiple {@see Scalar<bool>}.
  *
- * Returns true only if all provided scalars evaluate to true.
+ * Short-circuits at the first scalar that evaluates to `false` — subsequent
+ * scalars are never asked for their value. An empty argument list returns
+ * `true` (the identity of conjunction).
  *
  * Example:
- *     $and = new And_(new True_(), new False_());
- *     echo $and->value(); // false
+ *     $and = new And_(
+ *         new Constant(true),
+ *         new Constant(false),
+ *         new Constant(true),
+ *     );
+ *     echo $and->value() ? 'all true' : 'something false'; // 'something false'
+ *
+ *     (new And_())->value(); // true — vacuous truth
  *
  * @extends ScalarEnvelope<bool>
  */
@@ -29,15 +35,13 @@ final readonly class And_ extends ScalarEnvelope
         parent::__construct(
             new ScalarOf(
                 static function () use ($conditions): bool {
-                    if ($conditions === []) {
-                        throw new InvalidArgumentException('And requires at least one condition');
+                    foreach ($conditions as $condition) {
+                        if (!$condition->value()) {
+                            return false;
+                        }
                     }
 
-                    return array_reduce(
-                        $conditions,
-                        static fn(bool $carry, Scalar $cond): bool => $carry && $cond->value(),
-                        true,
-                    );
+                    return true;
                 },
             ),
         );

--- a/src/Scalar/Or_.php
+++ b/src/Scalar/Or_.php
@@ -4,12 +4,22 @@ declare(strict_types=1);
 
 namespace Primus\Scalar;
 
-use InvalidArgumentException;
-
 /**
  * Logical OR over multiple {@see Scalar<bool>}.
  *
- * Returns true if at least one provided scalar evaluates to true.
+ * Short-circuits at the first scalar that evaluates to `true` — subsequent
+ * scalars are never asked for their value. An empty argument list returns
+ * `false` (the identity of disjunction).
+ *
+ * Example:
+ *     $or = new Or_(
+ *         new Constant(false),
+ *         new Constant(true),
+ *         new Constant(false),
+ *     );
+ *     echo $or->value() ? 'any true' : 'all false'; // 'any true'
+ *
+ *     (new Or_())->value(); // false — no member is true
  *
  * @extends ScalarEnvelope<bool>
  */
@@ -25,11 +35,13 @@ final readonly class Or_ extends ScalarEnvelope
         parent::__construct(
             new ScalarOf(
                 static function () use ($conditions): bool {
-                    if ($conditions === []) {
-                        throw new InvalidArgumentException('Or requires at least one condition');
+                    foreach ($conditions as $condition) {
+                        if ($condition->value()) {
+                            return true;
+                        }
                     }
 
-                    return array_any($conditions, static fn($condition) => $condition->value());
+                    return false;
                 },
             ),
         );

--- a/src/Scalar/Xor_.php
+++ b/src/Scalar/Xor_.php
@@ -4,19 +4,21 @@ declare(strict_types=1);
 
 namespace Primus\Scalar;
 
-use InvalidArgumentException;
-
 /**
  * Logical XOR over multiple {@see Scalar<bool>}.
  *
- * Returns true only if an odd number of conditions are true.
+ * Returns `true` when an odd number of conditions evaluate to `true`. Unlike
+ * AND and OR, XOR cannot short-circuit — every scalar must be inspected to
+ * compute the parity. An empty argument list returns `false` (parity zero).
  *
  * Example:
- *     $scalar = new Xor_(
- *         new ScalarOf(fn() => true),
- *         new ScalarOf(fn() => false)
+ *     $xor = new Xor_(
+ *         new Constant(true),
+ *         new Constant(false),
  *     );
- *     echo $scalar->value(); // true
+ *     echo $xor->value() ? 'odd' : 'even'; // 'odd'
+ *
+ *     (new Xor_())->value(); // false — empty parity
  *
  * @extends ScalarEnvelope<bool>
  */
@@ -31,13 +33,14 @@ final readonly class Xor_ extends ScalarEnvelope
     {
         parent::__construct(
             new ScalarOf(
-                static fn(): bool => match (count($conditions)) {
-                    0 => throw new InvalidArgumentException('Xor requires at least one condition'),
-                    default => array_reduce(
-                        $conditions,
-                        static fn(bool $carry, Scalar $cond): bool => $carry xor $cond->value(),
-                        false,
-                    ),
+                static function () use ($conditions): bool {
+                    $parity = false;
+
+                    foreach ($conditions as $condition) {
+                        $parity = ($parity xor $condition->value());
+                    }
+
+                    return $parity;
                 },
             ),
         );

--- a/tests/Scalar/And_Test.php
+++ b/tests/Scalar/And_Test.php
@@ -4,16 +4,12 @@ declare(strict_types=1);
 
 namespace Primus\Tests\Scalar;
 
-use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Primus\Scalar\And_;
 use Primus\Scalar\ScalarOf;
 use Primus\Tests\Constraint\HasScalarBoolValue;
-use Primus\Tests\Constraint\ThrowsValue;
 
-/**
- */
 final class And_Test extends TestCase
 {
     #[Test]
@@ -25,7 +21,6 @@ final class And_Test extends TestCase
                 new ScalarOf(fn (): true => true)
             ),
             new HasScalarBoolValue(true),
-            'And must return true when all scalars are true'
         );
     }
 
@@ -38,7 +33,6 @@ final class And_Test extends TestCase
                 new ScalarOf(fn (): false => false)
             ),
             new HasScalarBoolValue(false),
-            'And must return false when at least one scalar is false'
         );
     }
 
@@ -51,17 +45,15 @@ final class And_Test extends TestCase
                 new ScalarOf(fn (): false => false)
             ),
             new HasScalarBoolValue(false),
-            'And must return false when all scalars are false'
         );
     }
 
     #[Test]
-    public function throwsWhenNoScalarsProvided(): void
+    public function returnsTrueForEmptyConjunction(): void
     {
         self::assertThat(
-            new ScalarOf(fn () => (new And_())->value()),
-            new ThrowsValue(InvalidArgumentException::class),
-            'And must throw an exception when no scalars are provided'
+            new And_(),
+            new HasScalarBoolValue(true),
         );
     }
 }

--- a/tests/Scalar/Or_Test.php
+++ b/tests/Scalar/Or_Test.php
@@ -4,16 +4,12 @@ declare(strict_types=1);
 
 namespace Primus\Tests\Scalar;
 
-use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Primus\Scalar\Or_;
 use Primus\Scalar\ScalarOf;
 use Primus\Tests\Constraint\HasScalarBoolValue;
-use Primus\Tests\Constraint\ThrowsValue;
 
-/**
- */
 final class Or_Test extends TestCase
 {
     #[Test]
@@ -25,7 +21,6 @@ final class Or_Test extends TestCase
                 new ScalarOf(fn (): true => true)
             ),
             new HasScalarBoolValue(true),
-            'Or must return true when at least one scalar is true'
         );
     }
 
@@ -38,7 +33,6 @@ final class Or_Test extends TestCase
                 new ScalarOf(fn (): false => false)
             ),
             new HasScalarBoolValue(false),
-            'Or must return false when all scalars are false'
         );
     }
 
@@ -51,17 +45,15 @@ final class Or_Test extends TestCase
                 new ScalarOf(fn (): true => true)
             ),
             new HasScalarBoolValue(true),
-            'Or must return true when all scalars are true'
         );
     }
 
     #[Test]
-    public function throwsWhenNoScalarsProvided(): void
+    public function returnsFalseForEmptyDisjunction(): void
     {
         self::assertThat(
-            new ScalarOf(fn () => (new Or_())->value()),
-            new ThrowsValue(InvalidArgumentException::class),
-            'Or must throw an exception when no scalars are provided'
+            new Or_(),
+            new HasScalarBoolValue(false),
         );
     }
 }

--- a/tests/Scalar/Xor_Test.php
+++ b/tests/Scalar/Xor_Test.php
@@ -4,16 +4,12 @@ declare(strict_types=1);
 
 namespace Primus\Tests\Scalar;
 
-use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Primus\Scalar\ScalarOf;
 use Primus\Scalar\Xor_;
 use Primus\Tests\Constraint\HasScalarBoolValue;
-use Primus\Tests\Constraint\ThrowsValue;
 
-/**
- */
 final class Xor_Test extends TestCase
 {
     #[Test]
@@ -70,12 +66,11 @@ final class Xor_Test extends TestCase
     }
 
     #[Test]
-    public function throwsWhenNoConditionsProvided(): void
+    public function returnsFalseForEmptyParity(): void
     {
         self::assertThat(
-            new ScalarOf(fn () => (new Xor_())->value()),
-            new ThrowsValue(InvalidArgumentException::class),
-            'Xor must throw an exception when no conditions are provided'
+            new Xor_(),
+            new HasScalarBoolValue(false),
         );
     }
 }


### PR DESCRIPTION
- Fixed And and Or to short-circuit at the first decisive scalar instead of eagerly evaluating every argument
- Updated all three operators to return their algebraic identity on empty input (And true, Or false, Xor false) instead of throwing InvalidArgumentException
- Refactored Xor to walk the conditions with a parity accumulator wrapped in parentheses to avoid PHP xor precedence pitfalls
- Updated tests to assert the new identity-on-empty contract and removed the throws-on-empty cases

**Breaking changes:**
- And_ Or_ Xor_ no longer throw InvalidArgumentException on empty input; callers expecting the exception must check the argument count themselves

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Logical gates (And, Or, Xor) now handle empty argument lists gracefully instead of throwing exceptions, returning appropriate default values.
  * Implemented short-circuit evaluation for improved performance in logical operations.

* **Documentation**
  * Clarified edge case behavior and evaluation semantics for logical gates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->