### PR TITLE
Named Constructor Mirrors For Func And Proc Classes

### DIFF
--- a/src/Func/BiFuncOf.php
+++ b/src/Func/BiFuncOf.php
@@ -10,6 +10,11 @@ use Override;
 /**
  * Wraps a {@see Closure} as a {@see BiFunc}.
  *
+ * Construction forms:
+ *
+ * - `new BiFuncOf(Closure)` — wrap the given closure.
+ * - `BiFuncOf::closure(Closure)` — named-constructor alias of the primary ctor.
+ *
  * @template X
  * @template Y
  * @template Z
@@ -23,6 +28,21 @@ final readonly class BiFuncOf implements BiFunc
      * @param Closure(X, Y): Z $origin The closure to wrap.
      */
     public function __construct(private Closure $origin) {}
+
+    /**
+     * Wraps a {@see Closure} as a {@see BiFunc}.
+     *
+     * @template A
+     * @template B
+     * @template C
+     * @param Closure(A, B): C $source The closure to wrap.
+     * @return self<A, B, C>
+     * @psalm-api
+     */
+    public static function closure(Closure $source): self
+    {
+        return new self($source);
+    }
 
     #[Override]
     public function apply(mixed $first, mixed $second): mixed

--- a/src/Func/BiProcOf.php
+++ b/src/Func/BiProcOf.php
@@ -10,6 +10,11 @@ use Override;
 /**
  * Wraps a {@see Closure} as a {@see BiProc}.
  *
+ * Construction forms:
+ *
+ * - `new BiProcOf(Closure)` — wrap the given closure.
+ * - `BiProcOf::closure(Closure)` — named-constructor alias of the primary ctor.
+ *
  * @template X
  * @template Y
  * @implements BiProc<X, Y>
@@ -22,6 +27,20 @@ final readonly class BiProcOf implements BiProc
      * @param Closure(X, Y): void $origin The closure to wrap.
      */
     public function __construct(private Closure $origin) {}
+
+    /**
+     * Wraps a {@see Closure} as a {@see BiProc}.
+     *
+     * @template A
+     * @template B
+     * @param Closure(A, B): void $source The closure to wrap.
+     * @return self<A, B>
+     * @psalm-api
+     */
+    public static function closure(Closure $source): self
+    {
+        return new self($source);
+    }
 
     #[Override]
     public function exec(mixed $first, mixed $second): void

--- a/src/Func/ForEach_.php
+++ b/src/Func/ForEach_.php
@@ -9,8 +9,13 @@ use Primus\List\List_;
 /**
  * Applies a Proc to each element of a List in iteration order.
  *
+ * Construction forms:
+ *
+ * - `new ForEach_(List_, Proc)` — wrap a list and the procedure to apply.
+ * - `ForEach_::ofList(List_, Proc)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $log = new ForEach_(
+ *     $log = ForEach_::ofList(
  *         new ListOf(['a', 'b']),
  *         new ProcOf(fn(string $s) => error_log($s)),
  *     );
@@ -29,7 +34,23 @@ final readonly class ForEach_
     public function __construct(private List_ $list, private Proc $proc) {}
 
     /**
+     * Applies a {@see Proc} to each element of a {@see List_} in iteration order.
+     *
+     * @template U
+     * @param List_<U> $source The list to iterate over.
+     * @param Proc<U> $action The procedure to apply to each element.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function ofList(List_ $source, Proc $action): self
+    {
+        return new self($source, $action);
+    }
+
+    /**
      * Apply the procedure to each element.
+     *
+     * @psalm-api
      */
     public function exec(): void
     {

--- a/src/Func/FuncOf.php
+++ b/src/Func/FuncOf.php
@@ -10,6 +10,11 @@ use Override;
 /**
  * Wraps a {@see Closure} as a {@see Func}.
  *
+ * Construction forms:
+ *
+ * - `new FuncOf(Closure)` — wrap the given closure.
+ * - `FuncOf::closure(Closure)` — named-constructor alias of the primary ctor.
+ *
  * @template I
  * @template O
  * @implements Func<I, O>
@@ -22,6 +27,20 @@ final readonly class FuncOf implements Func
      * @param Closure(I):O $origin The closure to wrap.
      */
     public function __construct(private Closure $origin) {}
+
+    /**
+     * Wraps a {@see Closure} as a {@see Func}.
+     *
+     * @template A
+     * @template B
+     * @param Closure(A):B $source The closure to wrap.
+     * @return self<A, B>
+     * @psalm-api
+     */
+    public static function closure(Closure $source): self
+    {
+        return new self($source);
+    }
 
     #[Override]
     public function apply($input): mixed

--- a/src/Func/FuncWithFallback.php
+++ b/src/Func/FuncWithFallback.php
@@ -9,6 +9,11 @@ use Throwable;
 /**
  * Func with fallback.
  *
+ * Construction forms:
+ *
+ * - `new FuncWithFallback(Func, Func)` — wrap the primary and fallback functions.
+ * - `FuncWithFallback::ofFunc(Func, Func)` — named-constructor alias of the primary ctor.
+ *
  * @template I
  * @template O
  * @extends FuncEnvelope<I, O>
@@ -39,5 +44,20 @@ final readonly class FuncWithFallback extends FuncEnvelope
                 },
             ),
         );
+    }
+
+    /**
+     * Wraps a primary {@see Func} with a fallback used on exception.
+     *
+     * @template A
+     * @template B
+     * @param Func<A, B> $primary The primary function.
+     * @param Func<A, B> $rescue The fallback function used on exception.
+     * @return self<A, B>
+     * @psalm-api
+     */
+    public static function ofFunc(Func $primary, Func $rescue): self
+    {
+        return new self($primary, $rescue);
     }
 }

--- a/src/Func/ProcOf.php
+++ b/src/Func/ProcOf.php
@@ -10,6 +10,11 @@ use Override;
 /**
  * Wraps a {@see Closure} as a {@see Proc}.
  *
+ * Construction forms:
+ *
+ * - `new ProcOf(Closure)` — wrap the given closure.
+ * - `ProcOf::closure(Closure)` — named-constructor alias of the primary ctor.
+ *
  * @template X
  * @implements Proc<X>
  */
@@ -21,6 +26,19 @@ final readonly class ProcOf implements Proc
      * @param Closure(X): void $origin The closure to wrap.
      */
     public function __construct(private Closure $origin) {}
+
+    /**
+     * Wraps a {@see Closure} as a {@see Proc}.
+     *
+     * @template A
+     * @param Closure(A): void $source The closure to wrap.
+     * @return self<A>
+     * @psalm-api
+     */
+    public static function closure(Closure $source): self
+    {
+        return new self($source);
+    }
 
     #[Override]
     public function exec(mixed $input): void

--- a/src/Func/Repeated.php
+++ b/src/Func/Repeated.php
@@ -10,8 +10,13 @@ use Primus\RuntimeException;
 /**
  * Func applied multiple times sequentially.
  *
+ * Construction forms:
+ *
+ * - `new Repeated(Func, int)` — wrap a function with a repetition count.
+ * - `Repeated::ofFunc(Func, int)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $func = new Repeated(
+ *     $func = Repeated::ofFunc(
  *         new FuncOf(fn(int $x): int => $x + 1),
  *         3
  *     );
@@ -29,6 +34,20 @@ final readonly class Repeated implements Func
      * @param int $times Number of sequential applications.
      */
     public function __construct(private Func $origin, private int $times) {}
+
+    /**
+     * Applies a {@see Func} multiple times sequentially.
+     *
+     * @template U
+     * @param Func<U, U> $source The function to repeat.
+     * @param int $count Number of sequential applications.
+     * @return self<U>
+     * @psalm-api
+     */
+    public static function ofFunc(Func $source, int $count): self
+    {
+        return new self($source, $count);
+    }
 
     #[Override]
     public function apply(mixed $input): mixed

--- a/src/Func/StickyFunc.php
+++ b/src/Func/StickyFunc.php
@@ -12,8 +12,13 @@ use Override;
  * Stores results of previous calls. Key is derived via `serialize($input)`,
  * which uniquely represents scalars, arrays, and objects.
  *
+ * Construction forms:
+ *
+ * - `new StickyFunc(Func)` — wrap a function to cache its results.
+ * - `StickyFunc::ofFunc(Func)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $doubled = new StickyFunc(new FuncOf(fn(int $x): int => $x * 2));
+ *     $doubled = StickyFunc::ofFunc(new FuncOf(fn(int $x): int => $x * 2));
  *     echo $doubled->apply(5); // 10
  *     echo $doubled->apply(5); // cached
  *
@@ -35,6 +40,20 @@ final class StickyFunc implements Func
      * @param Func<X, Y> $origin The function whose results are cached.
      */
     public function __construct(private readonly Func $origin) {}
+
+    /**
+     * Wraps a {@see Func} to cache its results per input.
+     *
+     * @template A
+     * @template B
+     * @param Func<A, B> $source The function whose results are cached.
+     * @return self<A, B>
+     * @psalm-api
+     */
+    public static function ofFunc(Func $source): self
+    {
+        return new self($source);
+    }
 
     #[Override]
     public function apply(mixed $input): mixed

--- a/tests/Func/BiFuncOfTest.php
+++ b/tests/Func/BiFuncOfTest.php
@@ -22,4 +22,15 @@ final class BiFuncOfTest extends TestCase
             'BiFuncOf must apply the closure to two inputs'
         );
     }
+
+    #[Test]
+    public function closureFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = static fn(int $a, int $b): int => $a + $b;
+
+        self::assertSame(
+            (new BiFuncOf($source))->apply(3, 4),
+            BiFuncOf::closure($source)->apply(3, 4),
+        );
+    }
 }

--- a/tests/Func/BiProcOfTest.php
+++ b/tests/Func/BiProcOfTest.php
@@ -23,4 +23,22 @@ final class BiProcOfTest extends TestCase
 
         self::assertSame(5, $sum, 'BiProcOf must modify the state as expected');
     }
+
+    #[Test]
+    public function closureFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $primary = 0;
+        $factory = 0;
+        $closurePrimary = static function (int $a, int $b) use (&$primary): void {
+            $primary = $a + $b;
+        };
+        $closureFactory = static function (int $a, int $b) use (&$factory): void {
+            $factory = $a + $b;
+        };
+
+        (new BiProcOf($closurePrimary))->exec(2, 3);
+        BiProcOf::closure($closureFactory)->exec(2, 3);
+
+        self::assertSame($primary, $factory);
+    }
 }

--- a/tests/Func/ForEach_Test.php
+++ b/tests/Func/ForEach_Test.php
@@ -42,4 +42,27 @@ final class ForEach_Test extends TestCase
         $this->assertSame(0, $calls);
     }
 
+    #[Test]
+    public function ofListFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $primary = [];
+        $factory = [];
+        $list = new ListOf('a', 'b');
+
+        (new ForEach_(
+            $list,
+            new ProcOf(static function (string $s) use (&$primary): void {
+                $primary[] = $s;
+            }),
+        ))->exec();
+        ForEach_::ofList(
+            $list,
+            new ProcOf(static function (string $s) use (&$factory): void {
+                $factory[] = $s;
+            }),
+        )->exec();
+
+        self::assertSame($primary, $factory);
+    }
+
 }

--- a/tests/Func/FuncOfTest.php
+++ b/tests/Func/FuncOfTest.php
@@ -18,4 +18,15 @@ final class FuncOfTest extends TestCase
         $func = new FuncOf(fn (int $x): int => $x * 2);
         self::assertSame(6, $func->apply(3), 'Doubles input value');
     }
+
+    #[Test]
+    public function closureFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = static fn(int $x): int => $x * 2;
+
+        self::assertSame(
+            (new FuncOf($source))->apply(3),
+            FuncOf::closure($source)->apply(3),
+        );
+    }
 }

--- a/tests/Func/FuncWithFallbackTest.php
+++ b/tests/Func/FuncWithFallbackTest.php
@@ -41,4 +41,16 @@ final class FuncWithFallbackTest extends TestCase
             'FuncWithFallback must return the fallback result when an exception is thrown'
         );
     }
+
+    #[Test]
+    public function ofFuncFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $primary = new FuncOf(static fn(int $x): int => $x * 2);
+        $rescue = new FuncOf(static fn(int $x): int => $x);
+
+        self::assertSame(
+            (new FuncWithFallback($primary, $rescue))->apply(5),
+            FuncWithFallback::ofFunc($primary, $rescue)->apply(5),
+        );
+    }
 }

--- a/tests/Func/ProcOfTest.php
+++ b/tests/Func/ProcOfTest.php
@@ -27,4 +27,22 @@ final class ProcOfTest extends TestCase
             'ProcOf must execute the closure exactly once'
         );
     }
+
+    #[Test]
+    public function closureFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $primary = 0;
+        $factory = 0;
+        $closurePrimary = static function (int $x) use (&$primary): void {
+            $primary = $x * 2;
+        };
+        $closureFactory = static function (int $x) use (&$factory): void {
+            $factory = $x * 2;
+        };
+
+        (new ProcOf($closurePrimary))->exec(5);
+        ProcOf::closure($closureFactory)->exec(5);
+
+        self::assertSame($primary, $factory);
+    }
 }

--- a/tests/Func/RepeatedTest.php
+++ b/tests/Func/RepeatedTest.php
@@ -82,4 +82,15 @@ final class RepeatedTest extends TestCase
             'Repeated must reject zero-times constructor argument',
         );
     }
+
+    #[Test]
+    public function ofFuncFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = new FuncOf(static fn(int $x): int => $x + 1);
+
+        self::assertSame(
+            (new Repeated($source, 3))->apply(5),
+            Repeated::ofFunc($source, 3)->apply(5),
+        );
+    }
 }

--- a/tests/Func/StickyFuncTest.php
+++ b/tests/Func/StickyFuncTest.php
@@ -66,4 +66,15 @@ final class StickyFuncTest extends TestCase
 
         self::assertThat($calls, new HasCallCount(1));
     }
+
+    #[Test]
+    public function ofFuncFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = new FuncOf(static fn(int $x): int => $x * 2);
+
+        self::assertSame(
+            (new StickyFunc($source))->apply(5),
+            StickyFunc::ofFunc($source)->apply(5),
+        );
+    }
 }


### PR DESCRIPTION
- Added named factory mirrors to four closure wrappers (FuncOf, BiFuncOf, ProcOf, BiProcOf)
- Added named factory mirrors to four function decorators (ForEach_, FuncWithFallback, Repeated, StickyFunc)
- Marked ForEach_::exec with @psalm-api to keep psalm happy after adding @psalm-api on the new factory

Part of #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added named constructors (`closure()`, `ofList()`, `ofFunc()`) to function and procedure wrapper classes, providing more expressive and semantic alternative construction methods.

* **Tests**
  * Added test coverage verifying named constructors produce identical behavior to primary constructors across all updated function wrapper classes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haspadar/primus/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->