### PR TITLE
Named Constructor Mirrors For Map Variadic Classes And MapOf

### DIFF
--- a/src/Map/Diff.php
+++ b/src/Map/Diff.php
@@ -10,8 +10,13 @@ use Override;
 /**
  * Map keeping pairs of the first source whose keys are absent from all other sources.
  *
+ * Construction forms:
+ *
+ * - `new Diff(Map, Map, ...)` — wrap the first map and the excluded maps.
+ * - `Diff::ofMaps(Map, Map, ...)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $diff = new Diff(
+ *     $diff = Diff::ofMaps(
  *         new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
  *         new MapOf(['b' => 99]),
  *         new MapOf(['c' => 0]),
@@ -36,6 +41,21 @@ final readonly class Diff implements Map
     public function __construct(private Map $first, Map ...$excluded)
     {
         $this->excluded = $excluded;
+    }
+
+    /**
+     * Subtracts pairs whose keys appear in any other {@see Map} from the first map.
+     *
+     * @template L of array-key
+     * @template W
+     * @param Map<L, W> $source The map to draw pairs from.
+     * @param Map<L, mixed> ...$removed Maps whose keys remove pairs from the source.
+     * @return self<L, W>
+     * @psalm-api
+     */
+    public static function ofMaps(Map $source, Map ...$removed): self
+    {
+        return new self($source, ...$removed);
     }
 
     #[Override]

--- a/src/Map/DiffAssoc.php
+++ b/src/Map/DiffAssoc.php
@@ -15,8 +15,13 @@ use Override;
  * pairs where another origin holds the same key with a strict-equal
  * value are dropped; same key with a different value is kept.
  *
+ * Construction forms:
+ *
+ * - `new DiffAssoc(Map, Map, ...)` — wrap the first map and the excluded maps.
+ * - `DiffAssoc::ofMaps(Map, Map, ...)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $map = new DiffAssoc(
+ *     $map = DiffAssoc::ofMaps(
  *         new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
  *         new MapOf(['a' => 1, 'b' => 99]),
  *     );
@@ -43,6 +48,21 @@ final readonly class DiffAssoc implements Map
     public function __construct(private Map $first, Map ...$excluded)
     {
         $this->excluded = $excluded;
+    }
+
+    /**
+     * Subtracts pairs whose key/value matches any other {@see Map} from the first map.
+     *
+     * @template L of array-key
+     * @template W
+     * @param Map<L, W> $source The map to draw pairs from.
+     * @param Map<L, W> ...$removed Maps whose key/value pairs remove matches from the source.
+     * @return self<L, W>
+     * @psalm-api
+     */
+    public static function ofMaps(Map $source, Map ...$removed): self
+    {
+        return new self($source, ...$removed);
     }
 
     #[Override]

--- a/src/Map/Intersect.php
+++ b/src/Map/Intersect.php
@@ -10,8 +10,13 @@ use Override;
 /**
  * Map keeping pairs of the first source whose keys are present in every other source.
  *
+ * Construction forms:
+ *
+ * - `new Intersect(Map, Map, ...)` — wrap the first map and the required maps.
+ * - `Intersect::ofMaps(Map, Map, ...)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $intersect = new Intersect(
+ *     $intersect = Intersect::ofMaps(
  *         new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
  *         new MapOf(['b' => 99, 'c' => 0]),
  *         new MapOf(['c' => 7, 'd' => 1]),
@@ -36,6 +41,21 @@ final readonly class Intersect implements Map
     public function __construct(private Map $first, Map ...$required)
     {
         $this->required = $required;
+    }
+
+    /**
+     * Keeps pairs whose keys exist in every other {@see Map}.
+     *
+     * @template L of array-key
+     * @template W
+     * @param Map<L, W> $source The map to draw pairs from.
+     * @param Map<L, mixed> ...$pinned Maps whose keys must contain a source key for it to be kept.
+     * @return self<L, W>
+     * @psalm-api
+     */
+    public static function ofMaps(Map $source, Map ...$pinned): self
+    {
+        return new self($source, ...$pinned);
     }
 
     #[Override]

--- a/src/Map/IntersectAssoc.php
+++ b/src/Map/IntersectAssoc.php
@@ -15,8 +15,13 @@ use Override;
  * origin holds the same key with a strict-equal value; same key with
  * a different value drops the pair.
  *
+ * Construction forms:
+ *
+ * - `new IntersectAssoc(Map, Map, ...)` — wrap the first map and the others.
+ * - `IntersectAssoc::ofMaps(Map, Map, ...)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $map = new IntersectAssoc(
+ *     $map = IntersectAssoc::ofMaps(
  *         new MapOf(['a' => 1, 'b' => 2, 'c' => 3]),
  *         new MapOf(['a' => 1, 'b' => 99, 'c' => 3]),
  *     );
@@ -43,6 +48,21 @@ final readonly class IntersectAssoc implements Map
     public function __construct(private Map $first, Map ...$others)
     {
         $this->others = $others;
+    }
+
+    /**
+     * Keeps pairs whose key/value exists in every other {@see Map}.
+     *
+     * @template L of array-key
+     * @template W
+     * @param Map<L, W> $source The map to draw pairs from.
+     * @param Map<L, W> ...$matched Maps whose key/value pairs must contain a strict-equal copy.
+     * @return self<L, W>
+     * @psalm-api
+     */
+    public static function ofMaps(Map $source, Map ...$matched): self
+    {
+        return new self($source, ...$matched);
     }
 
     #[Override]

--- a/src/Map/MapOf.php
+++ b/src/Map/MapOf.php
@@ -10,8 +10,13 @@ use Override;
 /**
  * Map built from an associative array.
  *
+ * Construction forms:
+ *
+ * - `new MapOf(array)` — wrap the given associative array.
+ * - `MapOf::pairs(array)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $map = new MapOf(['a' => 1, 'b' => 2]);
+ *     $map = MapOf::pairs(['a' => 1, 'b' => 2]);
  *     echo count($map); // 2
  *
  * @template K of array-key
@@ -26,6 +31,20 @@ final readonly class MapOf implements Map
      * @param array<K, V> $pairs The associative array to wrap.
      */
     public function __construct(private array $pairs) {}
+
+    /**
+     * Wraps an associative array into a {@see Map}.
+     *
+     * @template L of array-key
+     * @template W
+     * @param array<L, W> $entries The associative array to wrap.
+     * @return self<L, W>
+     * @psalm-api
+     */
+    public static function pairs(array $entries): self
+    {
+        return new self($entries);
+    }
 
     #[Override]
     public function value(): array

--- a/src/Map/Merged.php
+++ b/src/Map/Merged.php
@@ -10,8 +10,13 @@ use Override;
 /**
  * Map merged from several source maps with last-wins precedence on key conflicts.
  *
+ * Construction forms:
+ *
+ * - `new Merged(Map, ...)` — wrap the source maps to merge.
+ * - `Merged::ofMaps(Map, ...)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $merged = new Merged(
+ *     $merged = Merged::ofMaps(
  *         new MapOf(['a' => 1, 'b' => 2]),
  *         new MapOf(['b' => 99, 'c' => 3]),
  *     );
@@ -34,6 +39,20 @@ final readonly class Merged implements Map
     public function __construct(Map ...$sources)
     {
         $this->sources = $sources;
+    }
+
+    /**
+     * Merges several {@see Map} into one with last-wins precedence on key conflicts.
+     *
+     * @template L of array-key
+     * @template W
+     * @param Map<L, W> ...$parts The maps to merge; later sources override earlier ones.
+     * @return self<L, W>
+     * @psalm-api
+     */
+    public static function ofMaps(Map ...$parts): self
+    {
+        return new self(...$parts);
     }
 
     #[Override]

--- a/tests/Map/DiffAssocTest.php
+++ b/tests/Map/DiffAssocTest.php
@@ -129,4 +129,27 @@ final class DiffAssocTest extends TestCase
             ),
         );
     }
+
+    #[Test]
+    public function ofMapsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = new MapOf(['a' => 1, 'b' => 2, 'c' => 3]);
+        $excluded = new MapOf(['a' => 1, 'b' => 99]);
+
+        self::assertSame(
+            (new DiffAssoc($source, $excluded))->value(),
+            DiffAssoc::ofMaps($source, $excluded)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofMapsFactoryAgreesWithPrimaryConstructorWithoutExcluded(): void
+    {
+        $source = new MapOf(['a' => 1, 'b' => 2]);
+
+        self::assertSame(
+            (new DiffAssoc($source))->value(),
+            DiffAssoc::ofMaps($source)->value(),
+        );
+    }
 }

--- a/tests/Map/DiffTest.php
+++ b/tests/Map/DiffTest.php
@@ -141,4 +141,27 @@ final class DiffTest extends TestCase
         $this->assertSame(['a' => 1, 'b' => 2], $first->value());
         $this->assertSame(['b' => 99], $excluded->value());
     }
+
+    #[Test]
+    public function ofMapsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = new MapOf(['a' => 1, 'b' => 2, 'c' => 3]);
+        $excluded = new MapOf(['b' => 99]);
+
+        self::assertSame(
+            (new Diff($source, $excluded))->value(),
+            Diff::ofMaps($source, $excluded)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofMapsFactoryAgreesWithPrimaryConstructorWithoutExcluded(): void
+    {
+        $source = new MapOf(['a' => 1, 'b' => 2]);
+
+        self::assertSame(
+            (new Diff($source))->value(),
+            Diff::ofMaps($source)->value(),
+        );
+    }
 }

--- a/tests/Map/IntersectAssocTest.php
+++ b/tests/Map/IntersectAssocTest.php
@@ -143,4 +143,27 @@ final class IntersectAssocTest extends TestCase
             ),
         );
     }
+
+    #[Test]
+    public function ofMapsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = new MapOf(['a' => 1, 'b' => 2, 'c' => 3]);
+        $matched = new MapOf(['a' => 1, 'b' => 99, 'c' => 3]);
+
+        self::assertSame(
+            (new IntersectAssoc($source, $matched))->value(),
+            IntersectAssoc::ofMaps($source, $matched)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofMapsFactoryAgreesWithPrimaryConstructorWithoutMatched(): void
+    {
+        $source = new MapOf(['a' => 1, 'b' => 2]);
+
+        self::assertSame(
+            (new IntersectAssoc($source))->value(),
+            IntersectAssoc::ofMaps($source)->value(),
+        );
+    }
 }

--- a/tests/Map/IntersectTest.php
+++ b/tests/Map/IntersectTest.php
@@ -141,4 +141,27 @@ final class IntersectTest extends TestCase
         $this->assertSame(['a' => 1, 'b' => 2], $first->value());
         $this->assertSame(['b' => 99], $required->value());
     }
+
+    #[Test]
+    public function ofMapsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = new MapOf(['a' => 1, 'b' => 2, 'c' => 3]);
+        $pinned = new MapOf(['b' => 99, 'c' => 0]);
+
+        self::assertSame(
+            (new Intersect($source, $pinned))->value(),
+            Intersect::ofMaps($source, $pinned)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofMapsFactoryAgreesWithPrimaryConstructorWithoutPinned(): void
+    {
+        $source = new MapOf(['a' => 1, 'b' => 2]);
+
+        self::assertSame(
+            (new Intersect($source))->value(),
+            Intersect::ofMaps($source)->value(),
+        );
+    }
 }

--- a/tests/Map/MapOfTest.php
+++ b/tests/Map/MapOfTest.php
@@ -40,4 +40,22 @@ final class MapOfTest extends TestCase
     {
         $this->assertCount(0, new MapOf([]));
     }
+
+    #[Test]
+    public function pairsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new MapOf(['a' => 1, 'b' => 2]))->value(),
+            MapOf::pairs(['a' => 1, 'b' => 2])->value(),
+        );
+    }
+
+    #[Test]
+    public function pairsFactoryAgreesWithPrimaryConstructorForEmpty(): void
+    {
+        self::assertSame(
+            (new MapOf([]))->value(),
+            MapOf::pairs([])->value(),
+        );
+    }
 }

--- a/tests/Map/MergedTest.php
+++ b/tests/Map/MergedTest.php
@@ -92,4 +92,25 @@ final class MergedTest extends TestCase
             ))->value(),
         );
     }
+
+    #[Test]
+    public function ofMapsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $a = new MapOf(['a' => 1, 'b' => 2]);
+        $b = new MapOf(['b' => 99, 'c' => 3]);
+
+        self::assertSame(
+            (new Merged($a, $b))->value(),
+            Merged::ofMaps($a, $b)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofMapsFactoryAgreesWithPrimaryConstructorForNoSources(): void
+    {
+        self::assertSame(
+            (new Merged())->value(),
+            Merged::ofMaps()->value(),
+        );
+    }
 }


### PR DESCRIPTION
- Added named factory mirrors to five Map classes with variadic constructors (Diff, DiffAssoc, Intersect, IntersectAssoc, Merged)
- Added named factory mirror to MapOf for direct array wrapping
- Added equivalence tests covering empty variadic and empty-array edge cases

Part of #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map classes now support alternative named constructor methods for more readable object construction across multiple classes (Diff, DiffAssoc, Intersect, IntersectAssoc, MapOf, and Merged).

* **Tests**
  * Added comprehensive test coverage verifying that new factory methods produce equivalent results to primary constructors across all affected Map classes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->