### PR TITLE
BoolOf Accepts Native String Without Text Wrapping

### DIFF
--- a/src/Scalar/BoolOf.php
+++ b/src/Scalar/BoolOf.php
@@ -7,12 +7,21 @@ namespace Primus\Scalar;
 use Primus\Text\Text;
 
 /**
- * Boolean parsed from a {@see Text} value.
+ * Boolean parsed from a {@see Text} or native string.
  *
- * Delegates parsing to {@see filter_var()} with `FILTER_VALIDATE_BOOLEAN`,
- * which accepts the common truthy/falsy spellings: `true`, `false`, `yes`,
- * `no`, `on`, `off`, `1`, `0` (case-insensitive, surrounding whitespace is
- * tolerated). Any other input is treated as `false`.
+ * Named constructors dispatch on the source family:
+ *
+ * - `BoolOf::text(Text)` — parse a {@see Text} value.
+ * - `BoolOf::str(string)` — parse a native string directly.
+ *
+ * Both forms delegate parsing to {@see filter_var()} with
+ * `FILTER_VALIDATE_BOOLEAN`, which accepts the common truthy/falsy
+ * spellings: `true`, `false`, `yes`, `no`, `on`, `off`, `1`, `0`
+ * (case-insensitive, surrounding whitespace is tolerated). Any other
+ * input is treated as `false`.
+ *
+ * Each form re-evaluates the source on every {@see Scalar::value()}
+ * call — wrap in {@see Sticky} to memoize.
  *
  * The accepted vocabulary is wider than Cactoos `BoolOf` (which only
  * matches `Boolean.valueOf` semantics — `true` literal vs everything else) —
@@ -23,13 +32,13 @@ use Primus\Text\Text;
  * (`Ternary`, `And_`, `Or_`).
  *
  * Example:
- *     $enabled = new BoolOf(TextOf::str('yes'));
+ *     $enabled = BoolOf::str('yes');
  *     echo $enabled->value() ? 'on' : 'off'; // 'on'
  *
- *     $padded = new BoolOf(TextOf::str(' true '));
+ *     $padded = BoolOf::text(TextOf::str(' true '));
  *     echo $padded->value() ? 'on' : 'off'; // 'on' — surrounding whitespace tolerated
  *
- *     $disabled = new BoolOf(TextOf::str('garbage'));
+ *     $disabled = BoolOf::str('garbage');
  *     echo $disabled->value() ? 'on' : 'off'; // 'off'
  *
  * @extends ScalarEnvelope<bool>
@@ -37,16 +46,45 @@ use Primus\Text\Text;
 final readonly class BoolOf extends ScalarEnvelope
 {
     /**
-     * Ctor.
+     * Sole point of construction; reached through the named factories.
      *
-     * @param Text $origin The text to parse.
+     * @param Scalar<bool> $origin
      */
-    public function __construct(Text $origin)
+    private function __construct(Scalar $origin)
     {
-        parent::__construct(
+        parent::__construct($origin);
+    }
+
+    /**
+     * Wraps a {@see Text} value as a parsed boolean.
+     *
+     * @param Text $text Source text
+     * @psalm-api
+     */
+    public static function text(Text $text): self
+    {
+        return new self(
             new ScalarOf(
                 static fn(): bool => filter_var(
-                    $origin->value(),
+                    $text->value(),
+                    FILTER_VALIDATE_BOOLEAN,
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Wraps a native string as a parsed boolean.
+     *
+     * @param string $value Source string
+     * @psalm-api
+     */
+    public static function str(string $value): self
+    {
+        return new self(
+            new ScalarOf(
+                static fn(): bool => filter_var(
+                    $value,
                     FILTER_VALIDATE_BOOLEAN,
                 ),
             ),

--- a/tests/Scalar/BoolOfTest.php
+++ b/tests/Scalar/BoolOfTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Primus\Tests\Scalar;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
@@ -21,11 +22,9 @@ final class BoolOfTest extends TestCase
     #[TestWith(['on'])]
     #[TestWith(['ON'])]
     #[TestWith(['1'])]
-    public function parsesCanonicalTrueLiterals(string $input): void
+    public function strParsesCanonicalTrueLiterals(string $input): void
     {
-        self::assertTrue(
-            (new BoolOf(TextOf::str($input)))->value(),
-        );
+        self::assertTrue(BoolOf::str($input)->value());
     }
 
     #[Test]
@@ -36,39 +35,62 @@ final class BoolOfTest extends TestCase
     #[TestWith(['off'])]
     #[TestWith(['OFF'])]
     #[TestWith(['0'])]
-    public function parsesCanonicalFalseLiterals(string $input): void
+    public function strParsesCanonicalFalseLiterals(string $input): void
     {
-        self::assertFalse(
-            (new BoolOf(TextOf::str($input)))->value(),
-        );
+        self::assertFalse(BoolOf::str($input)->value());
     }
 
     #[Test]
-    public function returnsFalseForArbitraryNonBooleanText(): void
+    public function strReturnsFalseForArbitraryNonBooleanInput(): void
     {
-        self::assertFalse(
-            (new BoolOf(TextOf::str('garbage')))->value(),
-        );
+        self::assertFalse(BoolOf::str('garbage')->value());
     }
 
     #[Test]
-    public function returnsFalseForEmptyText(): void
+    public function strReturnsFalseForEmptyInput(): void
     {
-        self::assertFalse(
-            (new BoolOf(TextOf::str('')))->value(),
-        );
+        self::assertFalse(BoolOf::str('')->value());
     }
 
     #[Test]
-    public function toleratesSurroundingWhitespace(): void
+    public function strToleratesSurroundingWhitespace(): void
     {
-        self::assertTrue(
-            (new BoolOf(TextOf::str(' true ')))->value(),
-        );
+        self::assertTrue(BoolOf::str(' true ')->value());
     }
 
     #[Test]
-    public function defersTextResolutionUntilValueCall(): void
+    #[DataProvider('parsingInputs')]
+    public function textFormAgreesWithStringFormOnEveryInput(string $input): void
+    {
+        self::assertSame(
+            BoolOf::str($input)->value(),
+            BoolOf::text(TextOf::str($input))->value(),
+        );
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function parsingInputs(): array
+    {
+        return [
+            'true literal' => ['true'],
+            'false literal' => ['false'],
+            'yes' => ['yes'],
+            'no' => ['no'],
+            'on' => ['on'],
+            'off' => ['off'],
+            'one' => ['1'],
+            'zero' => ['0'],
+            'arbitrary garbage' => ['garbage'],
+            'empty string' => [''],
+            'whitespace padded true' => [' true '],
+            'whitespace padded garbage' => ['  garbage  '],
+        ];
+    }
+
+    #[Test]
+    public function textFormDefersResolutionUntilValueCall(): void
     {
         $resolved = false;
         $text = TextOf::scalar(
@@ -80,7 +102,7 @@ final class BoolOfTest extends TestCase
                 },
             ),
         );
-        $flag = new BoolOf($text);
+        $flag = BoolOf::text($text);
 
         self::assertFalse($resolved);
         self::assertTrue($flag->value());

--- a/tests/Scalar/BoolOfTest.php
+++ b/tests/Scalar/BoolOfTest.php
@@ -75,11 +75,17 @@ final class BoolOfTest extends TestCase
     {
         return [
             'true literal' => ['true'],
+            'TRUE literal' => ['TRUE'],
             'false literal' => ['false'],
+            'FALSE literal' => ['FALSE'],
             'yes' => ['yes'],
+            'YES' => ['YES'],
             'no' => ['no'],
+            'NO' => ['NO'],
             'on' => ['on'],
+            'ON' => ['ON'],
             'off' => ['off'],
+            'OFF' => ['OFF'],
             'one' => ['1'],
             'zero' => ['0'],
             'arbitrary garbage' => ['garbage'],


### PR DESCRIPTION
- Added BoolOf::str(string) named constructor that parses a native string into a boolean without requiring a Text wrapper at the call site.
- Added BoolOf::text(Text) named constructor that restates the previous parsing behaviour for Text inputs.
- Updated tests to cover both forms and to verify they agree on the full canonical input vocabulary.

Closes #242

**Breaking changes:**
- `BoolOf::__construct(Text)` is no longer part of the public API; replace `new BoolOf($text)` with `BoolOf::text($text)` or `BoolOf::str($string)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * `BoolOf` class constructor is now private; replaced with factory methods `BoolOf::text()` and `BoolOf::str()` for creating instances from Text objects or string values respectively.
  * Test suite updated to use the new factory methods while maintaining equivalent coverage for boolean parsing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->