### PR TITLE
Named Constructor Mirrors For Scalar List-Based Classes

### DIFF
--- a/src/Scalar/FirstOf.php
+++ b/src/Scalar/FirstOf.php
@@ -13,8 +13,13 @@ use Primus\List\List_;
  * Walks the list lazily and returns the first item for which `$condition`
  * yields `true`. If no element matches, falls back to `$fallback->value()`.
  *
+ * Construction forms:
+ *
+ * - `new FirstOf(Func, List_, Scalar)` — wrap predicate, list and fallback.
+ * - `FirstOf::list(Func, List_, Scalar)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $first = new FirstOf(
+ *     $first = FirstOf::list(
  *         new FuncOf(fn (int $n): bool => $n > 5),
  *         new ListOf(1, 3, 7, 10),
  *         new Constant(0),
@@ -48,5 +53,20 @@ final readonly class FirstOf extends ScalarEnvelope
                 },
             ),
         );
+    }
+
+    /**
+     * Selects the first element in a list matching a predicate.
+     *
+     * @template U
+     * @param Func<U, bool> $predicate The predicate that selects the element.
+     * @param List_<U> $list The list to scan.
+     * @param Scalar<U> $fallback The value returned when no element matches.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function list(Func $predicate, List_ $list, Scalar $fallback): self
+    {
+        return new self($predicate, $list, $fallback);
     }
 }

--- a/src/Scalar/Folded.php
+++ b/src/Scalar/Folded.php
@@ -31,6 +31,11 @@ use Primus\List\List_;
  *     );
  *     echo $emptyDefaultsToSeed->value(); // 42
  *
+ * Construction forms:
+ *
+ * - `new Folded(Scalar, List_, BiFunc)` — wrap seed, list and reducer.
+ * - `Folded::ofSeed(Scalar, List_, BiFunc)` — named-constructor alias of the primary ctor.
+ *
  * @template X
  * @template T
  * @extends ScalarEnvelope<X>
@@ -59,5 +64,21 @@ final readonly class Folded extends ScalarEnvelope
                 },
             ),
         );
+    }
+
+    /**
+     * Left-folds a {@see List_} with an explicit seed accumulator.
+     *
+     * @template Y
+     * @template U
+     * @param Scalar<Y> $seed The initial accumulator value.
+     * @param List_<U> $list The list to fold.
+     * @param BiFunc<Y, U, Y> $reducer The accumulator function.
+     * @return self<Y, U>
+     * @psalm-api
+     */
+    public static function ofSeed(Scalar $seed, List_ $list, BiFunc $reducer): self
+    {
+        return new self($seed, $list, $reducer);
     }
 }

--- a/src/Scalar/HighestOf.php
+++ b/src/Scalar/HighestOf.php
@@ -18,11 +18,16 @@ use Primus\List\List_;
  * {@see \UnderflowException} on first projection — there is no neutral
  * element for "greatest".
  *
+ * Construction forms:
+ *
+ * - `new HighestOf(List_)` — wrap an existing {@see List_}.
+ * - `HighestOf::list(List_)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $top = new HighestOf(new ListOf(1, 7, 3, 5));
+ *     $top = HighestOf::list(new ListOf(1, 7, 3, 5));
  *     echo $top->value(); // 7
  *
- *     $latest = new HighestOf(new ListOf('apple', 'orange', 'banana'));
+ *     $latest = HighestOf::list(new ListOf('apple', 'orange', 'banana'));
  *     echo $latest->value(); // 'orange'
  *
  * @extends ScalarEnvelope<mixed>
@@ -49,5 +54,16 @@ final readonly class HighestOf extends ScalarEnvelope
                 }),
             ),
         );
+    }
+
+    /**
+     * Selects the greatest element of a {@see List_} of comparable values.
+     *
+     * @param List_<mixed> $list The list to scan.
+     * @psalm-api
+     */
+    public static function list(List_ $list): self
+    {
+        return new self($list);
     }
 }

--- a/src/Scalar/ItemAt.php
+++ b/src/Scalar/ItemAt.php
@@ -16,15 +16,20 @@ use Primus\List\List_;
  * rejected with {@see InvalidArgumentException} — use an explicit
  * `count(...) - n` expression if "from the end" is intended.
  *
+ * Construction forms:
+ *
+ * - `new ItemAt(int, List_, Scalar)` — wrap position, list and fallback.
+ * - `ItemAt::ofList(int, List_, Scalar)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $second = new ItemAt(
+ *     $second = ItemAt::ofList(
  *         1,
  *         new ListOf('a', 'b', 'c'),
  *         new Constant('-'),
  *     );
  *     echo $second->value(); // 'b'
  *
- *     $tenth = new ItemAt(
+ *     $tenth = ItemAt::ofList(
  *         10,
  *         new ListOf('a', 'b'),
  *         new Constant('-'),
@@ -68,5 +73,20 @@ final readonly class ItemAt extends ScalarEnvelope
                 },
             ),
         );
+    }
+
+    /**
+     * Selects the element at a zero-based position in a {@see List_}.
+     *
+     * @template U
+     * @param int $position The zero-based index of the element to return.
+     * @param List_<U> $list The list to look up the element in.
+     * @param Scalar<U> $fallback The value returned when the position is missing.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function ofList(int $position, List_ $list, Scalar $fallback): self
+    {
+        return new self($position, $list, $fallback);
     }
 }

--- a/src/Scalar/LowestOf.php
+++ b/src/Scalar/LowestOf.php
@@ -18,11 +18,16 @@ use Primus\List\List_;
  * {@see \UnderflowException} on first projection — there is no neutral
  * element for "smallest".
  *
+ * Construction forms:
+ *
+ * - `new LowestOf(List_)` — wrap an existing {@see List_}.
+ * - `LowestOf::list(List_)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $bottom = new LowestOf(new ListOf(7, 1, 3, 5));
+ *     $bottom = LowestOf::list(new ListOf(7, 1, 3, 5));
  *     echo $bottom->value(); // 1
  *
- *     $earliest = new LowestOf(new ListOf('orange', 'apple', 'banana'));
+ *     $earliest = LowestOf::list(new ListOf('orange', 'apple', 'banana'));
  *     echo $earliest->value(); // 'apple'
  *
  * @extends ScalarEnvelope<mixed>
@@ -49,5 +54,16 @@ final readonly class LowestOf extends ScalarEnvelope
                 }),
             ),
         );
+    }
+
+    /**
+     * Selects the smallest element of a {@see List_} of comparable values.
+     *
+     * @param List_<mixed> $list The list to scan.
+     * @psalm-api
+     */
+    public static function list(List_ $list): self
+    {
+        return new self($list);
     }
 }

--- a/src/Scalar/Reduced.php
+++ b/src/Scalar/Reduced.php
@@ -16,8 +16,13 @@ use UnderflowException;
  * An empty source raises {@see UnderflowException} on first projection —
  * there is no neutral element without an explicit seed.
  *
+ * Construction forms:
+ *
+ * - `new Reduced(List_, BiFunc)` — wrap list and reducer.
+ * - `Reduced::ofList(List_, BiFunc)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $sum = new Reduced(
+ *     $sum = Reduced::ofList(
  *         new ListOf(1, 2, 3, 4),
  *         new BiFuncOf(static fn(int $a, int $b): int => $a + $b),
  *     );
@@ -56,5 +61,19 @@ final readonly class Reduced extends ScalarEnvelope
                 },
             ),
         );
+    }
+
+    /**
+     * Left-folds a {@see List_} via a {@see BiFunc} accumulator without a seed.
+     *
+     * @template U
+     * @param List_<U> $list The list to fold.
+     * @param BiFunc<U, U, U> $reducer The accumulator function.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function ofList(List_ $list, BiFunc $reducer): self
+    {
+        return new self($list, $reducer);
     }
 }

--- a/tests/Scalar/FirstOfTest.php
+++ b/tests/Scalar/FirstOfTest.php
@@ -106,4 +106,17 @@ final class FirstOfTest extends TestCase
         self::assertSame(2, $first->value());
         self::assertSame(2, $visited);
     }
+
+    #[Test]
+    public function listFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $predicate = new FuncOf(static fn(int $n): bool => $n > 5);
+        $list = new ListOf(1, 3, 7, 10);
+        $fallback = new Constant(0);
+
+        self::assertSame(
+            (new FirstOf($predicate, $list, $fallback))->value(),
+            FirstOf::list($predicate, $list, $fallback)->value(),
+        );
+    }
 }

--- a/tests/Scalar/FoldedTest.php
+++ b/tests/Scalar/FoldedTest.php
@@ -117,4 +117,17 @@ final class FoldedTest extends TestCase
         self::assertSame(6, $folded->value());
         self::assertSame(3, $touched);
     }
+
+    #[Test]
+    public function ofSeedFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $seed = new Constant(0);
+        $list = new ListOf(1, 2, 3);
+        $reducer = new BiFuncOf(static fn(int $a, int $b): int => $a + $b);
+
+        self::assertSame(
+            (new Folded($seed, $list, $reducer))->value(),
+            Folded::ofSeed($seed, $list, $reducer)->value(),
+        );
+    }
 }

--- a/tests/Scalar/HighestOfTest.php
+++ b/tests/Scalar/HighestOfTest.php
@@ -98,4 +98,15 @@ final class HighestOfTest extends TestCase
         self::assertSame(3, $top->value());
         self::assertSame(3, $touched);
     }
+
+    #[Test]
+    public function listFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $list = new ListOf(1, 7, 3, 5);
+
+        self::assertSame(
+            (new HighestOf($list))->value(),
+            HighestOf::list($list)->value(),
+        );
+    }
 }

--- a/tests/Scalar/ItemAtTest.php
+++ b/tests/Scalar/ItemAtTest.php
@@ -111,4 +111,15 @@ final class ItemAtTest extends TestCase
         self::assertTrue($touched);
     }
 
+    #[Test]
+    public function ofListFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $list = new ListOf('a', 'b', 'c');
+        $fallback = new Constant('-');
+
+        self::assertSame(
+            (new ItemAt(1, $list, $fallback))->value(),
+            ItemAt::ofList(1, $list, $fallback)->value(),
+        );
+    }
 }

--- a/tests/Scalar/LowestOfTest.php
+++ b/tests/Scalar/LowestOfTest.php
@@ -98,4 +98,15 @@ final class LowestOfTest extends TestCase
         self::assertSame(1, $bottom->value());
         self::assertSame(3, $touched);
     }
+
+    #[Test]
+    public function listFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $list = new ListOf(7, 1, 3, 5);
+
+        self::assertSame(
+            (new LowestOf($list))->value(),
+            LowestOf::list($list)->value(),
+        );
+    }
 }

--- a/tests/Scalar/ReducedTest.php
+++ b/tests/Scalar/ReducedTest.php
@@ -109,4 +109,16 @@ final class ReducedTest extends TestCase
         self::assertSame(6, $sum->value());
         self::assertSame(3, $touched);
     }
+
+    #[Test]
+    public function ofListFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $list = new ListOf(1, 2, 3, 4);
+        $reducer = new BiFuncOf(static fn(int $a, int $b): int => $a + $b);
+
+        self::assertSame(
+            (new Reduced($list, $reducer))->value(),
+            Reduced::ofList($list, $reducer)->value(),
+        );
+    }
 }


### PR DESCRIPTION
- Added Scalar\FirstOf::list factory mirroring its predicate-driven list ctor.
- Added Scalar\Folded::ofSeed factory mirroring its seeded list-fold ctor.
- Added Scalar\HighestOf::list and Scalar\LowestOf::list factories mirroring their list-comparator ctors.
- Added Scalar\ItemAt::ofList factory mirroring its position-based list ctor.
- Added Scalar\Reduced::ofList factory mirroring its seed-less list-fold ctor.
- Updated class-level docblocks to list both construction forms and document each factory.

Part of #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced named-constructor aliases across multiple Scalar classes (`FirstOf::list()`, `Folded::ofSeed()`, `HighestOf::list()`, `ItemAt::ofList()`, `LowestOf::list()`, `Reduced::ofList()`), providing developers with alternative construction methods for improved code readability.

* **Tests**
  * Added test coverage to verify that named constructors produce identical results to primary constructors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->