### PR TITLE
Named Constructor Mirrors For List Classes

### DIFF
--- a/src/List/Chunks.php
+++ b/src/List/Chunks.php
@@ -14,8 +14,13 @@ use Override;
  * configured size. The last chunk holds the remainder when the origin
  * size is not a multiple of the configured size.
  *
+ * Construction forms:
+ *
+ * - `new Chunks(List_, int)` — wrap an existing {@see List_} and chunk size.
+ * - `Chunks::ofList(List_, int)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $list = new Chunks(new ListOf(1, 2, 3, 4, 5), 2);
+ *     $list = Chunks::ofList(new ListOf(1, 2, 3, 4, 5), 2);
  *     foreach ($list as $chunk) {
  *         echo '[' . implode(',', $chunk->value()) . ']';
  *     }
@@ -33,6 +38,20 @@ final readonly class Chunks implements List_
      * @param positive-int $size The size of each chunk; the last chunk may be smaller.
      */
     public function __construct(private List_ $origin, private int $size) {}
+
+    /**
+     * Partitions a {@see List_} into fixed-size sub-lists.
+     *
+     * @template U
+     * @param List_<U> $list The list to partition.
+     * @param positive-int $capacity The size of each chunk; the last chunk may be smaller.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function ofList(List_ $list, int $capacity): self
+    {
+        return new self($list, $capacity);
+    }
 
     #[Override]
     public function value(): array

--- a/src/List/Contains.php
+++ b/src/List/Contains.php
@@ -10,8 +10,13 @@ use Primus\Scalar\ScalarOf;
 /**
  * Tells whether a list contains a value, using strict equality.
  *
+ * Construction forms:
+ *
+ * - `new Contains(List_, mixed)` — wrap a {@see List_} and the needle.
+ * - `Contains::ofList(List_, mixed)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $scalar = new Contains(new ListOf(1, 2, 3), 2);
+ *     $scalar = Contains::ofList(new ListOf(1, 2, 3), 2);
  *     echo $scalar->value() ? 'yes' : 'no'; // yes
  *
  * @template T
@@ -30,5 +35,19 @@ final readonly class Contains extends ScalarEnvelope
         parent::__construct(
             new ScalarOf(static fn(): bool => in_array($value, $origin->value(), true)),
         );
+    }
+
+    /**
+     * Tells whether a {@see List_} contains a value, using strict equality.
+     *
+     * @template U
+     * @param List_<U> $list The list to search in.
+     * @param U $needle The value to look for.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function ofList(List_ $list, mixed $needle): self
+    {
+        return new self($list, $needle);
     }
 }

--- a/src/List/Filtered.php
+++ b/src/List/Filtered.php
@@ -11,8 +11,13 @@ use Primus\Func\Func;
 /**
  * List of elements that match a predicate.
  *
+ * Construction forms:
+ *
+ * - `new Filtered(List_, Func)` — wrap an existing {@see List_} and predicate.
+ * - `Filtered::ofList(List_, Func)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $list = new Filtered(
+ *     $list = Filtered::ofList(
  *         new ListOf(10, 5, 40, 3),
  *         new FuncOf(fn (int $x): bool => $x > 10),
  *     );
@@ -34,6 +39,20 @@ final readonly class Filtered extends ListEnvelope
     public function __construct(List_ $origin, private Func $predicate)
     {
         parent::__construct($origin);
+    }
+
+    /**
+     * Selects elements of a {@see List_} that match a predicate.
+     *
+     * @template U
+     * @param List_<U> $list The list whose elements are filtered.
+     * @param Func<U, bool> $selector The predicate that selects elements.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function ofList(List_ $list, Func $selector): self
+    {
+        return new self($list, $selector);
     }
 
     #[Override]

--- a/src/List/IndexOf.php
+++ b/src/List/IndexOf.php
@@ -11,8 +11,13 @@ use Primus\Scalar\ScalarOf;
 /**
  * Tells the position of the first strict-equal occurrence of a value in a list.
  *
+ * Construction forms:
+ *
+ * - `new IndexOf(List_, mixed)` — wrap a {@see List_} and the needle.
+ * - `IndexOf::list(List_, mixed)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $scalar = new IndexOf(new ListOf('a', 'b', 'c'), 'b');
+ *     $scalar = IndexOf::list(new ListOf('a', 'b', 'c'), 'b');
  *     echo $scalar->value(); // 1
  *
  * @template T
@@ -43,5 +48,19 @@ final readonly class IndexOf extends ScalarEnvelope
                 throw new OutOfBoundsException('Value not found in list');
             }),
         );
+    }
+
+    /**
+     * Locates the index of the first strict-equal occurrence of a value in a {@see List_}.
+     *
+     * @template U
+     * @param List_<U> $list The list to search in.
+     * @param U $needle The value to locate.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function list(List_ $list, mixed $needle): self
+    {
+        return new self($list, $needle);
     }
 }

--- a/src/List/Mapped.php
+++ b/src/List/Mapped.php
@@ -11,8 +11,13 @@ use Primus\Func\Func;
 /**
  * List with each element transformed by a function.
  *
+ * Construction forms:
+ *
+ * - `new Mapped(List_, Func)` — wrap an existing {@see List_} and mapper.
+ * - `Mapped::ofList(List_, Func)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $list = new Mapped(
+ *     $list = Mapped::ofList(
  *         new ListOf(1, 2, 3),
  *         new FuncOf(fn (int $x): int => $x * 10),
  *     );
@@ -34,6 +39,21 @@ final readonly class Mapped implements List_
      * @param Func<X, Y> $func The transformation function.
      */
     public function __construct(private List_ $origin, private Func $func) {}
+
+    /**
+     * Transforms each element of a {@see List_} through a {@see Func}.
+     *
+     * @template A
+     * @template B
+     * @param List_<A> $list The list whose elements are transformed.
+     * @param Func<A, B> $mapper The transformation function.
+     * @return self<A, B>
+     * @psalm-api
+     */
+    public static function ofList(List_ $list, Func $mapper): self
+    {
+        return new self($list, $mapper);
+    }
 
     #[Override]
     public function value(): array

--- a/src/List/Plucked.php
+++ b/src/List/Plucked.php
@@ -11,8 +11,13 @@ use Primus\RuntimeException;
 /**
  * List of values picked at a single key from every row of a source list of rows.
  *
+ * Construction forms:
+ *
+ * - `new Plucked(List_, int|string)` — wrap a list of rows and the column key.
+ * - `Plucked::ofList(List_, int|string)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $names = new Plucked(
+ *     $names = Plucked::ofList(
  *         new ListOf(
  *             ['id' => 1, 'name' => 'Alice'],
  *             ['id' => 2, 'name' => 'Bob'],
@@ -33,6 +38,20 @@ final readonly class Plucked implements List_
      * @param array-key $key Column key to pluck from every row.
      */
     public function __construct(private List_ $origin, private int|string $key) {}
+
+    /**
+     * Picks a column from every row of a {@see List_} of row arrays.
+     *
+     * @template U
+     * @param List_<array<array-key, U>> $list Source list of row arrays.
+     * @param array-key $column Column key to pluck from every row.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function ofList(List_ $list, int|string $column): self
+    {
+        return new self($list, $column);
+    }
 
     #[Override]
     public function value(): array

--- a/src/List/Sliced.php
+++ b/src/List/Sliced.php
@@ -15,8 +15,13 @@ use Override;
  * extends to the end, negative length stops that many positions before
  * the end.
  *
+ * Construction forms:
+ *
+ * - `new Sliced(List_, int, int = PHP_INT_MAX)` — wrap an existing {@see List_}, offset and length.
+ * - `Sliced::ofList(List_, int, int = PHP_INT_MAX)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $list = new Sliced(new ListOf(1, 2, 3, 4, 5), 1, 3);
+ *     $list = Sliced::ofList(new ListOf(1, 2, 3, 4, 5), 1, 3);
  *     foreach ($list as $value) {
  *         echo $value;
  *     }
@@ -40,6 +45,21 @@ final readonly class Sliced extends ListEnvelope
         private int $length = PHP_INT_MAX,
     ) {
         parent::__construct($origin);
+    }
+
+    /**
+     * Exposes a contiguous slice of a {@see List_}.
+     *
+     * @template U
+     * @param List_<U> $list The list to slice.
+     * @param int $start The starting position; negative counts from the end.
+     * @param int $count The maximum number of elements; defaults to extending to the end.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function ofList(List_ $list, int $start, int $count = PHP_INT_MAX): self
+    {
+        return new self($list, $start, $count);
     }
 
     #[Override]

--- a/src/List/SortedBy.php
+++ b/src/List/SortedBy.php
@@ -15,8 +15,13 @@ use Primus\Func\BiFunc;
  * or a positive integer when the first item should be ordered before, equal
  * to, or after the second item.
  *
+ * Construction forms:
+ *
+ * - `new SortedBy(List_, BiFunc)` — wrap an existing {@see List_} and comparator.
+ * - `SortedBy::ofList(List_, BiFunc)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $byLength = new SortedBy(
+ *     $byLength = SortedBy::ofList(
  *         new ListOf('alpha', 'pi', 'gamma'),
  *         new BiFuncOf(static fn(string $left, string $right): int
  *             => strlen($left) <=> strlen($right)),
@@ -37,6 +42,20 @@ final readonly class SortedBy extends ListEnvelope
     public function __construct(List_ $origin, private BiFunc $comparator)
     {
         parent::__construct($origin);
+    }
+
+    /**
+     * Orders a {@see List_} by an externally supplied pairwise comparator.
+     *
+     * @template U
+     * @param List_<U> $list The list to order.
+     * @param BiFunc<U, U, int> $order The pairwise comparator.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function ofList(List_ $list, BiFunc $order): self
+    {
+        return new self($list, $order);
     }
 
     #[Override]

--- a/tests/List/ChunksTest.php
+++ b/tests/List/ChunksTest.php
@@ -105,4 +105,15 @@ final class ChunksTest extends TestCase
     {
         $this->assertCount(3, new Chunks(new ListOf(1, 2, 3, 4, 5), 2));
     }
+
+    #[Test]
+    public function ofListFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $list = new ListOf(1, 2, 3, 4, 5);
+
+        self::assertEquals(
+            (new Chunks($list, 2))->value(),
+            Chunks::ofList($list, 2)->value(),
+        );
+    }
 }

--- a/tests/List/ContainsTest.php
+++ b/tests/List/ContainsTest.php
@@ -59,4 +59,15 @@ final class ContainsTest extends TestCase
             (new Contains(new ListOf(new \stdClass(), $object), $object))->value(),
         );
     }
+
+    #[Test]
+    public function ofListFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $list = new ListOf(1, 2, 3);
+
+        self::assertSame(
+            (new Contains($list, 2))->value(),
+            Contains::ofList($list, 2)->value(),
+        );
+    }
 }

--- a/tests/List/FilteredTest.php
+++ b/tests/List/FilteredTest.php
@@ -87,4 +87,16 @@ final class FilteredTest extends TestCase
             ))->value(),
         );
     }
+
+    #[Test]
+    public function ofListFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $list = new ListOf(1, 2, 3, 4);
+        $selector = new FuncOf(static fn(int $x): bool => $x > 2);
+
+        self::assertSame(
+            (new Filtered($list, $selector))->value(),
+            Filtered::ofList($list, $selector)->value(),
+        );
+    }
 }

--- a/tests/List/IndexOfTest.php
+++ b/tests/List/IndexOfTest.php
@@ -62,4 +62,15 @@ final class IndexOfTest extends TestCase
             (new IndexOf(new ListOf('start', 'middle', 'end'), 'start'))->value(),
         );
     }
+
+    #[Test]
+    public function listFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $list = new ListOf('start', 'middle', 'end');
+
+        self::assertSame(
+            (new IndexOf($list, 'middle'))->value(),
+            IndexOf::list($list, 'middle')->value(),
+        );
+    }
 }

--- a/tests/List/MappedTest.php
+++ b/tests/List/MappedTest.php
@@ -78,4 +78,16 @@ final class MappedTest extends TestCase
             ))->value(),
         );
     }
+
+    #[Test]
+    public function ofListFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $list = new ListOf(1, 2, 3);
+        $mapper = new FuncOf(static fn(int $x): int => $x * 10);
+
+        self::assertSame(
+            (new Mapped($list, $mapper))->value(),
+            Mapped::ofList($list, $mapper)->value(),
+        );
+    }
 }

--- a/tests/List/PluckedTest.php
+++ b/tests/List/PluckedTest.php
@@ -142,4 +142,18 @@ final class PluckedTest extends TestCase
         iterator_to_array($plucked);
         $this->assertSame($rows, $source->value());
     }
+
+    #[Test]
+    public function ofListFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $list = new ListOf(
+            ['name' => 'a'],
+            ['name' => 'b'],
+        );
+
+        self::assertSame(
+            (new Plucked($list, 'name'))->value(),
+            Plucked::ofList($list, 'name')->value(),
+        );
+    }
 }

--- a/tests/List/SlicedTest.php
+++ b/tests/List/SlicedTest.php
@@ -83,4 +83,15 @@ final class SlicedTest extends TestCase
         }
         $this->assertSame([2, 3], $collected);
     }
+
+    #[Test]
+    public function ofListFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $list = new ListOf(1, 2, 3, 4, 5);
+
+        self::assertSame(
+            (new Sliced($list, 1, 2))->value(),
+            Sliced::ofList($list, 1, 2)->value(),
+        );
+    }
 }

--- a/tests/List/SortedByTest.php
+++ b/tests/List/SortedByTest.php
@@ -99,4 +99,16 @@ final class SortedByTest extends TestCase
         iterator_to_array($sorted);
         $this->assertSame([3, 1, 2], $source->value());
     }
+
+    #[Test]
+    public function ofListFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $list = new ListOf(3, 1, 2);
+        $order = new BiFuncOf(static fn(int $left, int $right): int => $left <=> $right);
+
+        self::assertSame(
+            (new SortedBy($list, $order))->value(),
+            SortedBy::ofList($list, $order)->value(),
+        );
+    }
 }


### PR DESCRIPTION
- Added named factory mirrors to eight `List` classes with single construction form
- Added equivalence tests verifying each factory produces the same result as the primary constructor

Part of #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added named-constructor factory methods across several list-manipulation classes to offer alternative, clearer construction patterns for common operations.

* **Documentation**
  * Updated class documentation to list supported construction forms and examples using the new named constructors.

* **Tests**
  * Added tests ensuring each factory method produces identical results to the existing primary constructors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->