### PR TITLE
Bump Sheriff To 0.33.0

### DIFF
--- a/.github/workflows/sheriff.yml
+++ b/.github/workflows/sheriff.yml
@@ -9,27 +9,6 @@ on:
 jobs:
 
   # ============================================================
-  # PR SIZE CHECK
-  # ============================================================
-  pr_size:
-    name: PR Size
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-
-    steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
-        with:
-          fetch-depth: 0
-
-      - uses: maidsafe/pr_size_checker@948bfb3e96d93fbeeef4e207375163e8dae5665e
-        with:
-          max_lines_changed: 500
-
-
-  # ============================================================
   # INFRA CHECKS
   # ============================================================
   infra:

--- a/.sheriff.yaml
+++ b/.sheriff.yaml
@@ -17,6 +17,7 @@ override:
                     - Primus\Text\Mapped
                     - Primus\Func\FuncOf
                     - Primus\Scalar\ScalarOf
-    phpunit.testsuites.unit: ["../../tests"]
+    # Empty subdirectory: tests live directly under php.tests (tests/),
+    # not in tests/Unit. Sheriff appends the subdir, so "" resolves to tests/.
+    phpunit.testsuites.unit: [""]
     phpunit.testsuites.integration: []
-    ci.pr.max_lines_changed: 500

--- a/.sheriff/config.yaml
+++ b/.sheriff/config.yaml
@@ -11,6 +11,8 @@
 
 defaults:
   php.src: ["src"]
+  php.tests: ["tests"]
+  php.exclude: ["vendor", ".git"]
   infra.exclude: ["vendor", "tests", ".git"]
   php.versions: ["8.3"]
   envs: {}
@@ -20,7 +22,6 @@ defaults:
   check.slow: ["infection", "sonar"]
 
   ci.sheriff_bin: "vendor/bin/sheriff"
-  ci.pr.max_lines_changed: 250
   ci.infra_checks: ["actionlint", "hadolint", "markdownlint", "yamllint", "typos", "shellcheck", "jsonlint"]
   ci.php_checks: ["phpcs", "phpstan", "psalm", "phpmd", "phpmetrics"]
 
@@ -94,7 +95,7 @@ defaults:
 
   phpstan.cli: true
   phpstan.memory: "1G"
-  phpstan.neon_includes: ["../../vendor/phpstan/phpstan-strict-rules/rules.neon", "../../vendor/haspadar/phpstan-rules/rules.neon"]
+  phpstan.neon_includes: ["../../vendor/phpstan/phpstan-strict-rules/rules.neon", "../../vendor/phpstan/phpstan-phpunit/extension.neon", "../../vendor/phpstan/phpstan-phpunit/rules.neon", "../../vendor/haspadar/phpstan-rules/rules.neon"]
   phpstan.parameters:
     level: 9
     errorFormat: table
@@ -114,8 +115,9 @@ defaults:
 
   phpunit.cli: true
   phpunit.php_options: "-d memory_limit=1G"
-  phpunit.testsuites.unit: ["../../tests/Unit"]
-  phpunit.testsuites.integration: ["../../tests/Integration"]
+  # phpunit.testsuites.* values are subdirectories of php.tests, not full paths
+  phpunit.testsuites.unit: ["Unit"]
+  phpunit.testsuites.integration: ["Integration"]
 
   psalm.cli: true
   psalm.error_level: 1
@@ -140,7 +142,6 @@ defaults:
   sonar.cli: false
   sonar.organization: ""
   sonar.projectKey: ""
-  sonar.tests: ["tests"]
   sonar.exclusions: []
   sonar.php.coverage.reportPaths: [".sheriff/codecov/coverage.xml"]
 

--- a/.sheriff/php-cs-fixer/php-cs-fixer.php
+++ b/.sheriff/php-cs-fixer/php-cs-fixer.php
@@ -106,6 +106,18 @@ return (new PhpCsFixer\Config())
         // PHP 8.4 compatibility: keep parentheses around `new` expressions
         // so tools based on pdepend (phpmd) can still parse the code
         'new_expression_parentheses' => ['use_parentheses' => true],
+
+        // PHPUnit
+        'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
+        'php_unit_dedicate_assert' => true,
+        'php_unit_mock_short_will_return' => true,
+        'php_unit_method_casing' => true,
+        'php_unit_data_provider_static' => true,
+        'php_unit_data_provider_name' => true,
+        'php_unit_data_provider_return_type' => true,
+        'php_unit_attributes' => true,
+        'php_unit_strict' => true,
+        'php_unit_set_up_tear_down_visibility' => true,
         'phpdoc_types' => ['groups' => ['meta', 'simple', 'alias'], 'exclude' => ['scalar', 'integer']],
     ]))
     ->setUnsupportedPhpVersionAllowed(true);

--- a/.sheriff/phpstan/phpstan.neon
+++ b/.sheriff/phpstan/phpstan.neon
@@ -1,5 +1,7 @@
 includes:
     - ../../vendor/phpstan/phpstan-strict-rules/rules.neon
+    - ../../vendor/phpstan/phpstan-phpunit/extension.neon
+    - ../../vendor/phpstan/phpstan-phpunit/rules.neon
     - ../../vendor/haspadar/phpstan-rules/rules.neon
 
 parameters:

--- a/.sheriff/phpunit/phpunit.xml
+++ b/.sheriff/phpunit/phpunit.xml
@@ -11,7 +11,7 @@
 >
     <testsuites>
         <testsuite name="unit">
-            <directory suffix="Test.php">../../tests</directory>
+            <directory suffix="Test.php">../../tests/</directory>
         </testsuite>
 
         <testsuite name="integration">

--- a/.sheriff/psalm/psalm.xml
+++ b/.sheriff/psalm/psalm.xml
@@ -14,6 +14,9 @@
 
         </ignoreFiles>
     </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin" />
+    </plugins>
     <issueHandlers>
         <InvalidAttribute errorLevel="suppress" />
         <UnusedClass errorLevel="suppress">

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,6 @@
         }
     },
     "require-dev": {
-        "haspadar/sheriff": "^0.32.1"
+        "haspadar/sheriff": "^0.33"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f8dedbbd71d0e31e1d3e363c7a96311b",
+    "content-hash": "3594c20d8bb3d25c88eb765c1e00c0ec",
     "packages": [],
     "packages-dev": [
         {
@@ -1868,16 +1868,16 @@
         },
         {
             "name": "haspadar/sheriff",
-            "version": "v0.32.1",
+            "version": "v0.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/haspadar/sheriff.git",
-                "reference": "bb735a07a049a2d171b805643f8f6cb9e551b0a6"
+                "reference": "a10f358aafe2b830882789ebc82588a2fb363a54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/haspadar/sheriff/zipball/bb735a07a049a2d171b805643f8f6cb9e551b0a6",
-                "reference": "bb735a07a049a2d171b805643f8f6cb9e551b0a6",
+                "url": "https://api.github.com/repos/haspadar/sheriff/zipball/a10f358aafe2b830882789ebc82588a2fb363a54",
+                "reference": "a10f358aafe2b830882789ebc82588a2fb363a54",
                 "shasum": ""
             },
             "require": {
@@ -1889,8 +1889,10 @@
                 "phpmd/phpmd": "^2.15",
                 "phpmetrics/phpmetrics": "^2.9",
                 "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
                 "phpstan/phpstan-strict-rules": "^2.0",
                 "phpunit/phpunit": "^12.0",
+                "psalm/plugin-phpunit": "^0.19.7",
                 "slevomat/coding-standard": "^8.28",
                 "squizlabs/php_codesniffer": "^4.0",
                 "symfony/process": "^7.0",
@@ -1930,9 +1932,9 @@
             "description": "Picky standards for PHP projects",
             "support": {
                 "issues": "https://github.com/haspadar/sheriff/issues",
-                "source": "https://github.com/haspadar/sheriff/tree/v0.32.1"
+                "source": "https://github.com/haspadar/sheriff/tree/v0.33.0"
             },
-            "time": "2026-05-19T15:00:58+00:00"
+            "time": "2026-05-22T15:41:44+00:00"
         },
         {
             "name": "infection/abstract-testframework-adapter",
@@ -3600,6 +3602,62 @@
             "time": "2026-05-18T11:57:34+00:00"
         },
         {
+            "name": "phpstan/phpstan-phpunit",
+            "version": "2.0.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-phpunit.git",
+                "reference": "6ab598e1bc106e6827fd346ae4a12b4a5d634c32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/6ab598e1bc106e6827fd346ae4a12b4a5d634c32",
+                "reference": "6ab598e1bc106e6827fd346ae4a12b4a5d634c32",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.1.32"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^5",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPUnit extensions and rules for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.16"
+            },
+            "time": "2026-02-14T09:05:21+00:00"
+        },
+        {
             "name": "phpstan/phpstan-strict-rules",
             "version": "2.0.11",
             "source": {
@@ -4084,6 +4142,64 @@
                 }
             ],
             "time": "2026-05-13T03:56:57+00:00"
+        },
+        {
+            "name": "psalm/plugin-phpunit",
+            "version": "0.19.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/psalm/psalm-plugin-phpunit.git",
+                "reference": "143f9d5e049fffcdbc0da3fbb99f6149f9d3e2dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/143f9d5e049fffcdbc0da3fbb99f6149f9d3e2dc",
+                "reference": "143f9d5e049fffcdbc0da3fbb99f6149f9d3e2dc",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "php": ">=8.1",
+                "vimeo/psalm": "dev-master || ^6.10.0"
+            },
+            "conflict": {
+                "phpspec/prophecy": "<1.20.0",
+                "phpspec/prophecy-phpunit": "<2.3.0",
+                "phpunit/phpunit": "<8.5.1"
+            },
+            "require-dev": {
+                "php": "^7.3 || ^8.0",
+                "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0",
+                "squizlabs/php_codesniffer": "^3.3.1",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "type": "psalm-plugin",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Psalm\\PhpUnitPlugin\\Plugin"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\PhpUnitPlugin\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Brown",
+                    "email": "github@muglug.com"
+                }
+            ],
+            "description": "Psalm plugin for PHPUnit",
+            "support": {
+                "issues": "https://github.com/psalm/psalm-plugin-phpunit/issues",
+                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.19.7"
+            },
+            "time": "2025-03-31T18:49:55+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
- Updated haspadar/sheriff dependency from 0.32.1 to 0.33.0.
- Removed pr_size job from the generated workflow after the upstream maidsafe/pr_size_checker action was deleted.
- Adjusted phpunit testsuite override to match the new subdirectory semantics in sheriff 0.33.0.
- Picked up sheriff-managed phpstan and psalm phpunit plugins alongside the new php-cs-fixer rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded and reconfigured code quality and testing infrastructure tools
  * Added PHPUnit-specific rules to code style and static analysis tools
  * Updated Sheriff development dependency from 0.32.1 to 0.33
  * Refined test suite configurations for improved test organization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->