### PR TITLE
Text Case Transformers Accept Native Strings

### DIFF
--- a/src/Text/Capitalized.php
+++ b/src/Text/Capitalized.php
@@ -10,8 +10,17 @@ namespace Primus\Text;
  * Converts only the first character to uppercase
  * and leaves the rest of the text unchanged.
  *
+ * Construction forms:
+ *
+ * - `new Capitalized(Text)` — wrap an existing {@see Text} value.
+ * - `Capitalized::ofString(string)` — shortcut that wraps a native string in
+ *   {@see TextOf::str()} before capitalising.
+ *
  * Example:
  *     $text = new Capitalized(TextOf::str('hello'));
+ *     echo $text->value(); // 'Hello'
+ *
+ *     $text = Capitalized::ofString('hello');
  *     echo $text->value(); // 'Hello'
  */
 final readonly class Capitalized extends TextEnvelope
@@ -29,5 +38,16 @@ final readonly class Capitalized extends TextEnvelope
                 new Sub($origin, 1),
             ]),
         );
+    }
+
+    /**
+     * Capitalises a native string.
+     *
+     * @param string $value The string to capitalise.
+     * @psalm-api
+     */
+    public static function ofString(string $value): self
+    {
+        return new self(TextOf::str($value));
     }
 }

--- a/src/Text/Lowered.php
+++ b/src/Text/Lowered.php
@@ -11,8 +11,17 @@ use Primus\Func\FuncOf;
  *
  * Converts the given text to lowercase using multibyte support.
  *
+ * Construction forms:
+ *
+ * - `new Lowered(Text)` — wrap an existing {@see Text} value.
+ * - `Lowered::ofString(string)` — shortcut that wraps a native string in
+ *   {@see TextOf::str()} before lowercasing.
+ *
  * Example:
  *     $text = new Lowered(TextOf::str('CAFÉ & TÜRKİYE'));
+ *     echo $text->value(); // 'café & türkiye'
+ *
+ *     $text = Lowered::ofString('CAFÉ & TÜRKİYE');
  *     echo $text->value(); // 'café & türkiye'
  */
 final readonly class Lowered extends TextEnvelope
@@ -30,5 +39,16 @@ final readonly class Lowered extends TextEnvelope
                 new FuncOf(static fn(string $s): string => mb_strtolower($s, 'UTF-8')),
             ),
         );
+    }
+
+    /**
+     * Lowercases a native string.
+     *
+     * @param string $value The string to lowercase.
+     * @psalm-api
+     */
+    public static function ofString(string $value): self
+    {
+        return new self(TextOf::str($value));
     }
 }

--- a/src/Text/Uppered.php
+++ b/src/Text/Uppered.php
@@ -11,8 +11,17 @@ use Primus\Func\FuncOf;
  *
  * Converts the given text to uppercase using multibyte support.
  *
+ * Construction forms:
+ *
+ * - `new Uppered(Text)` — wrap an existing {@see Text} value.
+ * - `Uppered::ofString(string)` — shortcut that wraps a native string in
+ *   {@see TextOf::str()} before uppercasing.
+ *
  * Example:
  *     $text = new Uppered(TextOf::str('touché résumé'));
+ *     echo $text->value(); // 'TOUCHÉ RÉSUMÉ'
+ *
+ *     $text = Uppered::ofString('touché résumé');
  *     echo $text->value(); // 'TOUCHÉ RÉSUMÉ'
  */
 final readonly class Uppered extends TextEnvelope
@@ -30,5 +39,16 @@ final readonly class Uppered extends TextEnvelope
                 new FuncOf(static fn(string $s): string => mb_strtoupper($s, 'UTF-8')),
             ),
         );
+    }
+
+    /**
+     * Uppercases a native string.
+     *
+     * @param string $value The string to uppercase.
+     * @psalm-api
+     */
+    public static function ofString(string $value): self
+    {
+        return new self(TextOf::str($value));
     }
 }

--- a/tests/Text/CapitalizedTest.php
+++ b/tests/Text/CapitalizedTest.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Primus\Tests\Text;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Primus\Tests\Constraint\HasTextValue;
 use Primus\Text\Capitalized;
 use Primus\Text\TextOf;
 
-/**
- */
 final class CapitalizedTest extends TestCase
 {
     #[Test]
@@ -62,5 +61,39 @@ final class CapitalizedTest extends TestCase
             new HasTextValue('Hello WORLD'),
             'Capitalized must capitalize only the first character'
         );
+    }
+
+    #[Test]
+    public function ofStringCapitalisesNativeString(): void
+    {
+        self::assertThat(
+            Capitalized::ofString('hello'),
+            new HasTextValue('Hello')
+        );
+    }
+
+    #[Test]
+    #[DataProvider('inputs')]
+    public function ofStringAgreesWithTextFormOnEveryInput(string $input): void
+    {
+        self::assertSame(
+            (new Capitalized(TextOf::str($input)))->value(),
+            Capitalized::ofString($input)->value(),
+        );
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function inputs(): array
+    {
+        return [
+            'empty string' => [''],
+            'lowercase word' => ['hello'],
+            'already capitalised' => ['World'],
+            'multibyte first char' => ['ёлка'],
+            'mixed case after first' => ['hello WORLD'],
+            'single char' => ['x'],
+        ];
     }
 }

--- a/tests/Text/LoweredTest.php
+++ b/tests/Text/LoweredTest.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Primus\Tests\Text;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Primus\Tests\Constraint\HasTextValue;
 use Primus\Text\Lowered;
 use Primus\Text\TextOf;
 
-/**
- */
 final class LoweredTest extends TestCase
 {
     #[Test]
@@ -39,5 +38,39 @@ final class LoweredTest extends TestCase
             new Lowered(TextOf::str('ÀÉÎÖÜ')),
             new HasTextValue('àéîöü')
         );
+    }
+
+    #[Test]
+    public function ofStringLowercasesNativeString(): void
+    {
+        self::assertThat(
+            Lowered::ofString('HELLO'),
+            new HasTextValue('hello')
+        );
+    }
+
+    #[Test]
+    #[DataProvider('inputs')]
+    public function ofStringAgreesWithTextFormOnEveryInput(string $input): void
+    {
+        self::assertSame(
+            (new Lowered(TextOf::str($input)))->value(),
+            Lowered::ofString($input)->value(),
+        );
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function inputs(): array
+    {
+        return [
+            'empty string' => [''],
+            'all uppercase' => ['HELLO'],
+            'mixed case' => ['HeLLo WoRLD'],
+            'diacritics' => ['ÀÉÎÖÜ'],
+            'already lowercase' => ['café'],
+            'cyrillic' => ['ПРИВЕТ'],
+        ];
     }
 }

--- a/tests/Text/UpperedTest.php
+++ b/tests/Text/UpperedTest.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Primus\Tests\Text;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Primus\Tests\Constraint\HasTextValue;
 use Primus\Text\TextOf;
 use Primus\Text\Uppered;
 
-/**
- */
 final class UpperedTest extends TestCase
 {
     #[Test]
@@ -75,5 +74,41 @@ final class UpperedTest extends TestCase
             new Uppered(TextOf::str('   ')),
             new HasTextValue('   ')
         );
+    }
+
+    #[Test]
+    public function ofStringUppercasesNativeString(): void
+    {
+        self::assertThat(
+            Uppered::ofString('hello'),
+            new HasTextValue('HELLO')
+        );
+    }
+
+    #[Test]
+    #[DataProvider('inputs')]
+    public function ofStringAgreesWithTextFormOnEveryInput(string $input): void
+    {
+        self::assertSame(
+            (new Uppered(TextOf::str($input)))->value(),
+            Uppered::ofString($input)->value(),
+        );
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function inputs(): array
+    {
+        return [
+            'empty string' => [''],
+            'all lowercase' => ['hello'],
+            'mixed case' => ['HeLLo WoRLD'],
+            'diacritics' => ['àéîöü'],
+            'already uppercase' => ['ALREADY'],
+            'special characters' => ['test@123!'],
+            'whitespace only' => ['   '],
+            'cyrillic' => ['привет'],
+        ];
     }
 }


### PR DESCRIPTION
- Added Text\Lowered::ofString factory that lowercases a native string without an explicit Text wrapper.
- Added Text\Uppered::ofString factory that uppercases a native string without an explicit Text wrapper.
- Added Text\Capitalized::ofString factory that capitalises a native string without an explicit Text wrapper.
- Removed leftover empty docblocks above the affected test classes.

Part of #246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added convenient factory methods (`ofString()`) to text case manipulation classes, enabling direct string input processing without intermediate object wrapping.

* **Tests**
  * Expanded test coverage with parameterized tests validating new functionality across diverse inputs including multibyte characters, diacritics, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->