### PR TITLE
Text Joined And Concatenated Accept Native Strings

### DIFF
--- a/src/Text/Concatenated.php
+++ b/src/Text/Concatenated.php
@@ -5,16 +5,25 @@ declare(strict_types=1);
 namespace Primus\Text;
 
 /**
- * Text concatenated from multiple {@see Text} parts without a separator.
+ * Text concatenated from multiple parts without a separator.
  *
  * Equivalent to {@see Joined} with an empty separator. Parts are concatenated
  * in argument order.
+ *
+ * Construction forms:
+ *
+ * - `new Concatenated(Text ...)` — concatenate variadic {@see Text} parts.
+ * - `Concatenated::ofStrings(string ...)` — shortcut that wraps each native
+ *   string in {@see TextOf::str()} before concatenating.
  *
  * Example:
  *     $text = new Concatenated(
  *         TextOf::str('hello, '),
  *         TextOf::str('world'),
  *     );
+ *     echo $text->value(); // 'hello, world'
+ *
+ *     $text = Concatenated::ofStrings('hello, ', 'world');
  *     echo $text->value(); // 'hello, world'
  */
 final readonly class Concatenated extends TextEnvelope
@@ -29,5 +38,21 @@ final readonly class Concatenated extends TextEnvelope
     public function __construct(Text ...$parts)
     {
         parent::__construct(new Joined(self::SEPARATOR, array_values($parts)));
+    }
+
+    /**
+     * Concatenates native strings in argument order.
+     *
+     * @param string ...$parts The strings to concatenate.
+     * @psalm-api
+     */
+    public static function ofStrings(string ...$parts): self
+    {
+        return new self(
+            ...array_map(
+                static fn(string $part): Text => TextOf::str($part),
+                $parts,
+            ),
+        );
     }
 }

--- a/src/Text/Joined.php
+++ b/src/Text/Joined.php
@@ -7,10 +7,19 @@ namespace Primus\Text;
 use Primus\Scalar\ScalarOf;
 
 /**
- * Text joined from multiple Text parts with a separator.
+ * Text joined from multiple parts with a separator.
+ *
+ * Construction forms:
+ *
+ * - `new Joined(string, list<Text>)` — join an array of {@see Text} parts.
+ * - `Joined::ofStrings(string, string ...)` — shortcut that wraps each
+ *   native string in {@see TextOf::str()} before joining.
  *
  * Example:
  *     $text = new Joined(', ', [TextOf::str('a'), TextOf::str('b'), TextOf::str('c')]);
+ *     echo $text->value(); // 'a, b, c'
+ *
+ *     $text = Joined::ofStrings(', ', 'a', 'b', 'c');
  *     echo $text->value(); // 'a, b, c'
  */
 final readonly class Joined extends TextEnvelope
@@ -32,6 +41,26 @@ final readonly class Joined extends TextEnvelope
                         $parts,
                     ),
                 )),
+            ),
+        );
+    }
+
+    /**
+     * Joins native strings with a separator.
+     *
+     * @param string $separator The glue inserted between parts.
+     * @param string ...$parts The strings to join.
+     * @psalm-api
+     */
+    public static function ofStrings(string $separator, string ...$parts): self
+    {
+        return new self(
+            $separator,
+            array_values(
+                array_map(
+                    static fn(string $part): Text => TextOf::str($part),
+                    $parts,
+                ),
             ),
         );
     }

--- a/tests/Text/ConcatenatedTest.php
+++ b/tests/Text/ConcatenatedTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Primus\Tests\Text;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Primus\Tests\Constraint\HasTextValue;
 use Primus\Text\Concatenated;
+use Primus\Text\Text;
 use Primus\Text\TextOf;
 
 final class ConcatenatedTest extends TestCase
@@ -66,5 +68,59 @@ final class ConcatenatedTest extends TestCase
             new Concatenated(TextOf::str('only')),
             new HasTextValue('only')
         );
+    }
+
+    #[Test]
+    public function ofStringsConcatenatesNativeStrings(): void
+    {
+        self::assertThat(
+            Concatenated::ofStrings('hello, ', 'world'),
+            new HasTextValue('hello, world')
+        );
+    }
+
+    #[Test]
+    public function ofStringsReturnsEmptyForNoArguments(): void
+    {
+        self::assertThat(
+            Concatenated::ofStrings(),
+            new HasTextValue('')
+        );
+    }
+
+    #[Test]
+    public function ofStringsPreservesMultibyteCharacters(): void
+    {
+        self::assertThat(
+            Concatenated::ofStrings('café', ' & ', 'привет'),
+            new HasTextValue('café & привет')
+        );
+    }
+
+    #[Test]
+    #[DataProvider('concatenatedInputs')]
+    public function ofStringsAgreesWithTextFormOnEveryInput(array $parts): void
+    {
+        $texts = array_map(static fn(string $p): Text => TextOf::str($p), $parts);
+
+        self::assertSame(
+            (new Concatenated(...$texts))->value(),
+            Concatenated::ofStrings(...$parts)->value(),
+        );
+    }
+
+    /**
+     * @return array<string, array{list<string>}>
+     */
+    public static function concatenatedInputs(): array
+    {
+        return [
+            'empty parts' => [[]],
+            'single part' => [['only']],
+            'two parts' => [['hello, ', 'world']],
+            'three parts' => [['a', 'b', 'c']],
+            'multibyte parts' => [['café', ' & ', 'привет']],
+            'empty string parts' => [['a', '', 'b']],
+        ];
     }
 }

--- a/tests/Text/JoinedTest.php
+++ b/tests/Text/JoinedTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Primus\Tests\Text;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Primus\Tests\Constraint\HasTextValue;
@@ -89,4 +90,59 @@ final class JoinedTest extends TestCase
 
         self::assertSame(2, $calls);
     }
+
+    #[Test]
+    public function ofStringsJoinsNativeStringsWithSeparator(): void
+    {
+        self::assertThat(
+            Joined::ofStrings(', ', 'a', 'b', 'c'),
+            new HasTextValue('a, b, c')
+        );
+    }
+
+    #[Test]
+    public function ofStringsJoinsSingleNativeString(): void
+    {
+        self::assertThat(
+            Joined::ofStrings(', ', 'solo'),
+            new HasTextValue('solo')
+        );
+    }
+
+    #[Test]
+    public function ofStringsProducesEmptyResultWithoutParts(): void
+    {
+        self::assertThat(
+            Joined::ofStrings(', '),
+            new HasTextValue('')
+        );
+    }
+
+    #[Test]
+    #[DataProvider('joinedInputs')]
+    public function ofStringsAgreesWithTextFormOnEveryInput(string $separator, array $parts): void
+    {
+        $texts = array_map(static fn(string $p): Text => TextOf::str($p), $parts);
+
+        self::assertSame(
+            (new Joined($separator, $texts))->value(),
+            Joined::ofStrings($separator, ...$parts)->value(),
+        );
+    }
+
+    /**
+     * @return array<string, array{string, list<string>}>
+     */
+    public static function joinedInputs(): array
+    {
+        return [
+            'empty parts' => [', ', []],
+            'single part' => [', ', ['solo']],
+            'multiple parts' => [', ', ['a', 'b', 'c']],
+            'empty separator' => ['', ['a', 'b', 'c']],
+            'multibyte parts' => [' & ', ['café', 'привет']],
+            'multichar separator' => [' -- ', ['a', 'b']],
+        ];
+    }
+
 }


### PR DESCRIPTION
- Added Text\Joined::ofStrings factory that joins variadic native strings with a separator, wrapping each part in TextOf::str internally.
- Added Text\Concatenated::ofStrings factory that concatenates variadic native strings without a separator.
- Updated docblocks to list both construction forms and extended equivalence tests to cover empty, single, multibyte and multi-part inputs.

Closes #244

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added convenient shortcut methods for constructing concatenated and joined text directly from native strings, with support for multibyte characters and variable argument counts.

* **Documentation**
  * Updated class documentation to include construction forms and usage patterns for text creation utilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->