### PR TITLE
Named Constructor Mirrors For Bytes Namespace

### DIFF
--- a/src/Bytes/Base64Decoded.php
+++ b/src/Bytes/Base64Decoded.php
@@ -14,8 +14,13 @@ use Primus\Text\Text;
  * Strict decoding is used: any character outside the Base64 alphabet
  * rejects access with InvalidArgumentException.
  *
+ * Construction forms:
+ *
+ * - `new Base64Decoded(Text)` — wrap an existing {@see Text} value.
+ * - `Base64Decoded::of(Text)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $bytes = new Base64Decoded(TextOf::str("aGVsbG8="));
+ *     $bytes = Base64Decoded::of(TextOf::str("aGVsbG8="));
  *     $bytes->value(); // "hello"
  */
 final readonly class Base64Decoded implements Bytes
@@ -26,6 +31,17 @@ final readonly class Base64Decoded implements Bytes
      * @param Text $origin The Base64 text to decode.
      */
     public function __construct(private Text $origin) {}
+
+    /**
+     * Decodes a Base64-encoded {@see Text} into raw bytes.
+     *
+     * @param Text $text The Base64 text to decode.
+     * @psalm-api
+     */
+    public static function of(Text $text): self
+    {
+        return new self($text);
+    }
 
     #[Override]
     public function value(): string

--- a/src/Bytes/Base64Encoded.php
+++ b/src/Bytes/Base64Encoded.php
@@ -10,8 +10,13 @@ use Primus\Text\Text;
 /**
  * Canonical Base64 textual representation of Bytes.
  *
+ * Construction forms:
+ *
+ * - `new Base64Encoded(Bytes)` — wrap an existing {@see Bytes} value.
+ * - `Base64Encoded::of(Bytes)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $text = new Base64Encoded(new BytesOf("hello"));
+ *     $text = Base64Encoded::of(new BytesOf("hello"));
  *     $text->value(); // "aGVsbG8="
  */
 final readonly class Base64Encoded implements Text
@@ -22,6 +27,17 @@ final readonly class Base64Encoded implements Text
      * @param Bytes $origin The bytes to encode.
      */
     public function __construct(private Bytes $origin) {}
+
+    /**
+     * Encodes raw {@see Bytes} into a canonical Base64 representation.
+     *
+     * @param Bytes $bytes The bytes to encode.
+     * @psalm-api
+     */
+    public static function of(Bytes $bytes): self
+    {
+        return new self($bytes);
+    }
 
     #[Override]
     public function value(): string

--- a/src/Bytes/BytesOf.php
+++ b/src/Bytes/BytesOf.php
@@ -9,8 +9,13 @@ use Override;
 /**
  * Bytes wrapping a raw binary string.
  *
+ * Construction forms:
+ *
+ * - `new BytesOf(string)` — wrap an existing native string.
+ * - `BytesOf::str(string)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $b = new BytesOf("hello");
+ *     $b = BytesOf::str("hello");
  *     $b->value(); // "hello"
  */
 final readonly class BytesOf implements Bytes
@@ -21,6 +26,17 @@ final readonly class BytesOf implements Bytes
      * @param string $value The raw binary byte sequence.
      */
     public function __construct(private string $value) {}
+
+    /**
+     * Wraps a raw binary string as a {@see Bytes}.
+     *
+     * @param string $str The raw binary byte sequence.
+     * @psalm-api
+     */
+    public static function str(string $str): self
+    {
+        return new self($str);
+    }
 
     #[Override]
     public function value(): string

--- a/src/Bytes/HexDecoded.php
+++ b/src/Bytes/HexDecoded.php
@@ -15,8 +15,13 @@ use Primus\Text\Text;
  * length or any non-hex character rejects access with
  * InvalidArgumentException.
  *
+ * Construction forms:
+ *
+ * - `new HexDecoded(Text)` — wrap an existing {@see Text} value.
+ * - `HexDecoded::of(Text)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $bytes = new HexDecoded(TextOf::str("6869"));
+ *     $bytes = HexDecoded::of(TextOf::str("6869"));
  *     $bytes->value(); // "hi"
  */
 final readonly class HexDecoded implements Bytes
@@ -27,6 +32,17 @@ final readonly class HexDecoded implements Bytes
      * @param Text $origin The hexadecimal text to decode.
      */
     public function __construct(private Text $origin) {}
+
+    /**
+     * Decodes a hexadecimal {@see Text} into raw bytes.
+     *
+     * @param Text $text The hexadecimal text to decode.
+     * @psalm-api
+     */
+    public static function of(Text $text): self
+    {
+        return new self($text);
+    }
 
     #[Override]
     public function value(): string

--- a/src/Bytes/HexEncoded.php
+++ b/src/Bytes/HexEncoded.php
@@ -12,8 +12,13 @@ use Primus\Text\Text;
  *
  * Each byte becomes two hex digits; the result has even length.
  *
+ * Construction forms:
+ *
+ * - `new HexEncoded(Bytes)` — wrap an existing {@see Bytes} value.
+ * - `HexEncoded::of(Bytes)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $text = new HexEncoded(new BytesOf("hi"));
+ *     $text = HexEncoded::of(new BytesOf("hi"));
  *     $text->value(); // "6869"
  */
 final readonly class HexEncoded implements Text
@@ -24,6 +29,17 @@ final readonly class HexEncoded implements Text
      * @param Bytes $origin The bytes to encode.
      */
     public function __construct(private Bytes $origin) {}
+
+    /**
+     * Encodes raw {@see Bytes} into a lowercase hexadecimal text.
+     *
+     * @param Bytes $bytes The bytes to encode.
+     * @psalm-api
+     */
+    public static function of(Bytes $bytes): self
+    {
+        return new self($bytes);
+    }
 
     #[Override]
     public function value(): string

--- a/src/Bytes/Md5.php
+++ b/src/Bytes/Md5.php
@@ -11,8 +11,13 @@ use Override;
  *
  * Compose with {@see HexEncoded} for the canonical hexadecimal form.
  *
+ * Construction forms:
+ *
+ * - `new Md5(Bytes)` — wrap an existing {@see Bytes} value.
+ * - `Md5::of(Bytes)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $hex = new HexEncoded(new Md5(new BytesOf('hello')));
+ *     $hex = HexEncoded::of(Md5::of(new BytesOf('hello')));
  *     $hex->value(); // "5d41402abc4b2a76b9719d911017c592"
  */
 final readonly class Md5 implements Bytes
@@ -23,6 +28,17 @@ final readonly class Md5 implements Bytes
      * @param Bytes $origin The bytes to hash.
      */
     public function __construct(private Bytes $origin) {}
+
+    /**
+     * Computes the raw MD5 digest of the given {@see Bytes}.
+     *
+     * @param Bytes $bytes The bytes to hash.
+     * @psalm-api
+     */
+    public static function of(Bytes $bytes): self
+    {
+        return new self($bytes);
+    }
 
     #[Override]
     public function value(): string

--- a/src/Bytes/Sha256.php
+++ b/src/Bytes/Sha256.php
@@ -11,8 +11,13 @@ use Override;
  *
  * Compose with {@see HexEncoded} for the canonical hexadecimal form.
  *
+ * Construction forms:
+ *
+ * - `new Sha256(Bytes)` — wrap an existing {@see Bytes} value.
+ * - `Sha256::of(Bytes)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $hex = new HexEncoded(new Sha256(new BytesOf('hello')));
+ *     $hex = HexEncoded::of(Sha256::of(new BytesOf('hello')));
  *     $hex->value(); // "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
  */
 final readonly class Sha256 implements Bytes
@@ -23,6 +28,17 @@ final readonly class Sha256 implements Bytes
      * @param Bytes $origin The bytes to hash.
      */
     public function __construct(private Bytes $origin) {}
+
+    /**
+     * Computes the raw SHA-256 digest of the given {@see Bytes}.
+     *
+     * @param Bytes $bytes The bytes to hash.
+     * @psalm-api
+     */
+    public static function of(Bytes $bytes): self
+    {
+        return new self($bytes);
+    }
 
     #[Override]
     public function value(): string

--- a/tests/Bytes/Base64Test.php
+++ b/tests/Bytes/Base64Test.php
@@ -55,4 +55,26 @@ final class Base64Test extends TestCase
 
         (new Base64Decoded(TextOf::str('not_valid!!!')))->value();
     }
+
+    #[Test]
+    public function encodedOfFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $bytes = new BytesOf('hello');
+
+        $this->assertSame(
+            (new Base64Encoded($bytes))->value(),
+            Base64Encoded::of($bytes)->value(),
+        );
+    }
+
+    #[Test]
+    public function decodedOfFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $text = TextOf::str('aGVsbG8=');
+
+        $this->assertSame(
+            (new Base64Decoded($text))->value(),
+            Base64Decoded::of($text)->value(),
+        );
+    }
 }

--- a/tests/Bytes/BytesOfTest.php
+++ b/tests/Bytes/BytesOfTest.php
@@ -27,4 +27,13 @@ final class BytesOfTest extends TestCase
     {
         $this->assertSame("\x00\x01\xff", (new BytesOf("\x00\x01\xff"))->value());
     }
+
+    #[Test]
+    public function strFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $this->assertSame(
+            (new BytesOf("\x00\x01\xff"))->value(),
+            BytesOf::str("\x00\x01\xff")->value(),
+        );
+    }
 }

--- a/tests/Bytes/HexTest.php
+++ b/tests/Bytes/HexTest.php
@@ -69,4 +69,26 @@ final class HexTest extends TestCase
 
         (new HexDecoded(TextOf::str('zz')))->value();
     }
+
+    #[Test]
+    public function encodedOfFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $bytes = new BytesOf('hi');
+
+        $this->assertSame(
+            (new HexEncoded($bytes))->value(),
+            HexEncoded::of($bytes)->value(),
+        );
+    }
+
+    #[Test]
+    public function decodedOfFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $text = TextOf::str('6869');
+
+        $this->assertSame(
+            (new HexDecoded($text))->value(),
+            HexDecoded::of($text)->value(),
+        );
+    }
 }

--- a/tests/Bytes/Md5Test.php
+++ b/tests/Bytes/Md5Test.php
@@ -43,4 +43,15 @@ final class Md5Test extends TestCase
 
         $this->assertSame($md5->value(), $md5->value());
     }
+
+    #[Test]
+    public function ofFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $bytes = new BytesOf('hello');
+
+        $this->assertSame(
+            (new Md5($bytes))->value(),
+            Md5::of($bytes)->value(),
+        );
+    }
 }

--- a/tests/Bytes/Sha256Test.php
+++ b/tests/Bytes/Sha256Test.php
@@ -43,4 +43,15 @@ final class Sha256Test extends TestCase
 
         $this->assertSame($sha->value(), $sha->value());
     }
+
+    #[Test]
+    public function ofFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $bytes = new BytesOf('hello');
+
+        $this->assertSame(
+            (new Sha256($bytes))->value(),
+            Sha256::of($bytes)->value(),
+        );
+    }
 }


### PR DESCRIPTION
- Added Bytes\BytesOf::str native-string factory mirroring the primary constructor.
- Added Bytes\Base64Decoded::of, Base64Encoded::of, HexDecoded::of, HexEncoded::of, Md5::of, Sha256::of factories mirroring their primary constructors.
- Updated class-level docblocks to list both construction forms and document each factory.

Part of #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added alternative named constructor methods (`of()` and `str()`) to byte encoding and decoding classes for more intuitive and consistent object creation.

* **Tests**
  * Comprehensive test coverage added to verify new constructor factory methods function identically to primary constructors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->