### PR TITLE
Named Constructor Mirrors For Remaining Map Decorators

### DIFF
--- a/src/Map/BiFiltered.php
+++ b/src/Map/BiFiltered.php
@@ -11,8 +11,13 @@ use Primus\Func\BiFunc;
 /**
  * Map of pairs whose key and value match a function.
  *
+ * Construction forms:
+ *
+ * - `new BiFiltered(Map, BiFunc)` — wrap an existing {@see Map} and pair predicate.
+ * - `BiFiltered::ofMap(Map, BiFunc)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $map = new BiFiltered(
+ *     $map = BiFiltered::ofMap(
  *         new MapOf(['adult' => 19, 'minor' => 12]),
  *         new BiFuncOf(fn (string $key, int $value): bool => $key === 'adult' && $value >= 18),
  *     );
@@ -36,6 +41,21 @@ final readonly class BiFiltered extends MapEnvelope
     public function __construct(Map $origin, private BiFunc $predicate)
     {
         parent::__construct($origin);
+    }
+
+    /**
+     * Selects pairs of a {@see Map} whose key and value match a predicate.
+     *
+     * @template L of array-key
+     * @template W
+     * @param Map<L, W> $map The map whose pairs are filtered.
+     * @param BiFunc<L, W, bool> $selector The function that selects pairs.
+     * @return self<L, W>
+     * @psalm-api
+     */
+    public static function ofMap(Map $map, BiFunc $selector): self
+    {
+        return new self($map, $selector);
     }
 
     #[Override]

--- a/src/Map/BiMapped.php
+++ b/src/Map/BiMapped.php
@@ -11,8 +11,13 @@ use Primus\Func\BiFunc;
 /**
  * Map with each value transformed by a function of key and value while preserving keys.
  *
+ * Construction forms:
+ *
+ * - `new BiMapped(Map, BiFunc)` — wrap an existing {@see Map} and pair mapper.
+ * - `BiMapped::ofMap(Map, BiFunc)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $map = new BiMapped(
+ *     $map = BiMapped::ofMap(
  *         new MapOf(['a' => 1, 'b' => 2]),
  *         new BiFuncOf(fn (string $key, int $value): string => "$key=$value"),
  *     );
@@ -35,6 +40,22 @@ final readonly class BiMapped implements Map
      * @param BiFunc<K, V, W> $func The transformation function.
      */
     public function __construct(private Map $origin, private BiFunc $func) {}
+
+    /**
+     * Transforms each value of a {@see Map} through a key/value {@see BiFunc}, keeping keys.
+     *
+     * @template L of array-key
+     * @template A
+     * @template B
+     * @param Map<L, A> $map The map whose values are transformed.
+     * @param BiFunc<L, A, B> $mapper The transformation function.
+     * @return self<L, A, B>
+     * @psalm-api
+     */
+    public static function ofMap(Map $map, BiFunc $mapper): self
+    {
+        return new self($map, $mapper);
+    }
 
     #[Override]
     public function value(): array

--- a/src/Map/Combined.php
+++ b/src/Map/Combined.php
@@ -15,8 +15,13 @@ use Primus\RuntimeException;
  * Pairs are formed by zipping the keys list with the values list at the same positions.
  * Sources of different lengths fail fast on first observation.
  *
+ * Construction forms:
+ *
+ * - `new Combined(List_, List_)` — wrap the keys list and the values list.
+ * - `Combined::ofLists(List_, List_)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $map = new Combined(
+ *     $map = Combined::ofLists(
  *         new ListOf('a', 'b', 'c'),
  *         new ListOf(1, 2, 3),
  *     );
@@ -34,6 +39,20 @@ final readonly class Combined implements Map
      * @param List_<V> $values Source list of values, parallel to $keys.
      */
     public function __construct(private List_ $keys, private List_ $values) {}
+
+    /**
+     * Zips a list of keys with a parallel list of values into a {@see Map}.
+     *
+     * @template W
+     * @param List_<array-key> $names Source list of keys.
+     * @param List_<W> $items Source list of values, parallel to $names.
+     * @return self<W>
+     * @psalm-api
+     */
+    public static function ofLists(List_ $names, List_ $items): self
+    {
+        return new self($names, $items);
+    }
 
     #[Override]
     public function value(): array

--- a/src/Map/Filtered.php
+++ b/src/Map/Filtered.php
@@ -11,8 +11,13 @@ use Primus\Func\Func;
 /**
  * Map of pairs whose values match a predicate.
  *
+ * Construction forms:
+ *
+ * - `new Filtered(Map, Func)` — wrap an existing {@see Map} and value predicate.
+ * - `Filtered::ofMap(Map, Func)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $map = new Filtered(
+ *     $map = Filtered::ofMap(
  *         new MapOf(['a' => 10, 'b' => 5, 'c' => 40]),
  *         new FuncOf(fn (int $v): bool => $v > 10),
  *     );
@@ -36,6 +41,21 @@ final readonly class Filtered extends MapEnvelope
     public function __construct(Map $origin, private Func $predicate)
     {
         parent::__construct($origin);
+    }
+
+    /**
+     * Selects pairs of a {@see Map} whose values match a predicate.
+     *
+     * @template L of array-key
+     * @template W
+     * @param Map<L, W> $map The map whose pairs are filtered.
+     * @param Func<W, bool> $selector The predicate that selects values.
+     * @return self<L, W>
+     * @psalm-api
+     */
+    public static function ofMap(Map $map, Func $selector): self
+    {
+        return new self($map, $selector);
     }
 
     #[Override]

--- a/src/Map/PluckedBy.php
+++ b/src/Map/PluckedBy.php
@@ -12,8 +12,13 @@ use Primus\RuntimeException;
 /**
  * Map of pairs picked from row arrays where the index column supplies keys and the value column supplies values.
  *
+ * Construction forms:
+ *
+ * - `new PluckedBy(List_, int|string, int|string)` — wrap a list of rows with key and value columns.
+ * - `PluckedBy::ofList(List_, int|string, int|string)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $byId = new PluckedBy(
+ *     $byId = PluckedBy::ofList(
  *         new ListOf(
  *             ['id' => 1, 'name' => 'Alice'],
  *             ['id' => 2, 'name' => 'Bob'],
@@ -40,6 +45,20 @@ final readonly class PluckedBy implements Map
         private int|string $index,
         private int|string $column,
     ) {}
+
+    /**
+     * Picks pairs from rows in a {@see List_} using an index column for keys and a value column for values.
+     *
+     * @param List_<array<array-key, mixed>> $rows Source list of row arrays.
+     * @param array-key $tag Row column supplying pair keys.
+     * @param array-key $field Row column supplying pair values.
+     * @return self<mixed>
+     * @psalm-api
+     */
+    public static function ofList(List_ $rows, int|string $tag, int|string $field): self
+    {
+        return new self($rows, $tag, $field);
+    }
 
     #[Override]
     public function value(): array

--- a/src/Map/Sliced.php
+++ b/src/Map/Sliced.php
@@ -15,8 +15,13 @@ use Override;
  * extends to the end, negative length stops that many positions before
  * the end.
  *
+ * Construction forms:
+ *
+ * - `new Sliced(Map, int, int = PHP_INT_MAX)` — wrap a map with offset and length.
+ * - `Sliced::ofMap(Map, int, int = PHP_INT_MAX)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $map = new Sliced(new MapOf(['a' => 1, 'b' => 2, 'c' => 3]), 1);
+ *     $map = Sliced::ofMap(new MapOf(['a' => 1, 'b' => 2, 'c' => 3]), 1);
  *     foreach ($map as $key => $value) {
  *         echo "$key=$value ";
  *     }
@@ -41,6 +46,22 @@ final readonly class Sliced extends MapEnvelope
         private int $length = PHP_INT_MAX,
     ) {
         parent::__construct($origin);
+    }
+
+    /**
+     * Exposes a contiguous slice of a {@see Map} while preserving keys.
+     *
+     * @template L of array-key
+     * @template W
+     * @param Map<L, W> $map The map to slice.
+     * @param int $start The starting position; negative counts from the end.
+     * @param int $count The maximum number of entries; defaults to extending to the end.
+     * @return self<L, W>
+     * @psalm-api
+     */
+    public static function ofMap(Map $map, int $start, int $count = PHP_INT_MAX): self
+    {
+        return new self($map, $start, $count);
     }
 
     #[Override]

--- a/src/Map/SortedBy.php
+++ b/src/Map/SortedBy.php
@@ -15,8 +15,13 @@ use Primus\Func\BiFunc;
  * or a positive integer when the first value should be ordered before, equal
  * to, or after the second value.
  *
+ * Construction forms:
+ *
+ * - `new SortedBy(Map, BiFunc)` — wrap an existing {@see Map} and value comparator.
+ * - `SortedBy::ofMap(Map, BiFunc)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $byLength = new SortedBy(
+ *     $byLength = SortedBy::ofMap(
  *         new MapOf(['x' => 'alpha', 'y' => 'pi', 'z' => 'gamma']),
  *         new BiFuncOf(static fn(string $left, string $right): int
  *             => strlen($left) <=> strlen($right)),
@@ -38,6 +43,21 @@ final readonly class SortedBy extends MapEnvelope
     public function __construct(Map $origin, private BiFunc $comparator)
     {
         parent::__construct($origin);
+    }
+
+    /**
+     * Sorts pairs of a {@see Map} by an externally supplied value comparator, keys preserved.
+     *
+     * @template L of array-key
+     * @template W
+     * @param Map<L, W> $map The map to order.
+     * @param BiFunc<W, W, int> $order The value-pair comparator.
+     * @return self<L, W>
+     * @psalm-api
+     */
+    public static function ofMap(Map $map, BiFunc $order): self
+    {
+        return new self($map, $order);
     }
 
     #[Override]

--- a/tests/Map/BiFilteredTest.php
+++ b/tests/Map/BiFilteredTest.php
@@ -100,4 +100,16 @@ final class BiFilteredTest extends TestCase
         $this->assertCount(0, $filtered);
         $this->assertSame([], iterator_to_array($filtered));
     }
+
+    #[Test]
+    public function ofMapFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $map = new MapOf(['a' => 1, 'b' => 2, 'c' => 3]);
+        $selector = new BiFuncOf(static fn(string $k, int $v): bool => $v > 1);
+
+        self::assertSame(
+            (new BiFiltered($map, $selector))->value(),
+            BiFiltered::ofMap($map, $selector)->value(),
+        );
+    }
 }

--- a/tests/Map/BiMappedTest.php
+++ b/tests/Map/BiMappedTest.php
@@ -92,4 +92,16 @@ final class BiMappedTest extends TestCase
             ),
         );
     }
+
+    #[Test]
+    public function ofMapFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $map = new MapOf(['a' => 1, 'b' => 2]);
+        $mapper = new BiFuncOf(static fn(string $k, int $v): string => "$k=$v");
+
+        self::assertSame(
+            (new BiMapped($map, $mapper))->value(),
+            BiMapped::ofMap($map, $mapper)->value(),
+        );
+    }
 }

--- a/tests/Map/CombinedTest.php
+++ b/tests/Map/CombinedTest.php
@@ -141,4 +141,16 @@ final class CombinedTest extends TestCase
         $this->assertSame(['a', 'b'], $keys->value());
         $this->assertSame([1, 2], $values->value());
     }
+
+    #[Test]
+    public function ofListsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $keys = new ListOf('a', 'b', 'c');
+        $values = new ListOf(1, 2, 3);
+
+        self::assertSame(
+            (new Combined($keys, $values))->value(),
+            Combined::ofLists($keys, $values)->value(),
+        );
+    }
 }

--- a/tests/Map/FilteredTest.php
+++ b/tests/Map/FilteredTest.php
@@ -100,4 +100,16 @@ final class FilteredTest extends TestCase
             ),
         );
     }
+
+    #[Test]
+    public function ofMapFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $map = new MapOf(['a' => 10, 'b' => 5, 'c' => 40]);
+        $selector = new FuncOf(static fn(int $v): bool => $v > 10);
+
+        self::assertSame(
+            (new Filtered($map, $selector))->value(),
+            Filtered::ofMap($map, $selector)->value(),
+        );
+    }
 }

--- a/tests/Map/PluckedByTest.php
+++ b/tests/Map/PluckedByTest.php
@@ -194,4 +194,18 @@ final class PluckedByTest extends TestCase
         iterator_to_array($plucked);
         $this->assertSame($rows, $source->value());
     }
+
+    #[Test]
+    public function ofListFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $rows = new ListOf(
+            ['id' => 1, 'name' => 'Alice'],
+            ['id' => 2, 'name' => 'Bob'],
+        );
+
+        self::assertSame(
+            (new PluckedBy($rows, 'id', 'name'))->value(),
+            PluckedBy::ofList($rows, 'id', 'name')->value(),
+        );
+    }
 }

--- a/tests/Map/SlicedTest.php
+++ b/tests/Map/SlicedTest.php
@@ -92,4 +92,26 @@ final class SlicedTest extends TestCase
             new Sliced(new MapOf(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4]), 1, 2),
         );
     }
+
+    #[Test]
+    public function ofMapFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $map = new MapOf(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4]);
+
+        self::assertSame(
+            (new Sliced($map, 1, 2))->value(),
+            Sliced::ofMap($map, 1, 2)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofMapFactoryAgreesWithPrimaryConstructorForDefaultLength(): void
+    {
+        $map = new MapOf(['a' => 1, 'b' => 2, 'c' => 3]);
+
+        self::assertSame(
+            (new Sliced($map, 1))->value(),
+            Sliced::ofMap($map, 1)->value(),
+        );
+    }
 }

--- a/tests/Map/SortedByTest.php
+++ b/tests/Map/SortedByTest.php
@@ -99,4 +99,16 @@ final class SortedByTest extends TestCase
         iterator_to_array($sorted);
         $this->assertSame(['b' => 3, 'a' => 1, 'c' => 2], $source->value());
     }
+
+    #[Test]
+    public function ofMapFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $map = new MapOf(['b' => 3, 'a' => 1, 'c' => 2]);
+        $order = new BiFuncOf(static fn(int $left, int $right): int => $left <=> $right);
+
+        self::assertSame(
+            (new SortedBy($map, $order))->value(),
+            SortedBy::ofMap($map, $order)->value(),
+        );
+    }
 }


### PR DESCRIPTION
- Added named factory mirrors to six Map decorators with mixed signatures (BiFiltered, BiMapped, Filtered, Sliced, SortedBy, PluckedBy)
- Added named factory mirror to Combined for keys/values list pairing
- Added equivalence tests covering default-length Sliced edge case

Part of #249