### PR TITLE
Named Constructor Mirrors For Text Creators And Case Transforms

### DIFF
--- a/src/Text/Capitalized.php
+++ b/src/Text/Capitalized.php
@@ -13,11 +13,12 @@ namespace Primus\Text;
  * Construction forms:
  *
  * - `new Capitalized(Text)` — wrap an existing {@see Text} value.
+ * - `Capitalized::ofText(Text)` — named-constructor alias of the primary ctor.
  * - `Capitalized::ofString(string)` — shortcut that wraps a native string in
  *   {@see TextOf::str()} before capitalising.
  *
  * Example:
- *     $text = new Capitalized(TextOf::str('hello'));
+ *     $text = Capitalized::ofText(TextOf::str('hello'));
  *     echo $text->value(); // 'Hello'
  *
  *     $text = Capitalized::ofString('hello');
@@ -38,6 +39,17 @@ final readonly class Capitalized extends TextEnvelope
                 new Sub($origin, 1),
             ]),
         );
+    }
+
+    /**
+     * Capitalises a {@see Text}.
+     *
+     * @param Text $source The text to capitalise.
+     * @psalm-api
+     */
+    public static function ofText(Text $source): self
+    {
+        return new self($source);
     }
 
     /**

--- a/src/Text/Concatenated.php
+++ b/src/Text/Concatenated.php
@@ -13,11 +13,12 @@ namespace Primus\Text;
  * Construction forms:
  *
  * - `new Concatenated(Text ...)` — concatenate variadic {@see Text} parts.
+ * - `Concatenated::ofTexts(Text ...)` — named-constructor alias of the primary ctor.
  * - `Concatenated::ofStrings(string ...)` — shortcut that wraps each native
  *   string in {@see TextOf::str()} before concatenating.
  *
  * Example:
- *     $text = new Concatenated(
+ *     $text = Concatenated::ofTexts(
  *         TextOf::str('hello, '),
  *         TextOf::str('world'),
  *     );
@@ -38,6 +39,17 @@ final readonly class Concatenated extends TextEnvelope
     public function __construct(Text ...$parts)
     {
         parent::__construct(new Joined(self::SEPARATOR, array_values($parts)));
+    }
+
+    /**
+     * Concatenates {@see Text} parts in argument order.
+     *
+     * @param Text ...$pieces The texts to concatenate.
+     * @psalm-api
+     */
+    public static function ofTexts(Text ...$pieces): self
+    {
+        return new self(...$pieces);
     }
 
     /**

--- a/src/Text/FormattedText.php
+++ b/src/Text/FormattedText.php
@@ -25,11 +25,13 @@ use Primus\Func\FuncOf;
  *
  * - `new FormattedText(Text, int|float|string ...)` — wrap an existing
  *   {@see Text} pattern.
+ * - `FormattedText::ofText(Text, int|float|string ...)` — named-constructor alias
+ *   of the primary ctor.
  * - `FormattedText::ofString(string, int|float|string ...)` — shortcut that
  *   wraps a native string pattern in {@see TextOf::str()} before formatting.
  *
  * Example:
- *     $text = new FormattedText(
+ *     $text = FormattedText::ofText(
  *         TextOf::str('Hello, %s! You have %d messages.'),
  *         'world',
  *         5,
@@ -55,6 +57,18 @@ final readonly class FormattedText extends TextEnvelope
                 new FuncOf(static fn(string $p): string => sprintf($p, ...$arguments)),
             ),
         );
+    }
+
+    /**
+     * Formats a {@see Text} pattern with the given arguments.
+     *
+     * @param Text $template The sprintf pattern.
+     * @param int|float|string ...$values The values substituted into the pattern.
+     * @psalm-api
+     */
+    public static function ofText(Text $template, int|float|string ...$values): self
+    {
+        return new self($template, ...$values);
     }
 
     /**

--- a/src/Text/Joined.php
+++ b/src/Text/Joined.php
@@ -12,11 +12,12 @@ use Primus\Scalar\ScalarOf;
  * Construction forms:
  *
  * - `new Joined(string, list<Text>)` — join an array of {@see Text} parts.
+ * - `Joined::ofTexts(string, list<Text>)` — named-constructor alias of the primary ctor.
  * - `Joined::ofStrings(string, string ...)` — shortcut that wraps each
  *   native string in {@see TextOf::str()} before joining.
  *
  * Example:
- *     $text = new Joined(', ', [TextOf::str('a'), TextOf::str('b'), TextOf::str('c')]);
+ *     $text = Joined::ofTexts(', ', [TextOf::str('a'), TextOf::str('b'), TextOf::str('c')]);
  *     echo $text->value(); // 'a, b, c'
  *
  *     $text = Joined::ofStrings(', ', 'a', 'b', 'c');
@@ -43,6 +44,18 @@ final readonly class Joined extends TextEnvelope
                 )),
             ),
         );
+    }
+
+    /**
+     * Joins {@see Text} parts with a separator.
+     *
+     * @param string $glue The glue inserted between parts.
+     * @param list<Text> $pieces The texts to join.
+     * @psalm-api
+     */
+    public static function ofTexts(string $glue, array $pieces): self
+    {
+        return new self($glue, $pieces);
     }
 
     /**

--- a/src/Text/Lowered.php
+++ b/src/Text/Lowered.php
@@ -14,11 +14,12 @@ use Primus\Func\FuncOf;
  * Construction forms:
  *
  * - `new Lowered(Text)` — wrap an existing {@see Text} value.
+ * - `Lowered::ofText(Text)` — named-constructor alias of the primary ctor.
  * - `Lowered::ofString(string)` — shortcut that wraps a native string in
  *   {@see TextOf::str()} before lowercasing.
  *
  * Example:
- *     $text = new Lowered(TextOf::str('CAFÉ & TÜRKİYE'));
+ *     $text = Lowered::ofText(TextOf::str('CAFÉ & TÜRKİYE'));
  *     echo $text->value(); // 'café & türkiye'
  *
  *     $text = Lowered::ofString('CAFÉ & TÜRKİYE');
@@ -39,6 +40,17 @@ final readonly class Lowered extends TextEnvelope
                 new FuncOf(static fn(string $s): string => mb_strtolower($s, 'UTF-8')),
             ),
         );
+    }
+
+    /**
+     * Lowercases a {@see Text}.
+     *
+     * @param Text $source The text to lowercase.
+     * @psalm-api
+     */
+    public static function ofText(Text $source): self
+    {
+        return new self($source);
     }
 
     /**

--- a/src/Text/RandomText.php
+++ b/src/Text/RandomText.php
@@ -13,8 +13,13 @@ use Primus\Scalar\Sticky;
  * Creates a text of a given length composed of characters
  * from the specified alphabet.
  *
+ * Construction forms:
+ *
+ * - `new RandomText(int, string = ...)` — generate a random text of given length.
+ * - `RandomText::ofLength(int, string = ...)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $text = new RandomText(8);
+ *     $text = RandomText::ofLength(8);
  *     echo $text->value(); // e.g. 'aZ8mKp2Q'
  */
 final readonly class RandomText extends TextEnvelope
@@ -50,5 +55,19 @@ final readonly class RandomText extends TextEnvelope
                 ),
             ),
         );
+    }
+
+    /**
+     * Builds a random text of the given length from the alphabet.
+     *
+     * @param int $size The length of the generated text.
+     * @param string $charset The characters to pick from.
+     * @psalm-api
+     */
+    public static function ofLength(
+        int $size,
+        string $charset = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+    ): self {
+        return new self($size, $charset);
     }
 }

--- a/src/Text/RandomText.php
+++ b/src/Text/RandomText.php
@@ -24,16 +24,16 @@ use Primus\Scalar\Sticky;
  */
 final readonly class RandomText extends TextEnvelope
 {
+    private const string DEFAULT_ALPHABET = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+
     /**
      * Ctor.
      *
      * @param int $length The length of the generated text.
      * @param string $alphabet The characters to pick from.
      */
-    public function __construct(
-        int $length,
-        string $alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
-    ) {
+    public function __construct(int $length, string $alphabet = self::DEFAULT_ALPHABET)
+    {
         parent::__construct(
             TextOf::scalar(
                 new Sticky(
@@ -60,14 +60,12 @@ final readonly class RandomText extends TextEnvelope
     /**
      * Builds a random text of the given length from the alphabet.
      *
-     * @param int $size The length of the generated text.
-     * @param string $charset The characters to pick from.
+     * @param int $length The length of the generated text.
+     * @param string $alphabet The characters to pick from.
      * @psalm-api
      */
-    public static function ofLength(
-        int $size,
-        string $charset = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
-    ): self {
-        return new self($size, $charset);
+    public static function ofLength(int $length, string $alphabet = self::DEFAULT_ALPHABET): self
+    {
+        return new self($length, $alphabet);
     }
 }

--- a/src/Text/Repeated.php
+++ b/src/Text/Repeated.php
@@ -12,11 +12,12 @@ use Primus\Func\FuncOf;
  * Construction forms:
  *
  * - `new Repeated(Text, int)` — wrap an existing {@see Text} value.
+ * - `Repeated::ofText(Text, int)` — named-constructor alias of the primary ctor.
  * - `Repeated::ofString(string, int)` — shortcut that wraps a native string in
  *   {@see TextOf::str()} before repeating.
  *
  * Example:
- *     $text = new Repeated(TextOf::str('xo'), 3);
+ *     $text = Repeated::ofText(TextOf::str('xo'), 3);
  *     echo $text->value(); // 'xoxoxo'
  *
  *     $text = Repeated::ofString('xo', 3);
@@ -38,6 +39,18 @@ final readonly class Repeated extends TextEnvelope
                 new FuncOf(static fn(string $s): string => str_repeat($s, max(0, $count))),
             ),
         );
+    }
+
+    /**
+     * Repeats a {@see Text}.
+     *
+     * @param Text $source The text to repeat.
+     * @param int $times The number of repetitions.
+     * @psalm-api
+     */
+    public static function ofText(Text $source, int $times): self
+    {
+        return new self($source, $times);
     }
 
     /**

--- a/src/Text/TextOfScalar.php
+++ b/src/Text/TextOfScalar.php
@@ -17,6 +17,11 @@ use Primus\Scalar\Scalar;
  *     Primus does not model Text identity, so a public surface here would
  *     be redundant.
  *
+ * Construction forms:
+ *
+ * - `new TextOfScalar(Scalar)` — wrap a scalar producing a string.
+ * - `TextOfScalar::scalar(Scalar)` — named-constructor alias of the primary ctor.
+ *
  * Example:
  *     $text = TextOf::scalar(new ScalarOf(static fn(): string => 'hello'));
  *     echo $text->value(); // 'hello'
@@ -29,6 +34,17 @@ final readonly class TextOfScalar implements Text
      * @param Scalar<string> $origin The scalar producing the string value.
      */
     public function __construct(private Scalar $origin) {}
+
+    /**
+     * Wraps a {@see Scalar} producing a string as a {@see Text}.
+     *
+     * @param Scalar<string> $source The scalar producing the string value.
+     * @psalm-api
+     */
+    public static function scalar(Scalar $source): self
+    {
+        return new self($source);
+    }
 
     #[Override]
     public function value(): string

--- a/src/Text/TextOfScalar.php
+++ b/src/Text/TextOfScalar.php
@@ -20,7 +20,7 @@ use Primus\Scalar\Scalar;
  * Construction forms:
  *
  * - `new TextOfScalar(Scalar)` — wrap a scalar producing a string.
- * - `TextOfScalar::scalar(Scalar)` — named-constructor alias of the primary ctor.
+ * - `TextOfScalar::ofScalar(Scalar)` — named-constructor alias of the primary ctor.
  *
  * Example:
  *     $text = TextOf::scalar(new ScalarOf(static fn(): string => 'hello'));
@@ -41,7 +41,7 @@ final readonly class TextOfScalar implements Text
      * @param Scalar<string> $source The scalar producing the string value.
      * @psalm-api
      */
-    public static function scalar(Scalar $source): self
+    public static function ofScalar(Scalar $source): self
     {
         return new self($source);
     }

--- a/src/Text/Uppered.php
+++ b/src/Text/Uppered.php
@@ -14,11 +14,12 @@ use Primus\Func\FuncOf;
  * Construction forms:
  *
  * - `new Uppered(Text)` — wrap an existing {@see Text} value.
+ * - `Uppered::ofText(Text)` — named-constructor alias of the primary ctor.
  * - `Uppered::ofString(string)` — shortcut that wraps a native string in
  *   {@see TextOf::str()} before uppercasing.
  *
  * Example:
- *     $text = new Uppered(TextOf::str('touché résumé'));
+ *     $text = Uppered::ofText(TextOf::str('touché résumé'));
  *     echo $text->value(); // 'TOUCHÉ RÉSUMÉ'
  *
  *     $text = Uppered::ofString('touché résumé');
@@ -39,6 +40,17 @@ final readonly class Uppered extends TextEnvelope
                 new FuncOf(static fn(string $s): string => mb_strtoupper($s, 'UTF-8')),
             ),
         );
+    }
+
+    /**
+     * Uppercases a {@see Text}.
+     *
+     * @param Text $source The text to uppercase.
+     * @psalm-api
+     */
+    public static function ofText(Text $source): self
+    {
+        return new self($source);
     }
 
     /**

--- a/tests/Text/CapitalizedTest.php
+++ b/tests/Text/CapitalizedTest.php
@@ -96,4 +96,15 @@ final class CapitalizedTest extends TestCase
             'single char' => ['x'],
         ];
     }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str('hello');
+
+        self::assertSame(
+            (new Capitalized($source))->value(),
+            Capitalized::ofText($source)->value(),
+        );
+    }
 }

--- a/tests/Text/ConcatenatedTest.php
+++ b/tests/Text/ConcatenatedTest.php
@@ -123,4 +123,25 @@ final class ConcatenatedTest extends TestCase
             'empty string parts' => [['a', '', 'b']],
         ];
     }
+
+    #[Test]
+    public function ofTextsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $a = TextOf::str('hello, ');
+        $b = TextOf::str('world');
+
+        self::assertSame(
+            (new Concatenated($a, $b))->value(),
+            Concatenated::ofTexts($a, $b)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofTextsFactoryAgreesWithPrimaryConstructorForNoParts(): void
+    {
+        self::assertSame(
+            (new Concatenated())->value(),
+            Concatenated::ofTexts()->value(),
+        );
+    }
 }

--- a/tests/Text/FormattedTextTest.php
+++ b/tests/Text/FormattedTextTest.php
@@ -90,4 +90,15 @@ final class FormattedTextTest extends TestCase
             'multibyte' => ['café %s', ['привет']],
         ];
     }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $pattern = TextOf::str('Hello, %s! You have %d messages.');
+
+        self::assertSame(
+            (new FormattedText($pattern, 'world', 5))->value(),
+            FormattedText::ofText($pattern, 'world', 5)->value(),
+        );
+    }
 }

--- a/tests/Text/JoinedTest.php
+++ b/tests/Text/JoinedTest.php
@@ -145,4 +145,24 @@ final class JoinedTest extends TestCase
         ];
     }
 
+    #[Test]
+    public function ofTextsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $parts = [TextOf::str('a'), TextOf::str('b'), TextOf::str('c')];
+
+        self::assertSame(
+            (new Joined(', ', $parts))->value(),
+            Joined::ofTexts(', ', $parts)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofTextsFactoryAgreesWithPrimaryConstructorForEmptyParts(): void
+    {
+        self::assertSame(
+            (new Joined(', ', []))->value(),
+            Joined::ofTexts(', ', [])->value(),
+        );
+    }
+
 }

--- a/tests/Text/LoweredTest.php
+++ b/tests/Text/LoweredTest.php
@@ -73,4 +73,15 @@ final class LoweredTest extends TestCase
             'cyrillic' => ['ПРИВЕТ'],
         ];
     }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str('CAFÉ');
+
+        self::assertSame(
+            (new Lowered($source))->value(),
+            Lowered::ofText($source)->value(),
+        );
+    }
 }

--- a/tests/Text/RandomTextTest.php
+++ b/tests/Text/RandomTextTest.php
@@ -84,4 +84,22 @@ final class RandomTextTest extends TestCase
 
         self::assertSame($text->value(), $text->value());
     }
+
+    #[Test]
+    public function ofLengthFactoryAgreesWithPrimaryConstructorOnSize(): void
+    {
+        self::assertSame(
+            mb_strlen((new RandomText(8))->value(), 'UTF-8'),
+            mb_strlen(RandomText::ofLength(8)->value(), 'UTF-8'),
+        );
+    }
+
+    #[Test]
+    public function ofLengthFactoryAgreesWithPrimaryConstructorOnAlphabet(): void
+    {
+        self::assertMatchesRegularExpression(
+            '/^[abc]+$/',
+            RandomText::ofLength(8, 'abc')->value(),
+        );
+    }
 }

--- a/tests/Text/RepeatedTest.php
+++ b/tests/Text/RepeatedTest.php
@@ -100,4 +100,15 @@ final class RepeatedTest extends TestCase
             'unicode' => ['🔥', 3],
         ];
     }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str('xo');
+
+        self::assertSame(
+            (new Repeated($source, 3))->value(),
+            Repeated::ofText($source, 3)->value(),
+        );
+    }
 }

--- a/tests/Text/TextOfScalarTest.php
+++ b/tests/Text/TextOfScalarTest.php
@@ -24,13 +24,13 @@ final class TextOfScalarTest extends TestCase
     }
 
     #[Test]
-    public function scalarFactoryAgreesWithPrimaryConstructor(): void
+    public function ofScalarFactoryAgreesWithPrimaryConstructor(): void
     {
         $scalar = new ScalarOf(static fn(): string => 'hello');
 
         self::assertSame(
             (new TextOfScalar($scalar))->value(),
-            TextOfScalar::scalar($scalar)->value(),
+            TextOfScalar::ofScalar($scalar)->value(),
         );
     }
 }

--- a/tests/Text/TextOfScalarTest.php
+++ b/tests/Text/TextOfScalarTest.php
@@ -22,4 +22,15 @@ final class TextOfScalarTest extends TestCase
             new HasTextValue('hello')
         );
     }
+
+    #[Test]
+    public function scalarFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $scalar = new ScalarOf(static fn(): string => 'hello');
+
+        self::assertSame(
+            (new TextOfScalar($scalar))->value(),
+            TextOfScalar::scalar($scalar)->value(),
+        );
+    }
 }

--- a/tests/Text/UpperedTest.php
+++ b/tests/Text/UpperedTest.php
@@ -111,4 +111,15 @@ final class UpperedTest extends TestCase
             'cyrillic' => ['привет'],
         ];
     }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str('touché');
+
+        self::assertSame(
+            (new Uppered($source))->value(),
+            Uppered::ofText($source)->value(),
+        );
+    }
 }


### PR DESCRIPTION
- Added named factory mirrors to nine Text classes (TextOfScalar, Concatenated, Joined, Repeated, FormattedText, RandomText, Capitalized, Lowered, Uppered)
- Added equivalence tests covering variadic edge cases and random alphabet constraints

Part of #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added named constructor factory methods across text creation utilities, offering more convenient and consistent APIs for instantiating text objects.

* **Tests**
  * Expanded test suite with comprehensive coverage validating the new factory methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->