### PR TITLE
Named Constructor Mirrors For Scalar Unary And Binary Classes

### DIFF
--- a/src/Scalar/And_.php
+++ b/src/Scalar/And_.php
@@ -11,15 +11,20 @@ namespace Primus\Scalar;
  * scalars are never asked for their value. An empty argument list returns
  * `true` (the identity of conjunction).
  *
+ * Construction forms:
+ *
+ * - `new And_(Scalar ...)` — wrap a variadic list of {@see Scalar<bool>}.
+ * - `And_::ofScalars(Scalar ...)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $and = new And_(
+ *     $and = And_::ofScalars(
  *         new Constant(true),
  *         new Constant(false),
  *         new Constant(true),
  *     );
  *     echo $and->value() ? 'all true' : 'something false'; // 'something false'
  *
- *     (new And_())->value(); // true — vacuous truth
+ *     And_::ofScalars()->value(); // true — vacuous truth
  *
  * @extends ScalarEnvelope<bool>
  */
@@ -45,5 +50,16 @@ final readonly class And_ extends ScalarEnvelope
                 },
             ),
         );
+    }
+
+    /**
+     * Conjoins variadic {@see Scalar<bool>} conditions.
+     *
+     * @param Scalar<bool> ...$scalars The scalars to AND together.
+     * @psalm-api
+     */
+    public static function ofScalars(Scalar ...$scalars): self
+    {
+        return new self(...$scalars);
     }
 }

--- a/src/Scalar/Constant.php
+++ b/src/Scalar/Constant.php
@@ -13,8 +13,13 @@ use Override;
  * Unlike {@see ScalarOf}, it performs no computation — the value
  * is provided at construction time and never changes.
  *
+ * Construction forms:
+ *
+ * - `new Constant(mixed)` — wrap a value.
+ * - `Constant::ofValue(mixed)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $scalar = new Constant(42);
+ *     $scalar = Constant::ofValue(42);
  *     echo $scalar->value(); // 42
  *
  * @template T
@@ -28,6 +33,19 @@ final readonly class Constant implements Scalar
      * @param T $value The value returned on each call.
      */
     public function __construct(private mixed $value) {}
+
+    /**
+     * Wraps a value as a constant {@see Scalar}.
+     *
+     * @template U
+     * @param U $payload The value returned on each call.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function ofValue(mixed $payload): self
+    {
+        return new self($payload);
+    }
 
     #[Override]
     public function value()

--- a/src/Scalar/Not.php
+++ b/src/Scalar/Not.php
@@ -7,8 +7,13 @@ namespace Primus\Scalar;
 /**
  * Logical negation of a {@see Scalar<bool>}.
  *
+ * Construction forms:
+ *
+ * - `new Not(Scalar)` — wrap a {@see Scalar<bool>} value.
+ * - `Not::ofScalar(Scalar)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $scalar = new Not(new ScalarOf(fn() => false));
+ *     $scalar = Not::ofScalar(new ScalarOf(fn() => false));
  *     echo $scalar->value(); // true
  *
  * @extends ScalarEnvelope<bool>
@@ -25,5 +30,16 @@ final readonly class Not extends ScalarEnvelope
         parent::__construct(
             new ScalarOf(static fn(): bool => !$origin->value()),
         );
+    }
+
+    /**
+     * Negates a {@see Scalar<bool>}.
+     *
+     * @param Scalar<bool> $scalar The scalar to negate.
+     * @psalm-api
+     */
+    public static function ofScalar(Scalar $scalar): self
+    {
+        return new self($scalar);
     }
 }

--- a/src/Scalar/Or_.php
+++ b/src/Scalar/Or_.php
@@ -11,15 +11,20 @@ namespace Primus\Scalar;
  * scalars are never asked for their value. An empty argument list returns
  * `false` (the identity of disjunction).
  *
+ * Construction forms:
+ *
+ * - `new Or_(Scalar ...)` — wrap a variadic list of {@see Scalar<bool>}.
+ * - `Or_::ofScalars(Scalar ...)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $or = new Or_(
+ *     $or = Or_::ofScalars(
  *         new Constant(false),
  *         new Constant(true),
  *         new Constant(false),
  *     );
  *     echo $or->value() ? 'any true' : 'all false'; // 'any true'
  *
- *     (new Or_())->value(); // false — no member is true
+ *     Or_::ofScalars()->value(); // false — no member is true
  *
  * @extends ScalarEnvelope<bool>
  */
@@ -45,5 +50,16 @@ final readonly class Or_ extends ScalarEnvelope
                 },
             ),
         );
+    }
+
+    /**
+     * Disjoins variadic {@see Scalar<bool>} conditions.
+     *
+     * @param Scalar<bool> ...$scalars The scalars to OR together.
+     * @psalm-api
+     */
+    public static function ofScalars(Scalar ...$scalars): self
+    {
+        return new self(...$scalars);
     }
 }

--- a/src/Scalar/RootCause.php
+++ b/src/Scalar/RootCause.php
@@ -13,8 +13,13 @@ use Throwable;
  * Walks getPrevious() until a Throwable without a previous one is reached and
  * returns it. For a Throwable without any cause, returns the input itself.
  *
+ * Construction forms:
+ *
+ * - `new RootCause(Throwable)` — wrap an existing Throwable.
+ * - `RootCause::ofThrowable(Throwable)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $root = new RootCause($outer);
+ *     $root = RootCause::ofThrowable($outer);
  *     $root->value(); // the innermost Throwable in the chain
  *
  * @implements Scalar<Throwable>
@@ -27,6 +32,17 @@ final readonly class RootCause implements Scalar
      * @param Throwable $origin The Throwable whose chain to unwrap.
      */
     public function __construct(private Throwable $origin) {}
+
+    /**
+     * Unwraps a Throwable chain to its deepest cause.
+     *
+     * @param Throwable $throwable The Throwable whose chain to unwrap.
+     * @psalm-api
+     */
+    public static function ofThrowable(Throwable $throwable): self
+    {
+        return new self($throwable);
+    }
 
     #[Override]
     public function value(): Throwable

--- a/src/Scalar/ScalarOf.php
+++ b/src/Scalar/ScalarOf.php
@@ -16,8 +16,13 @@ use Override;
  * The closure is evaluated on every call to value() unless wrapped in a
  * caching decorator like Sticky.
  *
+ * Construction forms:
+ *
+ * - `new ScalarOf(Closure)` — wrap a zero-argument closure.
+ * - `ScalarOf::closure(Closure)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $scalar = new ScalarOf(fn() => 2 + 2);
+ *     $scalar = ScalarOf::closure(fn() => 2 + 2);
  *     echo $scalar->value(); // 4
  *
  * @template T
@@ -31,6 +36,19 @@ final readonly class ScalarOf implements Scalar
      * @param Closure(): T $closure The deferred computation.
      */
     public function __construct(private Closure $closure) {}
+
+    /**
+     * Wraps a zero-argument {@see Closure} as a deferred {@see Scalar}.
+     *
+     * @template U
+     * @param Closure(): U $body The deferred computation.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function closure(Closure $body): self
+    {
+        return new self($body);
+    }
 
     #[Override]
     public function value()

--- a/src/Scalar/Sticky.php
+++ b/src/Scalar/Sticky.php
@@ -15,8 +15,13 @@ use Override;
  * This class is not thread-safe. To share cached data across objects,
  * use an external cache or synchronization mechanism.
  *
+ * Construction forms:
+ *
+ * - `new Sticky(Scalar)` — wrap a {@see Scalar} value.
+ * - `Sticky::ofScalar(Scalar)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $scalar = new Sticky(new ScalarOf(fn() => time()));
+ *     $scalar = Sticky::ofScalar(new ScalarOf(fn() => time()));
  *     echo $scalar->value(); // computed once
  *     echo $scalar->value(); // cached value
  *
@@ -41,6 +46,19 @@ final class Sticky implements Scalar
      * @param Scalar<T> $origin The scalar whose value is cached.
      */
     public function __construct(private readonly Scalar $origin) {}
+
+    /**
+     * Memoises the value of a {@see Scalar}.
+     *
+     * @template U
+     * @param Scalar<U> $scalar The scalar whose value is cached.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function ofScalar(Scalar $scalar): self
+    {
+        return new self($scalar);
+    }
 
     #[Override]
     public function value()

--- a/src/Scalar/Ternary.php
+++ b/src/Scalar/Ternary.php
@@ -10,8 +10,13 @@ namespace Primus\Scalar;
  * Returns {@see $truthy} if {@see $condition} evaluates to true,
  * otherwise {@see $falsy}.
  *
+ * Construction forms:
+ *
+ * - `new Ternary(Scalar, Scalar, Scalar)` — wrap a condition and two branches.
+ * - `Ternary::ofScalars(Scalar, Scalar, Scalar)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $scalar = new Ternary(
+ *     $scalar = Ternary::ofScalars(
  *         new ScalarOf(fn() => 2 > 1),
  *         new Constant('yes'),
  *         new Constant('no')
@@ -37,5 +42,20 @@ final readonly class Ternary extends ScalarEnvelope
                 static fn() => $condition->value() ? $truthy->value() : $falsy->value(),
             ),
         );
+    }
+
+    /**
+     * Selects one of two {@see Scalar<T>} branches by a {@see Scalar<bool>}.
+     *
+     * @template U
+     * @param Scalar<bool> $condition The branching condition.
+     * @param Scalar<U> $truthy The value returned when condition is true.
+     * @param Scalar<U> $falsy The value returned when condition is false.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function ofScalars(Scalar $condition, Scalar $truthy, Scalar $falsy): self
+    {
+        return new self($condition, $truthy, $falsy);
     }
 }

--- a/src/Scalar/Xor_.php
+++ b/src/Scalar/Xor_.php
@@ -11,14 +11,19 @@ namespace Primus\Scalar;
  * AND and OR, XOR cannot short-circuit — every scalar must be inspected to
  * compute the parity. An empty argument list returns `false` (parity zero).
  *
+ * Construction forms:
+ *
+ * - `new Xor_(Scalar ...)` — wrap a variadic list of {@see Scalar<bool>}.
+ * - `Xor_::ofScalars(Scalar ...)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $xor = new Xor_(
+ *     $xor = Xor_::ofScalars(
  *         new Constant(true),
  *         new Constant(false),
  *     );
  *     echo $xor->value() ? 'odd' : 'even'; // 'odd'
  *
- *     (new Xor_())->value(); // false — empty parity
+ *     Xor_::ofScalars()->value(); // false — empty parity
  *
  * @extends ScalarEnvelope<bool>
  */
@@ -44,5 +49,16 @@ final readonly class Xor_ extends ScalarEnvelope
                 },
             ),
         );
+    }
+
+    /**
+     * Computes XOR parity over variadic {@see Scalar<bool>} conditions.
+     *
+     * @param Scalar<bool> ...$scalars The scalars to XOR together.
+     * @psalm-api
+     */
+    public static function ofScalars(Scalar ...$scalars): self
+    {
+        return new self(...$scalars);
     }
 }

--- a/tests/Scalar/And_Test.php
+++ b/tests/Scalar/And_Test.php
@@ -56,4 +56,36 @@ final class And_Test extends TestCase
             new HasScalarBoolValue(true),
         );
     }
+
+    #[Test]
+    public function ofScalarsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $a = new ScalarOf(static fn(): bool => true);
+        $b = new ScalarOf(static fn(): bool => false);
+
+        self::assertSame(
+            (new And_($a, $b))->value(),
+            And_::ofScalars($a, $b)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofScalarsFactoryAgreesWithPrimaryConstructorOnEmpty(): void
+    {
+        self::assertSame(
+            (new And_())->value(),
+            And_::ofScalars()->value(),
+        );
+    }
+
+    #[Test]
+    public function ofScalarsFactoryAgreesWithPrimaryConstructorOnSingleOperand(): void
+    {
+        $single = new ScalarOf(static fn(): bool => true);
+
+        self::assertSame(
+            (new And_($single))->value(),
+            And_::ofScalars($single)->value(),
+        );
+    }
 }

--- a/tests/Scalar/ConstantTest.php
+++ b/tests/Scalar/ConstantTest.php
@@ -35,4 +35,13 @@ final class ConstantTest extends TestCase
             'Constant must return the same value on subsequent calls'
         );
     }
+
+    #[Test]
+    public function ofValueFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new Constant('foo'))->value(),
+            Constant::ofValue('foo')->value(),
+        );
+    }
 }

--- a/tests/Scalar/NotTest.php
+++ b/tests/Scalar/NotTest.php
@@ -33,4 +33,15 @@ final class NotTest extends TestCase
             'Not must return true when the condition is false'
         );
     }
+
+    #[Test]
+    public function ofScalarFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $scalar = new ScalarOf(static fn(): bool => true);
+
+        self::assertSame(
+            (new Not($scalar))->value(),
+            Not::ofScalar($scalar)->value(),
+        );
+    }
 }

--- a/tests/Scalar/Or_Test.php
+++ b/tests/Scalar/Or_Test.php
@@ -56,4 +56,36 @@ final class Or_Test extends TestCase
             new HasScalarBoolValue(false),
         );
     }
+
+    #[Test]
+    public function ofScalarsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $a = new ScalarOf(static fn(): bool => false);
+        $b = new ScalarOf(static fn(): bool => true);
+
+        self::assertSame(
+            (new Or_($a, $b))->value(),
+            Or_::ofScalars($a, $b)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofScalarsFactoryAgreesWithPrimaryConstructorOnEmpty(): void
+    {
+        self::assertSame(
+            (new Or_())->value(),
+            Or_::ofScalars()->value(),
+        );
+    }
+
+    #[Test]
+    public function ofScalarsFactoryAgreesWithPrimaryConstructorOnSingleOperand(): void
+    {
+        $single = new ScalarOf(static fn(): bool => false);
+
+        self::assertSame(
+            (new Or_($single))->value(),
+            Or_::ofScalars($single)->value(),
+        );
+    }
 }

--- a/tests/Scalar/RootCauseTest.php
+++ b/tests/Scalar/RootCauseTest.php
@@ -16,7 +16,7 @@ final class RootCauseTest extends TestCase
     {
         $only = new RuntimeException('only');
 
-        $this->assertSame($only, (new RootCause($only))->value());
+        self::assertSame($only, (new RootCause($only))->value());
     }
 
     #[Test]
@@ -25,7 +25,7 @@ final class RootCauseTest extends TestCase
         $inner = new RuntimeException('inner');
         $outer = new RuntimeException('outer', 0, $inner);
 
-        $this->assertSame($inner, (new RootCause($outer))->value());
+        self::assertSame($inner, (new RootCause($outer))->value());
     }
 
     #[Test]
@@ -35,7 +35,7 @@ final class RootCauseTest extends TestCase
         $middle = new RuntimeException('middle', 0, $deepest);
         $outer = new RuntimeException('outer', 0, $middle);
 
-        $this->assertSame($deepest, (new RootCause($outer))->value());
+        self::assertSame($deepest, (new RootCause($outer))->value());
     }
 
     #[Test]
@@ -46,6 +46,18 @@ final class RootCauseTest extends TestCase
 
         $root = new RootCause($outer);
 
-        $this->assertSame($root->value(), $root->value());
+        self::assertSame($root->value(), $root->value());
+    }
+
+    #[Test]
+    public function ofThrowableFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $inner = new RuntimeException('inner');
+        $outer = new RuntimeException('outer', 0, $inner);
+
+        self::assertSame(
+            (new RootCause($outer))->value(),
+            RootCause::ofThrowable($outer)->value(),
+        );
     }
 }

--- a/tests/Scalar/ScalarOfTest.php
+++ b/tests/Scalar/ScalarOfTest.php
@@ -38,4 +38,15 @@ final class ScalarOfTest extends TestCase
             'ScalarOf must invoke the closure when value() is called'
         );
     }
+
+    #[Test]
+    public function closureFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $closure = static fn(): int => 42;
+
+        self::assertSame(
+            (new ScalarOf($closure))->value(),
+            ScalarOf::closure($closure)->value(),
+        );
+    }
 }

--- a/tests/Scalar/StickyTest.php
+++ b/tests/Scalar/StickyTest.php
@@ -35,4 +35,15 @@ final class StickyTest extends TestCase
             'Sticky must return the stored value'
         );
     }
+
+    #[Test]
+    public function ofScalarFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $scalar = new ScalarOf(static fn(): int => 42);
+
+        self::assertSame(
+            (new Sticky($scalar))->value(),
+            Sticky::ofScalar($scalar)->value(),
+        );
+    }
 }

--- a/tests/Scalar/TernaryTest.php
+++ b/tests/Scalar/TernaryTest.php
@@ -42,4 +42,17 @@ final class TernaryTest extends TestCase
             'Ternary must return the "no" value when the condition is false'
         );
     }
+
+    #[Test]
+    public function ofScalarsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $condition = new ScalarOf(static fn(): bool => true);
+        $truthy = new Constant('yes');
+        $falsy = new Constant('no');
+
+        self::assertSame(
+            (new Ternary($condition, $truthy, $falsy))->value(),
+            Ternary::ofScalars($condition, $truthy, $falsy)->value(),
+        );
+    }
 }

--- a/tests/Scalar/Xor_Test.php
+++ b/tests/Scalar/Xor_Test.php
@@ -73,4 +73,36 @@ final class Xor_Test extends TestCase
             new HasScalarBoolValue(false),
         );
     }
+
+    #[Test]
+    public function ofScalarsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $a = new ScalarOf(static fn(): bool => true);
+        $b = new ScalarOf(static fn(): bool => false);
+
+        self::assertSame(
+            (new Xor_($a, $b))->value(),
+            Xor_::ofScalars($a, $b)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofScalarsFactoryAgreesWithPrimaryConstructorOnEmpty(): void
+    {
+        self::assertSame(
+            (new Xor_())->value(),
+            Xor_::ofScalars()->value(),
+        );
+    }
+
+    #[Test]
+    public function ofScalarsFactoryAgreesWithPrimaryConstructorOnSingleOperand(): void
+    {
+        $single = new ScalarOf(static fn(): bool => true);
+
+        self::assertSame(
+            (new Xor_($single))->value(),
+            Xor_::ofScalars($single)->value(),
+        );
+    }
 }


### PR DESCRIPTION
- Added Scalar\And_::ofScalars, Or_::ofScalars, Xor_::ofScalars factories mirroring their variadic Scalar<bool> constructors.
- Added Scalar\Not::ofScalar, Sticky::ofScalar, RootCause::ofThrowable factories mirroring their unary primary constructors.
- Added Scalar\Constant::ofValue and Ternary::ofScalars factories mirroring their value and three-branch primary constructors.
- Added Scalar\ScalarOf::closure factory mirroring its Closure primary constructor.
- Updated class-level docblocks to list both construction forms and document each factory.

Part of #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added factory methods to scalar classes for more convenient and expressive object construction. Named constructor alternatives now available for And, Or, Xor, Not, Constant, Sticky, Ternary, RootCause, and ScalarOf.

* **Tests**
  * Expanded test coverage to verify factory methods produce consistent behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->