### PR TITLE
Map Sorted And SortedBy Decorators

### DIFF
--- a/src/Map/Sorted.php
+++ b/src/Map/Sorted.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Map;
+
+use Generator;
+use Override;
+
+/**
+ * Map with pairs ordered by ascending value comparison, keys preserved.
+ *
+ * Uses PHP's spaceship operator on every value pair, which yields ascending
+ * order and stable ordering between pairs whose values compare equal.
+ *
+ * Example:
+ *     $sorted = new Sorted(new MapOf(['b' => 3, 'a' => 1, 'c' => 2]));
+ *     // ['a' => 1, 'c' => 2, 'b' => 3]
+ *
+ * @template K of array-key
+ * @template V
+ * @extends MapEnvelope<K, V>
+ */
+final readonly class Sorted extends MapEnvelope
+{
+    #[Override]
+    public function value(): array
+    {
+        $pairs = $this->origin->value();
+        uasort($pairs, static fn(mixed $left, mixed $right): int => $left <=> $right);
+
+        return $pairs;
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->value();
+    }
+}

--- a/src/Map/SortedBy.php
+++ b/src/Map/SortedBy.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Map;
+
+use Generator;
+use Override;
+use Primus\Func\BiFunc;
+
+/**
+ * Map with pairs ordered by an externally supplied value comparator, keys preserved.
+ *
+ * The comparator receives two values and returns a negative integer, zero,
+ * or a positive integer when the first value should be ordered before, equal
+ * to, or after the second value.
+ *
+ * Example:
+ *     $byLength = new SortedBy(
+ *         new MapOf(['x' => 'alpha', 'y' => 'pi', 'z' => 'gamma']),
+ *         new BiFuncOf(static fn(string $left, string $right): int
+ *             => strlen($left) <=> strlen($right)),
+ *     );
+ *     // ['y' => 'pi', 'x' => 'alpha', 'z' => 'gamma']
+ *
+ * @template K of array-key
+ * @template V
+ * @extends MapEnvelope<K, V>
+ */
+final readonly class SortedBy extends MapEnvelope
+{
+    /**
+     * Ctor.
+     *
+     * @param Map<K, V> $origin The map to order.
+     * @param BiFunc<V, V, int> $comparator The value-pair comparator.
+     */
+    public function __construct(Map $origin, private BiFunc $comparator)
+    {
+        parent::__construct($origin);
+    }
+
+    #[Override]
+    public function value(): array
+    {
+        $pairs = $this->origin->value();
+        $compare = $this->comparator;
+        uasort(
+            $pairs,
+            /**
+             * @param V $left
+             * @param V $right
+             */
+            static fn(mixed $left, mixed $right): int => $compare->apply($left, $right),
+        );
+
+        return $pairs;
+    }
+
+    #[Override]
+    public function getIterator(): Generator
+    {
+        yield from $this->value();
+    }
+}

--- a/tests/Map/SortedByTest.php
+++ b/tests/Map/SortedByTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Map;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Func\BiFuncOf;
+use Primus\Map\MapOf;
+use Primus\Map\SortedBy;
+
+final class SortedByTest extends TestCase
+{
+    #[Test]
+    public function exposesEmptyMapAsEmpty(): void
+    {
+        $this->assertSame(
+            [],
+            (new SortedBy(
+                new MapOf([]),
+                new BiFuncOf(static fn(mixed $left, mixed $right): int => $left <=> $right),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function ordersByComparatorResultAndPreservesKeys(): void
+    {
+        $this->assertSame(
+            ['y' => 'pi', 'x' => 'alpha', 'z' => 'gamma'],
+            (new SortedBy(
+                new MapOf(['x' => 'alpha', 'y' => 'pi', 'z' => 'gamma']),
+                new BiFuncOf(static fn(string $left, string $right): int
+                    => strlen($left) <=> strlen($right)),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function supportsDescendingComparator(): void
+    {
+        $this->assertSame(
+            ['d' => 5, 'c' => 4, 'a' => 3, 'e' => 2, 'b' => 1],
+            (new SortedBy(
+                new MapOf(['a' => 3, 'b' => 1, 'c' => 4, 'd' => 5, 'e' => 2]),
+                new BiFuncOf(static fn(int $left, int $right): int => $right <=> $left),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesPairsConsideredEqualByComparator(): void
+    {
+        $this->assertSame(
+            ['e' => 'k', 'a' => 'ab', 'c' => 'cd', 'b' => 'efg', 'd' => 'hij'],
+            (new SortedBy(
+                new MapOf(['a' => 'ab', 'b' => 'efg', 'c' => 'cd', 'd' => 'hij', 'e' => 'k']),
+                new BiFuncOf(static fn(string $left, string $right): int
+                    => strlen($left) <=> strlen($right)),
+            ))->value(),
+        );
+    }
+
+    #[Test]
+    public function iteratorYieldsSameSequenceAsValue(): void
+    {
+        $sorted = new SortedBy(
+            new MapOf(['b' => 3, 'a' => 1, 'c' => 2]),
+            new BiFuncOf(static fn(int $left, int $right): int => $left <=> $right),
+        );
+        $this->assertSame(
+            $sorted->value(),
+            iterator_to_array($sorted),
+        );
+    }
+
+    #[Test]
+    public function countsSourcePairs(): void
+    {
+        $this->assertCount(
+            5,
+            new SortedBy(
+                new MapOf(['a' => 3, 'b' => 1, 'c' => 4, 'd' => 5, 'e' => 2]),
+                new BiFuncOf(static fn(int $left, int $right): int => $left <=> $right),
+            ),
+        );
+    }
+
+    #[Test]
+    public function leavesSourceUntouchedAfterReading(): void
+    {
+        $source = new MapOf(['b' => 3, 'a' => 1, 'c' => 2]);
+        $sorted = new SortedBy(
+            $source,
+            new BiFuncOf(static fn(int $left, int $right): int => $left <=> $right),
+        );
+        $sorted->value();
+        iterator_to_array($sorted);
+        $this->assertSame(['b' => 3, 'a' => 1, 'c' => 2], $source->value());
+    }
+}

--- a/tests/Map/SortedTest.php
+++ b/tests/Map/SortedTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primus\Tests\Map;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Primus\Map\MapOf;
+use Primus\Map\Sorted;
+
+final class SortedTest extends TestCase
+{
+    #[Test]
+    public function exposesEmptyMapAsEmpty(): void
+    {
+        $this->assertSame([], (new Sorted(new MapOf([])))->value());
+    }
+
+    #[Test]
+    public function ordersIntegersAscendingAndPreservesKeys(): void
+    {
+        $this->assertSame(
+            ['a' => 1, 'c' => 2, 'b' => 3],
+            (new Sorted(new MapOf(['b' => 3, 'a' => 1, 'c' => 2])))->value(),
+        );
+    }
+
+    #[Test]
+    public function ordersStringsLexicographicallyAndPreservesKeys(): void
+    {
+        $this->assertSame(
+            ['x' => 'alpha', 'z' => 'bravo', 'y' => 'charlie'],
+            (new Sorted(new MapOf(['y' => 'charlie', 'x' => 'alpha', 'z' => 'bravo'])))->value(),
+        );
+    }
+
+    #[Test]
+    public function preservesRelativeOrderOfEqualValues(): void
+    {
+        $this->assertSame(
+            ['b' => 1, 'd' => 1, 'a' => 2, 'c' => 2, 'e' => 3],
+            (new Sorted(new MapOf(['a' => 2, 'b' => 1, 'c' => 2, 'd' => 1, 'e' => 3])))->value(),
+        );
+    }
+
+    #[Test]
+    public function iteratorYieldsSameSequenceAsValue(): void
+    {
+        $sorted = new Sorted(new MapOf(['b' => 3, 'a' => 1, 'c' => 2]));
+        $this->assertSame(
+            $sorted->value(),
+            iterator_to_array($sorted),
+        );
+    }
+
+    #[Test]
+    public function countsSourcePairs(): void
+    {
+        $this->assertCount(
+            3,
+            new Sorted(new MapOf(['b' => 3, 'a' => 1, 'c' => 2])),
+        );
+    }
+
+    #[Test]
+    public function leavesSourceUntouchedAfterReading(): void
+    {
+        $source = new MapOf(['b' => 3, 'a' => 1, 'c' => 2]);
+        $sorted = new Sorted($source);
+        $sorted->value();
+        iterator_to_array($sorted);
+        $this->assertSame(['b' => 3, 'a' => 1, 'c' => 2], $source->value());
+    }
+}


### PR DESCRIPTION
- Added Map\Sorted decorator that orders pairs by ascending value through PHP spaceship comparison while preserving keys.
- Added Map\SortedBy decorator that orders pairs by an externally supplied BiFunc value comparator while preserving keys.

Closes #238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added map sorting functionality that orders entries by values in ascending order while preserving original keys.
  * Added customizable map sorting with support for external comparator functions to define custom sort order.

* **Tests**
  * Added test suites for sorting functionality, covering edge cases like empty maps, stable ordering, key preservation, and immutability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->