### PR TITLE
Named Constructor Naming Convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ cycle. Compose through the documented public surface instead.
   `Not`, `Xor_`, `RootCause` (unwrap a Throwable chain), `FirstOf`,
   `ItemAt`, `HighestOf`, `LowestOf`, `Reduced`, `Folded`, `BoolOf`,
   `LengthOf` (length of Text via `::text`, or any array/Countable via
-  `::ofCountable`), `ScalarEnvelope`.
+  `::countable`), `ScalarEnvelope`.
 
 - **`Primus\Number`** — root numeric contract.
   `Number` interface with three projections (`asInt()`, `asFloat()`,
@@ -166,6 +166,15 @@ Patterns that look reasonable but are wrong for Primus:
   PHP analogue of overloaded constructors in Cactoos Java. Anything else
   static (helper methods, factories returning unrelated types, `Trimmed::of`)
   is still forbidden.
+
+- **Named constructor naming follows the class suffix.** Exactly one
+  indicator of "of"-semantics belongs in any factory call. If the class
+  name ends with `Of`, the factory carries no `of` prefix:
+  `TextOf::scalar(...)`, `LengthOf::text(...)`, `MapOf::pair(...)`. If
+  the class name does not end with `Of`, the factory takes the prefix:
+  `Joined::ofStrings(...)`, `Ternary::ofBool(...)`,
+  `ItemAt::ofList(...)`. Forms like `LengthOf::ofCountable` or
+  `Joined::strings` mix or omit the indicator and are forbidden.
 
 ---
 

--- a/src/Scalar/LengthOf.php
+++ b/src/Scalar/LengthOf.php
@@ -13,15 +13,15 @@ use Primus\Text\Text;
  * Named constructors dispatch on the source family:
  *
  * - `LengthOf::text(Text)` — count of Unicode codepoints via `mb_strlen`.
- * - `LengthOf::ofCountable(array|Countable)` — count of elements via `count()`.
+ * - `LengthOf::countable(array|Countable)` — count of elements via `count()`.
  *
  * Each form re-evaluates the source on every {@see Scalar::value()}
  * call — wrap in {@see Sticky} to memoize.
  *
  * Example:
  *     LengthOf::text(TextOf::str('Café Noël'))->value(); // 9
- *     LengthOf::ofCountable(new ListOf(1, 2, 3))->value(); // 3
- *     LengthOf::ofCountable(['a' => 1, 'b' => 2])->value(); // 2
+ *     LengthOf::countable(new ListOf(1, 2, 3))->value(); // 3
+ *     LengthOf::countable(['a' => 1, 'b' => 2])->value(); // 2
  *
  * @extends ScalarEnvelope<int>
  */
@@ -56,7 +56,7 @@ final readonly class LengthOf extends ScalarEnvelope
      * @param array<array-key, mixed>|Countable $countable Source collection
      * @psalm-api
      */
-    public static function ofCountable(array|Countable $countable): self
+    public static function countable(array|Countable $countable): self
     {
         return new self(
             new ScalarOf(static fn(): int => count($countable)),

--- a/tests/Scalar/LengthOfTest.php
+++ b/tests/Scalar/LengthOfTest.php
@@ -34,7 +34,7 @@ final class LengthOfTest extends TestCase
     {
         self::assertSame(
             3,
-            LengthOf::ofCountable(new ListOf(1, 2, 3))->value(),
+            LengthOf::countable(new ListOf(1, 2, 3))->value(),
         );
     }
 
@@ -43,20 +43,20 @@ final class LengthOfTest extends TestCase
     {
         self::assertSame(
             2,
-            LengthOf::ofCountable(new MapOf(['a' => 1, 'b' => 2]))->value(),
+            LengthOf::countable(new MapOf(['a' => 1, 'b' => 2]))->value(),
         );
     }
 
     #[Test]
     public function countsPlainArrayAsCountable(): void
     {
-        self::assertSame(4, LengthOf::ofCountable([10, 20, 30, 40])->value());
+        self::assertSame(4, LengthOf::countable([10, 20, 30, 40])->value());
     }
 
     #[Test]
     public function returnsZeroForEmptyArray(): void
     {
-        self::assertSame(0, LengthOf::ofCountable([])->value());
+        self::assertSame(0, LengthOf::countable([])->value());
     }
 
     #[Test]


### PR DESCRIPTION
- Added named constructor naming rule to the agent contract, tying the `of` factory prefix to the absence of the `Of` class suffix.
- Renamed Scalar\LengthOf::ofCountable to Scalar\LengthOf::countable to remove the duplicate of-indicator.
- Updated docblock examples and the namespace overview to reference the renamed factory.

Closes #240

**Breaking changes:**
- `Scalar\LengthOf::ofCountable(array|Countable)` removed; call sites must use `Scalar\LengthOf::countable(array|Countable)` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed public factory method `ofCountable()` to `countable()` in the length scalar class.

* **Documentation**
  * Updated public agent contract specifications with named constructor naming conventions.

* **Tests**
  * Updated tests to reflect the renamed factory method.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->