### PR TITLE
Named Constructor Mirrors For List Decorators And Range

### DIFF
--- a/src/List/NoNulls.php
+++ b/src/List/NoNulls.php
@@ -14,11 +14,29 @@ use Primus\RuntimeException;
  * Iteration throws when the source list contains a null element,
  * enforcing a non-null invariant by failing fast.
  *
+ * Construction forms:
+ *
+ * - `new NoNulls(List_)` — wrap an existing {@see List_}.
+ * - `NoNulls::ofList(List_)` — named-constructor alias of the primary ctor.
+ *
  * @template T
  * @extends ListEnvelope<T>
  */
 final readonly class NoNulls extends ListEnvelope
 {
+    /**
+     * Forbids null values in a {@see List_}, throwing on iteration when one is found.
+     *
+     * @template U
+     * @param List_<U> $list The list to guard against nulls.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function ofList(List_ $list): self
+    {
+        return new self($list);
+    }
+
     #[Override]
     public function value(): array
     {

--- a/src/List/Range.php
+++ b/src/List/Range.php
@@ -15,8 +15,13 @@ use Override;
  * The step is always positive; it is the absolute distance between
  * consecutive elements.
  *
+ * Construction forms:
+ *
+ * - `new Range(int, int, int = 1)` — wrap start, end and step.
+ * - `Range::ofBounds(int, int, int = 1)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $list = new Range(1, 7, 2);
+ *     $list = Range::ofBounds(1, 7, 2);
  *     foreach ($list as $value) {
  *         echo $value;
  *     }
@@ -34,6 +39,19 @@ final readonly class Range implements List_
      * @param int $step The positive distance between consecutive values.
      */
     public function __construct(private int $start, private int $end, private int $step = 1) {}
+
+    /**
+     * Builds a finite arithmetic sequence of integers between two endpoints.
+     *
+     * @param int $from The first value of the sequence.
+     * @param int $upto The last reachable value not crossing the endpoint.
+     * @param int $stride The positive distance between consecutive values.
+     * @psalm-api
+     */
+    public static function ofBounds(int $from, int $upto, int $stride = 1): self
+    {
+        return new self($from, $upto, $stride);
+    }
 
     #[Override]
     public function value(): array

--- a/src/List/Reversed.php
+++ b/src/List/Reversed.php
@@ -10,8 +10,13 @@ use Override;
 /**
  * List with elements in reverse order.
  *
+ * Construction forms:
+ *
+ * - `new Reversed(List_)` — wrap an existing {@see List_}.
+ * - `Reversed::ofList(List_)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $list = new Reversed(new ListOf(1, 2, 3));
+ *     $list = Reversed::ofList(new ListOf(1, 2, 3));
  *     foreach ($list as $value) {
  *         echo $value;
  *     }
@@ -22,6 +27,19 @@ use Override;
  */
 final readonly class Reversed extends ListEnvelope
 {
+    /**
+     * Reverses element order of a {@see List_}.
+     *
+     * @template U
+     * @param List_<U> $list The list whose elements are reversed.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function ofList(List_ $list): self
+    {
+        return new self($list);
+    }
+
     #[Override]
     public function value(): array
     {

--- a/src/List/Sorted.php
+++ b/src/List/Sorted.php
@@ -13,8 +13,13 @@ use Override;
  * Uses PHP's spaceship operator on every pair, which yields ascending order
  * and stable ordering between equal items.
  *
+ * Construction forms:
+ *
+ * - `new Sorted(List_)` — wrap an existing {@see List_}.
+ * - `Sorted::ofList(List_)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $sorted = new Sorted(new ListOf(3, 1, 2));
+ *     $sorted = Sorted::ofList(new ListOf(3, 1, 2));
  *     // [1, 2, 3]
  *
  * @template T
@@ -22,6 +27,19 @@ use Override;
  */
 final readonly class Sorted extends ListEnvelope
 {
+    /**
+     * Sorts elements of a {@see List_} by PHP's spaceship comparison.
+     *
+     * @template U
+     * @param List_<U> $list The list whose elements are sorted.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function ofList(List_ $list): self
+    {
+        return new self($list);
+    }
+
     #[Override]
     public function value(): array
     {

--- a/src/List/Unique.php
+++ b/src/List/Unique.php
@@ -14,8 +14,13 @@ use Override;
  * occurrences are dropped. Values are compared with `===`, so `0` and
  * `'0'` are treated as different.
  *
+ * Construction forms:
+ *
+ * - `new Unique(List_)` — wrap an existing {@see List_}.
+ * - `Unique::ofList(List_)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $list = new Unique(new ListOf(1, 2, 1, 3, 2));
+ *     $list = Unique::ofList(new ListOf(1, 2, 1, 3, 2));
  *     foreach ($list as $value) {
  *         echo $value;
  *     }
@@ -26,6 +31,19 @@ use Override;
  */
 final readonly class Unique extends ListEnvelope
 {
+    /**
+     * Removes duplicate values from a {@see List_} using strict equality.
+     *
+     * @template U
+     * @param List_<U> $list The list to deduplicate.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function ofList(List_ $list): self
+    {
+        return new self($list);
+    }
+
     #[Override]
     public function value(): array
     {

--- a/tests/List/NoNullsTest.php
+++ b/tests/List/NoNullsTest.php
@@ -62,4 +62,15 @@ final class NoNullsTest extends TestCase
             (new Reversed(new NoNulls(new ListOf(1, 2, 3))))->value(),
         );
     }
+
+    #[Test]
+    public function ofListFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $list = new ListOf(1, 2, 3);
+
+        self::assertSame(
+            (new NoNulls($list))->value(),
+            NoNulls::ofList($list)->value(),
+        );
+    }
 }

--- a/tests/List/RangeTest.php
+++ b/tests/List/RangeTest.php
@@ -96,4 +96,31 @@ final class RangeTest extends TestCase
     {
         $this->assertCount(4, new Range(1, 7, 2));
     }
+
+    #[Test]
+    public function ofBoundsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new Range(1, 7, 2))->value(),
+            Range::ofBounds(1, 7, 2)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofBoundsFactoryAgreesWithPrimaryConstructorForDefaultStep(): void
+    {
+        self::assertSame(
+            (new Range(1, 5))->value(),
+            Range::ofBounds(1, 5)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofBoundsFactoryAgreesWithPrimaryConstructorForDescending(): void
+    {
+        self::assertSame(
+            (new Range(5, 1))->value(),
+            Range::ofBounds(5, 1)->value(),
+        );
+    }
 }

--- a/tests/List/ReversedTest.php
+++ b/tests/List/ReversedTest.php
@@ -57,4 +57,15 @@ final class ReversedTest extends TestCase
             (new Reversed(new Reversed(new ListOf(1, 2, 3))))->value(),
         );
     }
+
+    #[Test]
+    public function ofListFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $list = new ListOf(1, 2, 3);
+
+        self::assertSame(
+            (new Reversed($list))->value(),
+            Reversed::ofList($list)->value(),
+        );
+    }
 }

--- a/tests/List/SortedTest.php
+++ b/tests/List/SortedTest.php
@@ -82,4 +82,15 @@ final class SortedTest extends TestCase
             (new Reversed(new Sorted(new ListOf(3, 1, 4, 5, 2))))->value(),
         );
     }
+
+    #[Test]
+    public function ofListFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $list = new ListOf(3, 1, 2);
+
+        self::assertSame(
+            (new Sorted($list))->value(),
+            Sorted::ofList($list)->value(),
+        );
+    }
 }

--- a/tests/List/UniqueTest.php
+++ b/tests/List/UniqueTest.php
@@ -108,4 +108,15 @@ final class UniqueTest extends TestCase
 
         $this->expectNotToPerformAssertions();
     }
+
+    #[Test]
+    public function ofListFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $list = new ListOf(1, 2, 1, 3, 2);
+
+        self::assertSame(
+            (new Unique($list))->value(),
+            Unique::ofList($list)->value(),
+        );
+    }
 }


### PR DESCRIPTION
- Added named factory mirrors to four ListEnvelope-based decorators (NoNulls, Reversed, Sorted, Unique)
- Added named factory mirror to Range with rebound parameter names
- Added equivalence tests covering ascending, descending and default-step Range variants

Part of #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added convenience factory methods to List classes for streamlined object construction.

* **Documentation**
  * Enhanced class documentation with updated construction examples and available construction forms.

* **Tests**
  * Added comprehensive test coverage verifying new factory methods produce equivalent results to primary constructors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->