### PR TITLE
Sheriff 0.32.1 Drops onlyPublic Default After Phpstan-rules Refactor

### DIFF
--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -111,7 +111,6 @@ defaults:
         excludedClasses: []
       prohibitStaticMethods:
         allowNamedConstructors: true
-        onlyPublic: true
 
   phpunit.cli: true
   phpunit.php_options: "-d memory_limit=1G"

--- a/.sheriff/phpstan/phpstan.neon
+++ b/.sheriff/phpstan/phpstan.neon
@@ -29,4 +29,3 @@ parameters:
             ignoreAbstract: true
         prohibitStaticMethods:
             allowNamedConstructors: true
-            onlyPublic: true

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,6 @@
         }
     },
     "require-dev": {
-        "haspadar/sheriff": "^0.32.0"
+        "haspadar/sheriff": "^0.32.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee18290d52aa511a7091d4c8578226ee",
+    "content-hash": "f8dedbbd71d0e31e1d3e363c7a96311b",
     "packages": [],
     "packages-dev": [
         {
@@ -1815,16 +1815,16 @@
         },
         {
             "name": "haspadar/phpstan-rules",
-            "version": "v0.52.0",
+            "version": "v0.52.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/phpstan-rules.git",
-                "reference": "adb92b54bcde1a07e10a5daee57119c9e1d199a2"
+                "reference": "13391b5fabc81559010935c02ee01f8ede91a288"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/adb92b54bcde1a07e10a5daee57119c9e1d199a2",
-                "reference": "adb92b54bcde1a07e10a5daee57119c9e1d199a2",
+                "url": "https://api.github.com/repos/haspadar/phpstan-rules/zipball/13391b5fabc81559010935c02ee01f8ede91a288",
+                "reference": "13391b5fabc81559010935c02ee01f8ede91a288",
                 "shasum": ""
             },
             "require": {
@@ -1862,22 +1862,22 @@
             "description": "PHPStan design rules for immutability and structure",
             "support": {
                 "issues": "https://github.com/haspadar/phpstan-rules/issues",
-                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.52.0"
+                "source": "https://github.com/haspadar/phpstan-rules/tree/v0.52.1"
             },
-            "time": "2026-05-19T06:52:08+00:00"
+            "time": "2026-05-19T14:06:31+00:00"
         },
         {
             "name": "haspadar/sheriff",
-            "version": "v0.32.0",
+            "version": "v0.32.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/sheriff.git",
-                "reference": "9838dd14f03a273fdae783181586fe7ed55c9ee2"
+                "reference": "bb735a07a049a2d171b805643f8f6cb9e551b0a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/sheriff/zipball/9838dd14f03a273fdae783181586fe7ed55c9ee2",
-                "reference": "9838dd14f03a273fdae783181586fe7ed55c9ee2",
+                "url": "https://api.github.com/repos/haspadar/sheriff/zipball/bb735a07a049a2d171b805643f8f6cb9e551b0a6",
+                "reference": "bb735a07a049a2d171b805643f8f6cb9e551b0a6",
                 "shasum": ""
             },
             "require": {
@@ -1930,9 +1930,9 @@
             "description": "Picky standards for PHP projects",
             "support": {
                 "issues": "https://github.com/haspadar/sheriff/issues",
-                "source": "https://github.com/haspadar/sheriff/tree/v0.32.0"
+                "source": "https://github.com/haspadar/sheriff/tree/v0.32.1"
             },
-            "time": "2026-05-19T09:35:54+00:00"
+            "time": "2026-05-19T15:00:58+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",


### PR DESCRIPTION
- Updated haspadar/sheriff to ^0.32.1 picking up phpstan-rules 0.52.1
- Refactored generated sheriff and phpstan configs via `sheriff sync` to drop the now-redundant `prohibitStaticMethods.onlyPublic` default

Closes #236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality analysis configuration to refine static method validation rules
  * Bumped development dependency to the latest patch version for improved tooling compatibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->