### PR TITLE
Named Constructor Mirrors For Map Single-Form Decorators

### DIFF
--- a/src/Map/Keys.php
+++ b/src/Map/Keys.php
@@ -11,8 +11,13 @@ use Primus\List\List_;
 /**
  * List of keys from a map.
  *
+ * Construction forms:
+ *
+ * - `new Keys(Map)` — wrap an existing {@see Map}.
+ * - `Keys::ofMap(Map)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $keys = new Keys(new MapOf(['a' => 1, 'b' => 2]));
+ *     $keys = Keys::ofMap(new MapOf(['a' => 1, 'b' => 2]));
  *     // ['a', 'b']
  *
  * @template K of array-key
@@ -27,6 +32,20 @@ final readonly class Keys implements List_
      * @param Map<K, V> $origin The map to read keys from.
      */
     public function __construct(private Map $origin) {}
+
+    /**
+     * Lists keys of a {@see Map}.
+     *
+     * @template L of array-key
+     * @template W
+     * @param Map<L, W> $map The map to read keys from.
+     * @return self<L, W>
+     * @psalm-api
+     */
+    public static function ofMap(Map $map): self
+    {
+        return new self($map);
+    }
 
     #[Override]
     public function value(): array

--- a/src/Map/Mapped.php
+++ b/src/Map/Mapped.php
@@ -11,8 +11,13 @@ use Primus\Func\Func;
 /**
  * Map with each value transformed by a function while preserving keys.
  *
+ * Construction forms:
+ *
+ * - `new Mapped(Map, Func)` — wrap an existing {@see Map} and the value mapper.
+ * - `Mapped::ofMap(Map, Func)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $map = new Mapped(
+ *     $map = Mapped::ofMap(
  *         new MapOf(['a' => 1, 'b' => 2]),
  *         new FuncOf(fn (int $v): int => $v * 10),
  *     );
@@ -35,6 +40,22 @@ final readonly class Mapped implements Map
      * @param Func<V, W> $func The transformation function.
      */
     public function __construct(private Map $origin, private Func $func) {}
+
+    /**
+     * Transforms each value of a {@see Map} through a {@see Func}, keeping keys.
+     *
+     * @template L of array-key
+     * @template A
+     * @template B
+     * @param Map<L, A> $map The map whose values are transformed.
+     * @param Func<A, B> $mapper The transformation function.
+     * @return self<L, A, B>
+     * @psalm-api
+     */
+    public static function ofMap(Map $map, Func $mapper): self
+    {
+        return new self($map, $mapper);
+    }
 
     #[Override]
     public function value(): array

--- a/src/Map/NoNulls.php
+++ b/src/Map/NoNulls.php
@@ -14,12 +14,31 @@ use Primus\RuntimeException;
  * Any access (value, count, foreach) throws when the source map contains
  * a null value, enforcing a non-null invariant by failing fast.
  *
+ * Construction forms:
+ *
+ * - `new NoNulls(Map)` — wrap an existing {@see Map}.
+ * - `NoNulls::ofMap(Map)` — named-constructor alias of the primary ctor.
+ *
  * @template K of array-key
  * @template V
  * @extends MapEnvelope<K, V>
  */
 final readonly class NoNulls extends MapEnvelope
 {
+    /**
+     * Forbids null values in a {@see Map}, throwing on access when one is found.
+     *
+     * @template L of array-key
+     * @template W
+     * @param Map<L, W> $map The map to guard against nulls.
+     * @return self<L, W>
+     * @psalm-api
+     */
+    public static function ofMap(Map $map): self
+    {
+        return new self($map);
+    }
+
     #[Override]
     public function value(): array
     {

--- a/src/Map/Sorted.php
+++ b/src/Map/Sorted.php
@@ -13,8 +13,13 @@ use Override;
  * Uses PHP's spaceship operator on every value pair, which yields ascending
  * order and stable ordering between pairs whose values compare equal.
  *
+ * Construction forms:
+ *
+ * - `new Sorted(Map)` — wrap an existing {@see Map}.
+ * - `Sorted::ofMap(Map)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $sorted = new Sorted(new MapOf(['b' => 3, 'a' => 1, 'c' => 2]));
+ *     $sorted = Sorted::ofMap(new MapOf(['b' => 3, 'a' => 1, 'c' => 2]));
  *     // ['a' => 1, 'c' => 2, 'b' => 3]
  *
  * @template K of array-key
@@ -23,6 +28,20 @@ use Override;
  */
 final readonly class Sorted extends MapEnvelope
 {
+    /**
+     * Sorts pairs of a {@see Map} by ascending value comparison, keys preserved.
+     *
+     * @template L of array-key
+     * @template W
+     * @param Map<L, W> $map The map whose pairs are sorted by value.
+     * @return self<L, W>
+     * @psalm-api
+     */
+    public static function ofMap(Map $map): self
+    {
+        return new self($map);
+    }
+
     #[Override]
     public function value(): array
     {

--- a/src/Map/Unique.php
+++ b/src/Map/Unique.php
@@ -15,8 +15,13 @@ use Override;
  * `===`, so `0` and `'0'` are treated as different. The kept entries
  * retain their original keys from the origin map.
  *
+ * Construction forms:
+ *
+ * - `new Unique(Map)` — wrap an existing {@see Map}.
+ * - `Unique::ofMap(Map)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $map = new Unique(new MapOf(['a' => 1, 'b' => 2, 'c' => 1]));
+ *     $map = Unique::ofMap(new MapOf(['a' => 1, 'b' => 2, 'c' => 1]));
  *     foreach ($map as $key => $value) {
  *         echo "$key=$value ";
  *     }
@@ -28,6 +33,20 @@ use Override;
  */
 final readonly class Unique extends MapEnvelope
 {
+    /**
+     * Removes duplicate values from a {@see Map} using strict equality, keys preserved.
+     *
+     * @template L of array-key
+     * @template W
+     * @param Map<L, W> $map The map to deduplicate.
+     * @return self<L, W>
+     * @psalm-api
+     */
+    public static function ofMap(Map $map): self
+    {
+        return new self($map);
+    }
+
     #[Override]
     public function value(): array
     {

--- a/src/Map/Values.php
+++ b/src/Map/Values.php
@@ -11,8 +11,13 @@ use Primus\List\List_;
 /**
  * List of values from a map.
  *
+ * Construction forms:
+ *
+ * - `new Values(Map)` — wrap an existing {@see Map}.
+ * - `Values::ofMap(Map)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $values = new Values(new MapOf(['a' => 1, 'b' => 2]));
+ *     $values = Values::ofMap(new MapOf(['a' => 1, 'b' => 2]));
  *     // [1, 2]
  *
  * @template K of array-key
@@ -27,6 +32,20 @@ final readonly class Values implements List_
      * @param Map<K, V> $origin The map to read values from.
      */
     public function __construct(private Map $origin) {}
+
+    /**
+     * Lists values of a {@see Map}.
+     *
+     * @template L of array-key
+     * @template W
+     * @param Map<L, W> $map The map to read values from.
+     * @return self<L, W>
+     * @psalm-api
+     */
+    public static function ofMap(Map $map): self
+    {
+        return new self($map);
+    }
 
     #[Override]
     public function value(): array

--- a/tests/Map/KeysTest.php
+++ b/tests/Map/KeysTest.php
@@ -68,4 +68,15 @@ final class KeysTest extends TestCase
         iterator_to_array($keys);
         $this->assertSame(['a' => 1, 'b' => 2], $source->value());
     }
+
+    #[Test]
+    public function ofMapFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $map = new MapOf(['a' => 1, 'b' => 2]);
+
+        self::assertSame(
+            (new Keys($map))->value(),
+            Keys::ofMap($map)->value(),
+        );
+    }
 }

--- a/tests/Map/MappedTest.php
+++ b/tests/Map/MappedTest.php
@@ -91,4 +91,16 @@ final class MappedTest extends TestCase
             ),
         );
     }
+
+    #[Test]
+    public function ofMapFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $map = new MapOf(['a' => 1, 'b' => 2]);
+        $mapper = new FuncOf(static fn(int $v): int => $v * 10);
+
+        self::assertSame(
+            (new Mapped($map, $mapper))->value(),
+            Mapped::ofMap($map, $mapper)->value(),
+        );
+    }
 }

--- a/tests/Map/NoNullsTest.php
+++ b/tests/Map/NoNullsTest.php
@@ -61,4 +61,15 @@ final class NoNullsTest extends TestCase
             (new NoNulls(new NoNulls(new MapOf(['a' => 1, 'b' => 2]))))->value(),
         );
     }
+
+    #[Test]
+    public function ofMapFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $map = new MapOf(['a' => 1, 'b' => 2]);
+
+        self::assertSame(
+            (new NoNulls($map))->value(),
+            NoNulls::ofMap($map)->value(),
+        );
+    }
 }

--- a/tests/Map/SortedTest.php
+++ b/tests/Map/SortedTest.php
@@ -72,4 +72,15 @@ final class SortedTest extends TestCase
         iterator_to_array($sorted);
         $this->assertSame(['b' => 3, 'a' => 1, 'c' => 2], $source->value());
     }
+
+    #[Test]
+    public function ofMapFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $map = new MapOf(['b' => 3, 'a' => 1, 'c' => 2]);
+
+        self::assertSame(
+            (new Sorted($map))->value(),
+            Sorted::ofMap($map)->value(),
+        );
+    }
 }

--- a/tests/Map/UniqueTest.php
+++ b/tests/Map/UniqueTest.php
@@ -80,4 +80,15 @@ final class UniqueTest extends TestCase
     {
         $this->assertCount(2, new Unique(new MapOf(['a' => 1, 'b' => 1, 'c' => 2])));
     }
+
+    #[Test]
+    public function ofMapFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $map = new MapOf(['a' => 1, 'b' => 1, 'c' => 2]);
+
+        self::assertSame(
+            (new Unique($map))->value(),
+            Unique::ofMap($map)->value(),
+        );
+    }
 }

--- a/tests/Map/ValuesTest.php
+++ b/tests/Map/ValuesTest.php
@@ -77,4 +77,15 @@ final class ValuesTest extends TestCase
         iterator_to_array($values);
         $this->assertSame(['a' => 1, 'b' => 2], $source->value());
     }
+
+    #[Test]
+    public function ofMapFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $map = new MapOf(['a' => 1, 'b' => 2]);
+
+        self::assertSame(
+            (new Values($map))->value(),
+            Values::ofMap($map)->value(),
+        );
+    }
 }


### PR DESCRIPTION
- Added named factory mirrors to six Map classes with single-form constructors (NoNulls, Sorted, Unique, Keys, Values, Mapped)
- Added equivalence tests verifying each factory produces the same result as the primary constructor

Part of #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added named constructor factory methods (`::ofMap()`) to Map wrapper classes (Keys, Mapped, NoNulls, Sorted, Unique, Values).

* **Documentation**
  * Updated documentation to describe alternative construction forms for Map wrapper classes.

* **Tests**
  * Added test coverage verifying factory methods produce identical results to primary constructors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->