### PR TITLE
Named Constructor Mirrors For Time And Integer Namespaces

### DIFF
--- a/src/Integer/Abs.php
+++ b/src/Integer/Abs.php
@@ -15,8 +15,13 @@ use Primus\Text\TextOf;
  * `abs()` silently widens to float and the strict int return contract breaks
  * with a TypeError. Callers must keep operands above `PHP_INT_MIN`.
  *
+ * Construction forms:
+ *
+ * - `new Abs(Integer)` — wrap an existing {@see Integer} value.
+ * - `Abs::ofInteger(Integer)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $abs = new Abs(new IntegerOf(-7));
+ *     $abs = Abs::ofInteger(IntegerOf::int(-7));
  *     $abs->asInt(); // 7
  */
 final readonly class Abs implements Integer
@@ -27,6 +32,17 @@ final readonly class Abs implements Integer
      * @param Integer $origin The integer to take the absolute value of.
      */
     public function __construct(private Integer $origin) {}
+
+    /**
+     * Takes the absolute value of an {@see Integer}.
+     *
+     * @param Integer $integer The integer to take the absolute value of.
+     * @psalm-api
+     */
+    public static function ofInteger(Integer $integer): self
+    {
+        return new self($integer);
+    }
 
     #[Override]
     public function asInt(): int

--- a/src/Integer/DivOf.php
+++ b/src/Integer/DivOf.php
@@ -13,8 +13,13 @@ use Primus\Text\TextOf;
  *
  * Throws DivisionByZeroError on access when the divisor is zero.
  *
+ * Construction forms:
+ *
+ * - `new DivOf(Integer, Integer)` — wrap an existing pair of integers.
+ * - `DivOf::integers(Integer, Integer)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $div = new DivOf(new IntegerOf(7), new IntegerOf(2));
+ *     $div = DivOf::integers(IntegerOf::int(7), IntegerOf::int(2));
  *     $div->asInt(); // 3
  */
 final readonly class DivOf implements Integer
@@ -22,15 +27,27 @@ final readonly class DivOf implements Integer
     /**
      * Ctor.
      *
+     * @param Integer $top The integer to divide.
+     * @param Integer $bottom The integer to divide by.
+     */
+    public function __construct(private Integer $top, private Integer $bottom) {}
+
+    /**
+     * Divides one {@see Integer} by another, truncated toward zero.
+     *
      * @param Integer $dividend The integer to divide.
      * @param Integer $divisor The integer to divide by.
+     * @psalm-api
      */
-    public function __construct(private Integer $dividend, private Integer $divisor) {}
+    public static function integers(Integer $dividend, Integer $divisor): self
+    {
+        return new self($dividend, $divisor);
+    }
 
     #[Override]
     public function asInt(): int
     {
-        return intdiv($this->dividend->asInt(), $this->divisor->asInt());
+        return intdiv($this->top->asInt(), $this->bottom->asInt());
     }
 
     #[Override]

--- a/src/Integer/IntegerOf.php
+++ b/src/Integer/IntegerOf.php
@@ -11,8 +11,13 @@ use Primus\Text\TextOf;
 /**
  * Integer lifted from a native int.
  *
+ * Construction forms:
+ *
+ * - `new IntegerOf(int)` — wrap an existing native int.
+ * - `IntegerOf::int(int)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $n = new IntegerOf(42);
+ *     $n = IntegerOf::int(42);
  *     $n->asInt(); // 42
  *     $n->asFloat(); // 42.0
  *     $n->asText()->value(); // "42"
@@ -25,6 +30,17 @@ final readonly class IntegerOf implements Integer
      * @param int $value The native int to wrap.
      */
     public function __construct(private int $value) {}
+
+    /**
+     * Wraps a native int as an {@see Integer}.
+     *
+     * @param int $int The native int to wrap.
+     * @psalm-api
+     */
+    public static function int(int $int): self
+    {
+        return new self($int);
+    }
 
     #[Override]
     public function asInt(): int

--- a/src/Integer/MaxOf.php
+++ b/src/Integer/MaxOf.php
@@ -14,8 +14,13 @@ use UnderflowException;
  *
  * Throws on an empty operand list — maximum is undefined without operands.
  *
+ * Construction forms:
+ *
+ * - `new MaxOf(Integer ...)` — wrap an existing variadic list of integers.
+ * - `MaxOf::integers(Integer ...)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $max = new MaxOf(new IntegerOf(3), new IntegerOf(9), new IntegerOf(5));
+ *     $max = MaxOf::integers(IntegerOf::int(3), IntegerOf::int(9), IntegerOf::int(5));
  *     $max->asInt(); // 9
  */
 final readonly class MaxOf implements Integer
@@ -31,6 +36,17 @@ final readonly class MaxOf implements Integer
     public function __construct(Integer ...$operands)
     {
         $this->operands = $operands;
+    }
+
+    /**
+     * Selects the maximum of variadic {@see Integer} operands.
+     *
+     * @param Integer ...$integers The integers to compare.
+     * @psalm-api
+     */
+    public static function integers(Integer ...$integers): self
+    {
+        return new self(...$integers);
     }
 
     #[Override]

--- a/src/Integer/MinOf.php
+++ b/src/Integer/MinOf.php
@@ -14,8 +14,13 @@ use UnderflowException;
  *
  * Throws on an empty operand list — minimum is undefined without operands.
  *
+ * Construction forms:
+ *
+ * - `new MinOf(Integer ...)` — wrap an existing variadic list of integers.
+ * - `MinOf::integers(Integer ...)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $min = new MinOf(new IntegerOf(9), new IntegerOf(3), new IntegerOf(5));
+ *     $min = MinOf::integers(IntegerOf::int(9), IntegerOf::int(3), IntegerOf::int(5));
  *     $min->asInt(); // 3
  */
 final readonly class MinOf implements Integer
@@ -31,6 +36,17 @@ final readonly class MinOf implements Integer
     public function __construct(Integer ...$operands)
     {
         $this->operands = $operands;
+    }
+
+    /**
+     * Selects the minimum of variadic {@see Integer} operands.
+     *
+     * @param Integer ...$integers The integers to compare.
+     * @psalm-api
+     */
+    public static function integers(Integer ...$integers): self
+    {
+        return new self(...$integers);
     }
 
     #[Override]

--- a/src/Integer/ModOf.php
+++ b/src/Integer/ModOf.php
@@ -13,8 +13,13 @@ use Primus\Text\TextOf;
  *
  * Throws DivisionByZeroError on access when the divisor is zero.
  *
+ * Construction forms:
+ *
+ * - `new ModOf(Integer, Integer)` — wrap an existing pair of integers.
+ * - `ModOf::integers(Integer, Integer)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $mod = new ModOf(new IntegerOf(7), new IntegerOf(3));
+ *     $mod = ModOf::integers(IntegerOf::int(7), IntegerOf::int(3));
  *     $mod->asInt(); // 1
  */
 final readonly class ModOf implements Integer
@@ -22,15 +27,27 @@ final readonly class ModOf implements Integer
     /**
      * Ctor.
      *
+     * @param Integer $top The integer to divide.
+     * @param Integer $bottom The integer to divide by.
+     */
+    public function __construct(private Integer $top, private Integer $bottom) {}
+
+    /**
+     * Computes the remainder of dividing one {@see Integer} by another.
+     *
      * @param Integer $dividend The integer to divide.
      * @param Integer $divisor The integer to divide by.
+     * @psalm-api
      */
-    public function __construct(private Integer $dividend, private Integer $divisor) {}
+    public static function integers(Integer $dividend, Integer $divisor): self
+    {
+        return new self($dividend, $divisor);
+    }
 
     #[Override]
     public function asInt(): int
     {
-        return $this->dividend->asInt() % $this->divisor->asInt();
+        return $this->top->asInt() % $this->bottom->asInt();
     }
 
     #[Override]

--- a/src/Integer/MultOf.php
+++ b/src/Integer/MultOf.php
@@ -15,10 +15,15 @@ use Primus\Text\TextOf;
  * semantics (the result silently widens to float, breaking the int contract).
  * Callers are responsible for staying within PHP_INT_MAX.
  *
+ * Construction forms:
+ *
+ * - `new MultOf(Integer ...)` — wrap an existing variadic list of integers.
+ * - `MultOf::integers(Integer ...)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $product = new MultOf(new IntegerOf(3), new IntegerOf(4));
+ *     $product = MultOf::integers(IntegerOf::int(3), IntegerOf::int(4));
  *     $product->asInt(); // 12
- *     (new MultOf())->asInt(); // 1 (multiplicative identity)
+ *     MultOf::integers()->asInt(); // 1 (multiplicative identity)
  */
 final readonly class MultOf implements Integer
 {
@@ -33,6 +38,17 @@ final readonly class MultOf implements Integer
     public function __construct(Integer ...$factors)
     {
         $this->factors = $factors;
+    }
+
+    /**
+     * Multiplies variadic {@see Integer} factors.
+     *
+     * @param Integer ...$integers The integers to multiply.
+     * @psalm-api
+     */
+    public static function integers(Integer ...$integers): self
+    {
+        return new self(...$integers);
     }
 
     #[Override]

--- a/src/Integer/Sticky.php
+++ b/src/Integer/Sticky.php
@@ -24,6 +24,11 @@ use Primus\Text\TextOf;
  *     $cached->asInt(); // computed once, traverses the tree
  *     $cached->asInt(); // cached
  *     $cached->asFloat(); // derived from the cached int, no extra traversal
+ *
+ * Construction forms:
+ *
+ * - `new Sticky(Integer)` — wrap an existing {@see Integer} value.
+ * - `Sticky::ofInteger(Integer)` — named-constructor alias of the primary ctor.
  */
 final class Sticky implements Integer
 {
@@ -39,6 +44,17 @@ final class Sticky implements Integer
      * @param Integer $origin The integer whose projection is cached.
      */
     public function __construct(private readonly Integer $origin) {}
+
+    /**
+     * Memoises the projection of an {@see Integer}.
+     *
+     * @param Integer $integer The integer whose projection is cached.
+     * @psalm-api
+     */
+    public static function ofInteger(Integer $integer): self
+    {
+        return new self($integer);
+    }
 
     #[Override]
     public function asInt(): int

--- a/src/Integer/SumOf.php
+++ b/src/Integer/SumOf.php
@@ -15,10 +15,15 @@ use Primus\Text\TextOf;
  * semantics (the result silently widens to float, breaking the int contract).
  * Callers are responsible for staying within PHP_INT_MAX.
  *
+ * Construction forms:
+ *
+ * - `new SumOf(Integer ...)` — wrap an existing variadic list of integers.
+ * - `SumOf::integers(Integer ...)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $sum = new SumOf(new IntegerOf(2), new IntegerOf(3));
+ *     $sum = SumOf::integers(IntegerOf::int(2), IntegerOf::int(3));
  *     $sum->asInt(); // 5
- *     (new SumOf())->asInt(); // 0 (additive identity)
+ *     SumOf::integers()->asInt(); // 0 (additive identity)
  */
 final readonly class SumOf implements Integer
 {
@@ -33,6 +38,17 @@ final readonly class SumOf implements Integer
     public function __construct(Integer ...$addends)
     {
         $this->addends = $addends;
+    }
+
+    /**
+     * Sums variadic {@see Integer} addends.
+     *
+     * @param Integer ...$integers The integers to add.
+     * @psalm-api
+     */
+    public static function integers(Integer ...$integers): self
+    {
+        return new self(...$integers);
     }
 
     #[Override]

--- a/src/Time/Iso.php
+++ b/src/Time/Iso.php
@@ -13,8 +13,13 @@ use Primus\Text\Text;
  * Formatting follows PHP DateTimeImmutable's `c` format (ISO-8601 with
  * timezone offset). The Time is resolved on each value() call.
  *
+ * Construction forms:
+ *
+ * - `new Iso(Time)` — wrap an existing {@see Time} value.
+ * - `Iso::of(Time)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $iso = new Iso(new TimeOf('2026-05-12T10:00:00Z'));
+ *     $iso = Iso::of(new TimeOf('2026-05-12T10:00:00Z'));
  *     $iso->value(); // "2026-05-12T10:00:00+00:00"
  */
 final readonly class Iso implements Text
@@ -25,6 +30,17 @@ final readonly class Iso implements Text
      * @param Time $origin The time to format.
      */
     public function __construct(private Time $origin) {}
+
+    /**
+     * Formats a {@see Time} as ISO-8601 text.
+     *
+     * @param Time $time The time to format.
+     * @psalm-api
+     */
+    public static function of(Time $time): self
+    {
+        return new self($time);
+    }
 
     #[Override]
     public function value(): string

--- a/src/Time/TimeOf.php
+++ b/src/Time/TimeOf.php
@@ -14,8 +14,13 @@ use Override;
  * which accepts ISO-8601, RFC-3339, "now", "tomorrow", and other
  * relative formats. Parsing happens at each value() call.
  *
+ * Construction forms:
+ *
+ * - `new TimeOf(string)` — wrap an existing native datetime string.
+ * - `TimeOf::str(string)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $t = new TimeOf('2026-05-12T10:00:00Z');
+ *     $t = TimeOf::str('2026-05-12T10:00:00Z');
  *     $t->value(); // DateTimeImmutable @ 2026-05-12 10:00:00 UTC
  */
 final readonly class TimeOf implements Time
@@ -26,6 +31,17 @@ final readonly class TimeOf implements Time
      * @param string $datetime The textual moment in any format accepted by DateTimeImmutable.
      */
     public function __construct(private string $datetime) {}
+
+    /**
+     * Wraps a native datetime string as a {@see Time}.
+     *
+     * @param string $str The textual moment in any format accepted by DateTimeImmutable.
+     * @psalm-api
+     */
+    public static function str(string $str): self
+    {
+        return new self($str);
+    }
 
     #[Override]
     public function value(): DateTimeImmutable

--- a/tests/Integer/AbsTest.php
+++ b/tests/Integer/AbsTest.php
@@ -49,4 +49,15 @@ final class AbsTest extends TestCase
     {
         $this->assertSame('7', (new Abs(new IntegerOf(-7)))->asText()->value());
     }
+
+    #[Test]
+    public function ofIntegerFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $integer = new IntegerOf(-7);
+
+        $this->assertSame(
+            (new Abs($integer))->asInt(),
+            Abs::ofInteger($integer)->asInt(),
+        );
+    }
 }

--- a/tests/Integer/DivOfTest.php
+++ b/tests/Integer/DivOfTest.php
@@ -65,4 +65,16 @@ final class DivOfTest extends TestCase
 
         (new DivOf(new IntegerOf(1), new IntegerOf(0)))->asText();
     }
+
+    #[Test]
+    public function integersFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $dividend = new IntegerOf(7);
+        $divisor = new IntegerOf(2);
+
+        $this->assertSame(
+            (new DivOf($dividend, $divisor))->asInt(),
+            DivOf::integers($dividend, $divisor)->asInt(),
+        );
+    }
 }

--- a/tests/Integer/IntegerOfTest.php
+++ b/tests/Integer/IntegerOfTest.php
@@ -57,4 +57,13 @@ final class IntegerOfTest extends TestCase
     {
         $this->assertSame('9007199254740993', (new IntegerOf(9007199254740993))->asText()->value());
     }
+
+    #[Test]
+    public function intFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $this->assertSame(
+            (new IntegerOf(42))->asInt(),
+            IntegerOf::int(42)->asInt(),
+        );
+    }
 }

--- a/tests/Integer/MaxOfTest.php
+++ b/tests/Integer/MaxOfTest.php
@@ -71,4 +71,16 @@ final class MaxOfTest extends TestCase
 
         (new MaxOf())->asText();
     }
+
+    #[Test]
+    public function integersFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $a = new IntegerOf(3);
+        $b = new IntegerOf(9);
+
+        $this->assertSame(
+            (new MaxOf($a, $b))->asInt(),
+            MaxOf::integers($a, $b)->asInt(),
+        );
+    }
 }

--- a/tests/Integer/MinOfTest.php
+++ b/tests/Integer/MinOfTest.php
@@ -71,4 +71,16 @@ final class MinOfTest extends TestCase
 
         (new MinOf())->asText();
     }
+
+    #[Test]
+    public function integersFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $a = new IntegerOf(9);
+        $b = new IntegerOf(3);
+
+        $this->assertSame(
+            (new MinOf($a, $b))->asInt(),
+            MinOf::integers($a, $b)->asInt(),
+        );
+    }
 }

--- a/tests/Integer/ModOfTest.php
+++ b/tests/Integer/ModOfTest.php
@@ -71,4 +71,16 @@ final class ModOfTest extends TestCase
 
         (new ModOf(new IntegerOf(1), new IntegerOf(0)))->asText();
     }
+
+    #[Test]
+    public function integersFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $dividend = new IntegerOf(7);
+        $divisor = new IntegerOf(3);
+
+        $this->assertSame(
+            (new ModOf($dividend, $divisor))->asInt(),
+            ModOf::integers($dividend, $divisor)->asInt(),
+        );
+    }
 }

--- a/tests/Integer/MultOfTest.php
+++ b/tests/Integer/MultOfTest.php
@@ -58,4 +58,25 @@ final class MultOfTest extends TestCase
     {
         $this->assertSame('12', (new MultOf(new IntegerOf(3), new IntegerOf(4)))->asText()->value());
     }
+
+    #[Test]
+    public function integersFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $a = new IntegerOf(3);
+        $b = new IntegerOf(4);
+
+        $this->assertSame(
+            (new MultOf($a, $b))->asInt(),
+            MultOf::integers($a, $b)->asInt(),
+        );
+    }
+
+    #[Test]
+    public function integersFactoryAgreesWithPrimaryConstructorOnEmptyOperands(): void
+    {
+        $this->assertSame(
+            (new MultOf())->asInt(),
+            MultOf::integers()->asInt(),
+        );
+    }
 }

--- a/tests/Integer/StickyTest.php
+++ b/tests/Integer/StickyTest.php
@@ -33,4 +33,15 @@ final class StickyTest extends TestCase
             new IsIdempotent(42.0),
         );
     }
+
+    #[Test]
+    public function ofIntegerFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $integer = new IntegerOf(42);
+
+        $this->assertSame(
+            (new Sticky($integer))->asInt(),
+            Sticky::ofInteger($integer)->asInt(),
+        );
+    }
 }

--- a/tests/Integer/SumOfTest.php
+++ b/tests/Integer/SumOfTest.php
@@ -52,4 +52,25 @@ final class SumOfTest extends TestCase
     {
         $this->assertSame('5', (new SumOf(new IntegerOf(2), new IntegerOf(3)))->asText()->value());
     }
+
+    #[Test]
+    public function integersFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $a = new IntegerOf(2);
+        $b = new IntegerOf(3);
+
+        $this->assertSame(
+            (new SumOf($a, $b))->asInt(),
+            SumOf::integers($a, $b)->asInt(),
+        );
+    }
+
+    #[Test]
+    public function integersFactoryAgreesWithPrimaryConstructorOnEmptyOperands(): void
+    {
+        $this->assertSame(
+            (new SumOf())->asInt(),
+            SumOf::integers()->asInt(),
+        );
+    }
 }

--- a/tests/Time/IsoTest.php
+++ b/tests/Time/IsoTest.php
@@ -36,4 +36,15 @@ final class IsoTest extends TestCase
 
         $this->assertStringStartsWith('2026-05-12T00:00:00', $iso);
     }
+
+    #[Test]
+    public function ofFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $time = new TimeOf('2026-05-12T10:00:00Z');
+
+        $this->assertSame(
+            (new Iso($time))->value(),
+            Iso::of($time)->value(),
+        );
+    }
 }

--- a/tests/Time/TimeOfTest.php
+++ b/tests/Time/TimeOfTest.php
@@ -35,4 +35,13 @@ final class TimeOfTest extends TestCase
 
         $this->assertEquals($time->value(), $time->value());
     }
+
+    #[Test]
+    public function strFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $this->assertEquals(
+            (new TimeOf('2026-05-12T10:00:00Z'))->value(),
+            TimeOf::str('2026-05-12T10:00:00Z')->value(),
+        );
+    }
 }


### PR DESCRIPTION
- Added named ctor mirrors for Time\Iso::of and Time\TimeOf::str.
- Added named ctor mirrors for Integer\IntegerOf::int, Integer\Abs::ofInteger, Integer\Sticky::ofInteger.
- Added named ctor mirrors for Integer\SumOf::integers, MaxOf::integers, MinOf::integers, MultOf::integers, DivOf::integers, ModOf::integers.
- Renamed DivOf and ModOf primary ctor parameters to top/bottom so the named factory can keep the math vocabulary dividend/divisor without shadowing the promoted property.
- Updated class-level docblocks to list both construction forms.

Part of #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added static factory methods across numeric operation classes and time utilities, offering more readable and consistent object construction patterns
  * Documentation updated to showcase recommended factory-based construction approaches

* **Tests**
  * Comprehensive test coverage added to verify factory methods consistently produce identical results to primary constructors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->