### PR TITLE
Named Constructor Mirrors For List Variadic Classes

### DIFF
--- a/src/List/Difference.php
+++ b/src/List/Difference.php
@@ -14,8 +14,13 @@ use Override;
  * are treated as different. Order and duplicates of the first origin
  * are preserved for kept values; keys are renumbered from zero.
  *
+ * Construction forms:
+ *
+ * - `new Difference(List_, List_, ...)` — wrap the first list and the excluded lists.
+ * - `Difference::ofLists(List_, List_, ...)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $list = new Difference(
+ *     $list = Difference::ofLists(
  *         new ListOf(1, 2, 3, 4),
  *         new ListOf(2, 4),
  *     );
@@ -41,6 +46,20 @@ final readonly class Difference implements List_
     public function __construct(private List_ $first, List_ ...$excluded)
     {
         $this->excluded = $excluded;
+    }
+
+    /**
+     * Subtracts values of one or more {@see List_} from the first list.
+     *
+     * @template U
+     * @param List_<U> $source The list to draw values from.
+     * @param List_<U> ...$removed Lists whose values remove matches from the source.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function ofLists(List_ $source, List_ ...$removed): self
+    {
+        return new self($source, ...$removed);
     }
 
     #[Override]

--- a/src/List/Intersection.php
+++ b/src/List/Intersection.php
@@ -14,8 +14,13 @@ use Override;
  * are treated as different. Order and duplicates of the first origin
  * are preserved for kept values; keys are renumbered from zero.
  *
+ * Construction forms:
+ *
+ * - `new Intersection(List_, List_, ...)` — wrap the first list and the others.
+ * - `Intersection::ofLists(List_, List_, ...)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $list = new Intersection(
+ *     $list = Intersection::ofLists(
  *         new ListOf(1, 2, 3, 4),
  *         new ListOf(2, 3, 5),
  *     );
@@ -41,6 +46,20 @@ final readonly class Intersection implements List_
     public function __construct(private List_ $first, List_ ...$others)
     {
         $this->others = $others;
+    }
+
+    /**
+     * Keeps values of the first {@see List_} that exist in every other list.
+     *
+     * @template U
+     * @param List_<U> $source The list to draw values from.
+     * @param List_<U> ...$required Lists whose values must contain a strict-equal copy.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function ofLists(List_ $source, List_ ...$required): self
+    {
+        return new self($source, ...$required);
     }
 
     #[Override]

--- a/src/List/Joined.php
+++ b/src/List/Joined.php
@@ -12,8 +12,13 @@ use Override;
  *
  * Element keys are reindexed as sequential integers starting at zero.
  *
+ * Construction forms:
+ *
+ * - `new Joined(List_, ...)` — wrap the source lists to concatenate.
+ * - `Joined::ofLists(List_, ...)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $joined = new Joined(
+ *     $joined = Joined::ofLists(
  *         new ListOf(1, 2),
  *         new ListOf(3, 4, 5),
  *     );
@@ -35,6 +40,19 @@ final readonly class Joined implements List_
     public function __construct(List_ ...$sources)
     {
         $this->sources = $sources;
+    }
+
+    /**
+     * Concatenates several {@see List_} into one in the order they were passed.
+     *
+     * @template U
+     * @param List_<U> ...$parts The lists to concatenate.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function ofLists(List_ ...$parts): self
+    {
+        return new self(...$parts);
     }
 
     #[Override]

--- a/src/List/ListOf.php
+++ b/src/List/ListOf.php
@@ -10,8 +10,13 @@ use Override;
 /**
  * List of given values.
  *
+ * Construction forms:
+ *
+ * - `new ListOf(mixed, ...)` — wrap the given values.
+ * - `ListOf::items(mixed, ...)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $list = new ListOf(1, 2, 3);
+ *     $list = ListOf::items(1, 2, 3);
  *     echo count($list); // 3
  *
  * @template T
@@ -30,6 +35,19 @@ final readonly class ListOf implements List_
     public function __construct(mixed ...$items)
     {
         $this->items = $items;
+    }
+
+    /**
+     * Wraps a variadic sequence of values into a {@see List_}.
+     *
+     * @template U
+     * @param U ...$values The values to wrap.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function items(mixed ...$values): self
+    {
+        return new self(...$values);
     }
 
     #[Override]

--- a/tests/List/DifferenceTest.php
+++ b/tests/List/DifferenceTest.php
@@ -123,4 +123,27 @@ final class DifferenceTest extends TestCase
             new Difference(new ListOf(1, 2, 3), new ListOf(2)),
         );
     }
+
+    #[Test]
+    public function ofListsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = new ListOf(1, 2, 3, 4);
+        $excluded = new ListOf(2, 4);
+
+        self::assertSame(
+            (new Difference($source, $excluded))->value(),
+            Difference::ofLists($source, $excluded)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofListsFactoryAgreesWithPrimaryConstructorWithoutExcluded(): void
+    {
+        $source = new ListOf(1, 2, 3);
+
+        self::assertSame(
+            (new Difference($source))->value(),
+            Difference::ofLists($source)->value(),
+        );
+    }
 }

--- a/tests/List/IntersectionTest.php
+++ b/tests/List/IntersectionTest.php
@@ -137,4 +137,27 @@ final class IntersectionTest extends TestCase
             new Intersection(new ListOf(1, 2, 3), new ListOf(2, 3, 4)),
         );
     }
+
+    #[Test]
+    public function ofListsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = new ListOf(1, 2, 3, 4);
+        $required = new ListOf(2, 3, 5);
+
+        self::assertSame(
+            (new Intersection($source, $required))->value(),
+            Intersection::ofLists($source, $required)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofListsFactoryAgreesWithPrimaryConstructorWithoutOthers(): void
+    {
+        $source = new ListOf(1, 2, 3);
+
+        self::assertSame(
+            (new Intersection($source))->value(),
+            Intersection::ofLists($source)->value(),
+        );
+    }
 }

--- a/tests/List/JoinedTest.php
+++ b/tests/List/JoinedTest.php
@@ -131,4 +131,25 @@ final class JoinedTest extends TestCase
             ))->value(),
         );
     }
+
+    #[Test]
+    public function ofListsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $a = new ListOf(1, 2);
+        $b = new ListOf(3, 4, 5);
+
+        self::assertSame(
+            (new Joined($a, $b))->value(),
+            Joined::ofLists($a, $b)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofListsFactoryAgreesWithPrimaryConstructorForNoSources(): void
+    {
+        self::assertSame(
+            (new Joined())->value(),
+            Joined::ofLists()->value(),
+        );
+    }
 }

--- a/tests/List/ListOfTest.php
+++ b/tests/List/ListOfTest.php
@@ -41,4 +41,33 @@ final class ListOfTest extends TestCase
     {
         $this->assertCount(0, new ListOf());
     }
+
+    #[Test]
+    public function itemsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new ListOf(1, 2, 3))->value(),
+            ListOf::items(1, 2, 3)->value(),
+        );
+    }
+
+    #[Test]
+    public function itemsFactoryAgreesWithPrimaryConstructorForMixedValues(): void
+    {
+        $object = new \stdClass();
+
+        self::assertSame(
+            (new ListOf(1, 'two', null, $object))->value(),
+            ListOf::items(1, 'two', null, $object)->value(),
+        );
+    }
+
+    #[Test]
+    public function itemsFactoryAgreesWithPrimaryConstructorForNoValues(): void
+    {
+        self::assertSame(
+            (new ListOf())->value(),
+            ListOf::items()->value(),
+        );
+    }
 }


### PR DESCRIPTION
- Added named factory mirrors to four List classes with variadic constructors
- Added equivalence tests covering empty variadic and single-source edge cases

Part of #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added named constructor factory methods to multiple List classes, providing alternative construction patterns for creating list objects.

* **Tests**
  * Added comprehensive test coverage validating the behavior of new factory methods across various scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->