### PR TITLE
Text Repeated And FormattedText Accept Native Strings

### DIFF
--- a/src/Text/FormattedText.php
+++ b/src/Text/FormattedText.php
@@ -7,7 +7,7 @@ namespace Primus\Text;
 use Primus\Func\FuncOf;
 
 /**
- * Text formatted from a {@see Text} pattern via {@see sprintf()}.
+ * Text formatted from a pattern via {@see sprintf()}.
  *
  * The pattern uses the PHP sprintf specification (`%s`, `%d`, `%f`,
  * positional `%1$s`, etc.). Arguments are restricted to int, float and
@@ -21,12 +21,22 @@ use Primus\Func\FuncOf;
  * Do not pass untrusted patterns: a hostile precision such as
  * `%.999999999s` can allocate a large buffer.
  *
+ * Construction forms:
+ *
+ * - `new FormattedText(Text, int|float|string ...)` — wrap an existing
+ *   {@see Text} pattern.
+ * - `FormattedText::ofString(string, int|float|string ...)` — shortcut that
+ *   wraps a native string pattern in {@see TextOf::str()} before formatting.
+ *
  * Example:
  *     $text = new FormattedText(
  *         TextOf::str('Hello, %s! You have %d messages.'),
  *         'world',
  *         5,
  *     );
+ *     echo $text->value(); // 'Hello, world! You have 5 messages.'
+ *
+ *     $text = FormattedText::ofString('Hello, %s! You have %d messages.', 'world', 5);
  *     echo $text->value(); // 'Hello, world! You have 5 messages.'
  */
 final readonly class FormattedText extends TextEnvelope
@@ -45,5 +55,17 @@ final readonly class FormattedText extends TextEnvelope
                 new FuncOf(static fn(string $p): string => sprintf($p, ...$arguments)),
             ),
         );
+    }
+
+    /**
+     * Formats a native string pattern with the given arguments.
+     *
+     * @param string $pattern The sprintf pattern.
+     * @param int|float|string ...$arguments The values substituted into the pattern.
+     * @psalm-api
+     */
+    public static function ofString(string $pattern, int|float|string ...$arguments): self
+    {
+        return new self(TextOf::str($pattern), ...$arguments);
     }
 }

--- a/src/Text/Repeated.php
+++ b/src/Text/Repeated.php
@@ -9,8 +9,17 @@ use Primus\Func\FuncOf;
 /**
  * Text repeated multiple times.
  *
+ * Construction forms:
+ *
+ * - `new Repeated(Text, int)` — wrap an existing {@see Text} value.
+ * - `Repeated::ofString(string, int)` — shortcut that wraps a native string in
+ *   {@see TextOf::str()} before repeating.
+ *
  * Example:
  *     $text = new Repeated(TextOf::str('xo'), 3);
+ *     echo $text->value(); // 'xoxoxo'
+ *
+ *     $text = Repeated::ofString('xo', 3);
  *     echo $text->value(); // 'xoxoxo'
  */
 final readonly class Repeated extends TextEnvelope
@@ -29,5 +38,17 @@ final readonly class Repeated extends TextEnvelope
                 new FuncOf(static fn(string $s): string => str_repeat($s, max(0, $count))),
             ),
         );
+    }
+
+    /**
+     * Repeats a native string.
+     *
+     * @param string $value The string to repeat.
+     * @param int $count The number of repetitions.
+     * @psalm-api
+     */
+    public static function ofString(string $value, int $count): self
+    {
+        return new self(TextOf::str($value), $count);
     }
 }

--- a/tests/Text/FormattedTextTest.php
+++ b/tests/Text/FormattedTextTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Primus\Tests\Text;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Primus\Tests\Constraint\HasTextValue;
@@ -55,5 +56,38 @@ final class FormattedTextTest extends TestCase
             new FormattedText(TextOf::str('café %s'), 'привет'),
             new HasTextValue('café привет')
         );
+    }
+
+    #[Test]
+    public function ofStringFormatsNativeStringPattern(): void
+    {
+        self::assertThat(
+            FormattedText::ofString('Hello, %s!', 'world'),
+            new HasTextValue('Hello, world!')
+        );
+    }
+
+    #[Test]
+    #[DataProvider('inputs')]
+    public function ofStringAgreesWithTextFormOnEveryInput(string $pattern, array $arguments): void
+    {
+        self::assertSame(
+            (new FormattedText(TextOf::str($pattern), ...$arguments))->value(),
+            FormattedText::ofString($pattern, ...$arguments)->value(),
+        );
+    }
+
+    /**
+     * @return array<string, array{string, list<int|float|string>}>
+     */
+    public static function inputs(): array
+    {
+        return [
+            'string substitution' => ['Hello, %s!', ['world']],
+            'int and float' => ['%d items at %.2f each', [5, 3.5]],
+            'no placeholders' => ['no placeholders here', []],
+            'positional' => ['%2$s %1$s', ['world', 'hello']],
+            'multibyte' => ['café %s', ['привет']],
+        ];
     }
 }

--- a/tests/Text/RepeatedTest.php
+++ b/tests/Text/RepeatedTest.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Primus\Tests\Text;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Primus\Tests\Constraint\HasTextValue;
 use Primus\Text\Repeated;
 use Primus\Text\TextOf;
 
-/**
- */
 final class RepeatedTest extends TestCase
 {
     #[Test]
@@ -66,5 +65,39 @@ final class RepeatedTest extends TestCase
             new Repeated(TextOf::str('🔥'), 3),
             new HasTextValue('🔥🔥🔥')
         );
+    }
+
+    #[Test]
+    public function ofStringRepeatsNativeString(): void
+    {
+        self::assertThat(
+            Repeated::ofString('xo', 3),
+            new HasTextValue('xoxoxo')
+        );
+    }
+
+    #[Test]
+    #[DataProvider('inputs')]
+    public function ofStringAgreesWithTextFormOnEveryInput(string $value, int $count): void
+    {
+        self::assertSame(
+            (new Repeated(TextOf::str($value), $count))->value(),
+            Repeated::ofString($value, $count)->value(),
+        );
+    }
+
+    /**
+     * @return array<string, array{string, int}>
+     */
+    public static function inputs(): array
+    {
+        return [
+            'multiple repeats' => ['xo', 3],
+            'zero count' => ['abc', 0],
+            'negative count' => ['abc', -2],
+            'empty input' => ['', 5],
+            'single char' => ['a', 5],
+            'unicode' => ['🔥', 3],
+        ];
     }
 }


### PR DESCRIPTION
- Added Text\Repeated::ofString factory that repeats a native string a given number of times without an explicit Text wrapper.
- Added Text\FormattedText::ofString factory that formats a native string sprintf pattern without an explicit Text wrapper.

Closes #246