### PR TITLE
Named Constructor Mirrors For Text Formatting And Sanitizing Decorators

### DIFF
--- a/src/Text/Abbreviated.php
+++ b/src/Text/Abbreviated.php
@@ -12,8 +12,15 @@ use Primus\Scalar\ScalarOf;
  * Truncates the origin text to a maximum length and appends an ellipsis.
  * If the text length does not exceed the limit, it is returned unchanged.
  *
+ * Construction forms:
+ *
+ * - `new Abbreviated(Text, int = 50)` — wrap an existing {@see Text} value.
+ * - `Abbreviated::ofText(Text, int = 50)` — named-constructor alias of the primary ctor.
+ * - `Abbreviated::ofString(string, int = 50)` — shortcut that wraps a native
+ *   string in {@see TextOf::str()} before abbreviating.
+ *
  * Example:
- *     $text = new Abbreviated(TextOf::str('Hello, world!'), 8);
+ *     $text = Abbreviated::ofText(TextOf::str('Hello, world!'), 8);
  *     echo $text->value(); // 'Hello, w…'
  */
 final readonly class Abbreviated extends TextEnvelope
@@ -43,5 +50,29 @@ final readonly class Abbreviated extends TextEnvelope
                 ),
             ),
         );
+    }
+
+    /**
+     * Abbreviates a {@see Text} to the given length.
+     *
+     * @param Text $source The text to abbreviate.
+     * @param int $limit The maximum length of the result.
+     * @psalm-api
+     */
+    public static function ofText(Text $source, int $limit = 50): self
+    {
+        return new self($source, $limit);
+    }
+
+    /**
+     * Abbreviates a native string to the given length.
+     *
+     * @param string $value The string to abbreviate.
+     * @param int $limit The maximum length of the result.
+     * @psalm-api
+     */
+    public static function ofString(string $value, int $limit = 50): self
+    {
+        return new self(TextOf::str($value), $limit);
     }
 }

--- a/src/Text/Abbreviated.php
+++ b/src/Text/Abbreviated.php
@@ -25,13 +25,15 @@ use Primus\Scalar\ScalarOf;
  */
 final readonly class Abbreviated extends TextEnvelope
 {
+    private const int DEFAULT_LIMIT = 50;
+
     /**
      * Ctor.
      *
      * @param Text $origin The text to abbreviate.
      * @param int $limit The maximum length of the result.
      */
-    public function __construct(Text $origin, int $limit = 50)
+    public function __construct(Text $origin, int $limit = self::DEFAULT_LIMIT)
     {
         parent::__construct(
             TextOf::scalar(
@@ -59,7 +61,7 @@ final readonly class Abbreviated extends TextEnvelope
      * @param int $limit The maximum length of the result.
      * @psalm-api
      */
-    public static function ofText(Text $source, int $limit = 50): self
+    public static function ofText(Text $source, int $limit = self::DEFAULT_LIMIT): self
     {
         return new self($source, $limit);
     }
@@ -71,7 +73,7 @@ final readonly class Abbreviated extends TextEnvelope
      * @param int $limit The maximum length of the result.
      * @psalm-api
      */
-    public static function ofString(string $value, int $limit = 50): self
+    public static function ofString(string $value, int $limit = self::DEFAULT_LIMIT): self
     {
         return new self(TextOf::str($value), $limit);
     }

--- a/src/Text/HtmlEscaped.php
+++ b/src/Text/HtmlEscaped.php
@@ -9,8 +9,15 @@ use Primus\Func\FuncOf;
 /**
  * Escaped {@see Text} safe for HTML rendering.
  *
+ * Construction forms:
+ *
+ * - `new HtmlEscaped(Text)` — wrap an existing {@see Text} value.
+ * - `HtmlEscaped::ofText(Text)` — named-constructor alias of the primary ctor.
+ * - `HtmlEscaped::ofString(string)` — shortcut that wraps a native string in
+ *   {@see TextOf::str()} before escaping.
+ *
  * Example:
- *     $text = new HtmlEscaped(TextOf::str('<b>"A & B"</b>'));
+ *     $text = HtmlEscaped::ofText(TextOf::str('<b>"A & B"</b>'));
  *     echo $text->value(); // &lt;b&gt;&quot;A &amp; B&quot;&lt;/b&gt;
  */
 final readonly class HtmlEscaped extends TextEnvelope
@@ -28,5 +35,27 @@ final readonly class HtmlEscaped extends TextEnvelope
                 new FuncOf(static fn(string $s): string => htmlspecialchars($s, ENT_QUOTES | ENT_HTML5, 'UTF-8')),
             ),
         );
+    }
+
+    /**
+     * Escapes a {@see Text} for safe HTML rendering.
+     *
+     * @param Text $source The text to escape.
+     * @psalm-api
+     */
+    public static function ofText(Text $source): self
+    {
+        return new self($source);
+    }
+
+    /**
+     * Escapes a native string for safe HTML rendering.
+     *
+     * @param string $value The string to escape.
+     * @psalm-api
+     */
+    public static function ofString(string $value): self
+    {
+        return new self(TextOf::str($value));
     }
 }

--- a/src/Text/LeftPadded.php
+++ b/src/Text/LeftPadded.php
@@ -12,8 +12,15 @@ use Primus\Func\FuncOf;
  * Pads the text on the left to the specified length
  * with the given character using {@see str_pad()}.
  *
+ * Construction forms:
+ *
+ * - `new LeftPadded(Text, int, string)` — wrap an existing {@see Text} value.
+ * - `LeftPadded::ofText(Text, int, string)` — named-constructor alias of the primary ctor.
+ * - `LeftPadded::ofString(string, int, string)` — shortcut that wraps a native
+ *   string in {@see TextOf::str()} before padding.
+ *
  * Example:
- *     $text = new LeftPadded(TextOf::str('foo'), 6, '.');
+ *     $text = LeftPadded::ofText(TextOf::str('foo'), 6, '.');
  *     echo $text->value(); // '...foo'
  */
 final readonly class LeftPadded extends TextEnvelope
@@ -33,5 +40,31 @@ final readonly class LeftPadded extends TextEnvelope
                 new FuncOf(static fn(string $s): string => str_pad($s, $length, $padding, STR_PAD_LEFT)),
             ),
         );
+    }
+
+    /**
+     * Pads a {@see Text} on the left to a desired length.
+     *
+     * @param Text $source The text to pad.
+     * @param int $length The desired total length after padding.
+     * @param string $padding The character to use for padding.
+     * @psalm-api
+     */
+    public static function ofText(Text $source, int $length, string $padding): self
+    {
+        return new self($source, $length, $padding);
+    }
+
+    /**
+     * Pads a native string on the left to a desired length.
+     *
+     * @param string $value The string to pad.
+     * @param int $length The desired total length after padding.
+     * @param string $padding The character to use for padding.
+     * @psalm-api
+     */
+    public static function ofString(string $value, int $length, string $padding): self
+    {
+        return new self(TextOf::str($value), $length, $padding);
     }
 }

--- a/src/Text/Normalized.php
+++ b/src/Text/Normalized.php
@@ -13,8 +13,15 @@ use Primus\Scalar\ScalarOf;
  * Replaces multiple spaces, tabs, and newlines
  * with a single space and trims leading/trailing whitespace.
  *
+ * Construction forms:
+ *
+ * - `new Normalized(Text)` — wrap an existing {@see Text} value.
+ * - `Normalized::ofText(Text)` — named-constructor alias of the primary ctor.
+ * - `Normalized::ofString(string)` — shortcut that wraps a native string in
+ *   {@see TextOf::str()} before normalizing.
+ *
  * Example:
- *     $text = new Normalized(TextOf::str(" Hello \n\t world "));
+ *     $text = Normalized::ofText(TextOf::str(" Hello \n\t world "));
  *     echo $text->value(); // 'Hello world'
  */
 final readonly class Normalized extends TextEnvelope
@@ -34,5 +41,27 @@ final readonly class Normalized extends TextEnvelope
                 ),
             ),
         );
+    }
+
+    /**
+     * Normalizes whitespace in a {@see Text}.
+     *
+     * @param Text $source The text to normalize.
+     * @psalm-api
+     */
+    public static function ofText(Text $source): self
+    {
+        return new self($source);
+    }
+
+    /**
+     * Normalizes whitespace in a native string.
+     *
+     * @param string $value The string to normalize.
+     * @psalm-api
+     */
+    public static function ofString(string $value): self
+    {
+        return new self(TextOf::str($value));
     }
 }

--- a/src/Text/Reversed.php
+++ b/src/Text/Reversed.php
@@ -16,8 +16,15 @@ use Primus\Func\FuncOf;
  * (NFD form, e.g. "e" + U+0301) are reordered separately from their base
  * character. Pre-normalize to NFC if grapheme stability is required.
  *
+ * Construction forms:
+ *
+ * - `new Reversed(Text)` — wrap an existing {@see Text} value.
+ * - `Reversed::ofText(Text)` — named-constructor alias of the primary ctor.
+ * - `Reversed::ofString(string)` — shortcut that wraps a native string in
+ *   {@see TextOf::str()} before reversing.
+ *
  * Example:
- *     $text = new Reversed(TextOf::str('café'));
+ *     $text = Reversed::ofText(TextOf::str('café'));
  *     echo $text->value(); // 'éfac'
  */
 final readonly class Reversed extends TextEnvelope
@@ -37,5 +44,27 @@ final readonly class Reversed extends TextEnvelope
                 ),
             ),
         );
+    }
+
+    /**
+     * Reverses character order in a {@see Text}.
+     *
+     * @param Text $source The text to reverse.
+     * @psalm-api
+     */
+    public static function ofText(Text $source): self
+    {
+        return new self($source);
+    }
+
+    /**
+     * Reverses character order in a native string.
+     *
+     * @param string $value The string to reverse.
+     * @psalm-api
+     */
+    public static function ofString(string $value): self
+    {
+        return new self(TextOf::str($value));
     }
 }

--- a/src/Text/RightPadded.php
+++ b/src/Text/RightPadded.php
@@ -11,8 +11,15 @@ use Primus\Func\FuncOf;
  *
  * Pads the text to the specified length with the given character using {@see str_pad()}.
  *
+ * Construction forms:
+ *
+ * - `new RightPadded(Text, int, string)` — wrap an existing {@see Text} value.
+ * - `RightPadded::ofText(Text, int, string)` — named-constructor alias of the primary ctor.
+ * - `RightPadded::ofString(string, int, string)` — shortcut that wraps a native
+ *   string in {@see TextOf::str()} before padding.
+ *
  * Example:
- *     $text = new RightPadded(TextOf::str('foo'), 6, '.');
+ *     $text = RightPadded::ofText(TextOf::str('foo'), 6, '.');
  *     echo $text->value(); // 'foo...'
  */
 final readonly class RightPadded extends TextEnvelope
@@ -32,5 +39,31 @@ final readonly class RightPadded extends TextEnvelope
                 new FuncOf(static fn(string $s): string => str_pad($s, $length, $padding)),
             ),
         );
+    }
+
+    /**
+     * Pads a {@see Text} on the right to a desired length.
+     *
+     * @param Text $source The text to pad.
+     * @param int $length The desired total length after padding.
+     * @param string $padding The character to use for padding.
+     * @psalm-api
+     */
+    public static function ofText(Text $source, int $length, string $padding): self
+    {
+        return new self($source, $length, $padding);
+    }
+
+    /**
+     * Pads a native string on the right to a desired length.
+     *
+     * @param string $value The string to pad.
+     * @param int $length The desired total length after padding.
+     * @param string $padding The character to use for padding.
+     * @psalm-api
+     */
+    public static function ofString(string $value, int $length, string $padding): self
+    {
+        return new self(TextOf::str($value), $length, $padding);
     }
 }

--- a/src/Text/Trimmed.php
+++ b/src/Text/Trimmed.php
@@ -11,8 +11,18 @@ use Primus\Func\FuncOf;
  *
  * Applies {@see trim()} to the original text.
  *
+ * Construction forms:
+ *
+ * - `new Trimmed(Text)` — wrap an existing {@see Text} value.
+ * - `Trimmed::ofText(Text)` — named-constructor alias of the primary ctor.
+ * - `Trimmed::ofString(string)` — shortcut that wraps a native string in
+ *   {@see TextOf::str()} before trimming.
+ *
  * Example:
- *     $text = new Trimmed(TextOf::str(' hello '));
+ *     $text = Trimmed::ofText(TextOf::str(' hello '));
+ *     echo $text->value(); // 'hello'
+ *
+ *     $text = Trimmed::ofString(' hello ');
  *     echo $text->value(); // 'hello'
  */
 final readonly class Trimmed extends TextEnvelope
@@ -30,5 +40,27 @@ final readonly class Trimmed extends TextEnvelope
                 new FuncOf(trim(...)),
             ),
         );
+    }
+
+    /**
+     * Trims leading and trailing whitespace from a {@see Text}.
+     *
+     * @param Text $source The text to trim.
+     * @psalm-api
+     */
+    public static function ofText(Text $source): self
+    {
+        return new self($source);
+    }
+
+    /**
+     * Trims leading and trailing whitespace from a native string.
+     *
+     * @param string $value The string to trim.
+     * @psalm-api
+     */
+    public static function ofString(string $value): self
+    {
+        return new self(TextOf::str($value));
     }
 }

--- a/src/Text/TrimmedLeft.php
+++ b/src/Text/TrimmedLeft.php
@@ -10,8 +10,15 @@ use Primus\Func\FuncOf;
 /**
  * Text with whitespace removed from the left side.
  *
+ * Construction forms:
+ *
+ * - `new TrimmedLeft(Text)` — wrap an existing {@see Text} value.
+ * - `TrimmedLeft::ofText(Text)` — named-constructor alias of the primary ctor.
+ * - `TrimmedLeft::ofString(string)` — shortcut that wraps a native string in
+ *   {@see TextOf::str()} before trimming.
+ *
  * Example:
- *     $text = new TrimmedLeft(TextOf::str(" hello "));
+ *     $text = TrimmedLeft::ofText(TextOf::str(" hello "));
  *     echo $text->value(); // 'hello '
  */
 final readonly class TrimmedLeft extends TextEnvelope
@@ -30,5 +37,27 @@ final readonly class TrimmedLeft extends TextEnvelope
                     ?? throw new InvalidArgumentException('Malformed UTF-8 input')),
             ),
         );
+    }
+
+    /**
+     * Removes leading whitespace from a {@see Text}.
+     *
+     * @param Text $source The text to trim on the left.
+     * @psalm-api
+     */
+    public static function ofText(Text $source): self
+    {
+        return new self($source);
+    }
+
+    /**
+     * Removes leading whitespace from a native string.
+     *
+     * @param string $value The string to trim on the left.
+     * @psalm-api
+     */
+    public static function ofString(string $value): self
+    {
+        return new self(TextOf::str($value));
     }
 }

--- a/src/Text/TrimmedRight.php
+++ b/src/Text/TrimmedRight.php
@@ -10,8 +10,15 @@ use Primus\Func\FuncOf;
 /**
  * Text with whitespace removed from the right side.
  *
+ * Construction forms:
+ *
+ * - `new TrimmedRight(Text)` — wrap an existing {@see Text} value.
+ * - `TrimmedRight::ofText(Text)` — named-constructor alias of the primary ctor.
+ * - `TrimmedRight::ofString(string)` — shortcut that wraps a native string in
+ *   {@see TextOf::str()} before trimming.
+ *
  * Example:
- *     $text = new TrimmedRight(TextOf::str(" hello "));
+ *     $text = TrimmedRight::ofText(TextOf::str(" hello "));
  *     echo $text->value(); // ' hello'
  */
 final readonly class TrimmedRight extends TextEnvelope
@@ -30,5 +37,27 @@ final readonly class TrimmedRight extends TextEnvelope
                     ?? throw new InvalidArgumentException('Malformed UTF-8 input')),
             ),
         );
+    }
+
+    /**
+     * Removes trailing whitespace from a {@see Text}.
+     *
+     * @param Text $source The text to trim on the right.
+     * @psalm-api
+     */
+    public static function ofText(Text $source): self
+    {
+        return new self($source);
+    }
+
+    /**
+     * Removes trailing whitespace from a native string.
+     *
+     * @param string $value The string to trim on the right.
+     * @psalm-api
+     */
+    public static function ofString(string $value): self
+    {
+        return new self(TextOf::str($value));
     }
 }

--- a/src/Text/WithoutTags.php
+++ b/src/Text/WithoutTags.php
@@ -11,8 +11,15 @@ use Primus\Func\FuncOf;
  *
  * Strips all HTML tags from the origin text using {@see strip_tags()}.
  *
+ * Construction forms:
+ *
+ * - `new WithoutTags(Text)` — wrap an existing {@see Text} value.
+ * - `WithoutTags::ofText(Text)` — named-constructor alias of the primary ctor.
+ * - `WithoutTags::ofString(string)` — shortcut that wraps a native string in
+ *   {@see TextOf::str()} before stripping tags.
+ *
  * Example:
- *     $text = new WithoutTags(TextOf::str('<b>John & "Jane"</b>'));
+ *     $text = WithoutTags::ofText(TextOf::str('<b>John & "Jane"</b>'));
  *     echo $text->value(); // 'John & "Jane"'
  */
 final readonly class WithoutTags extends TextEnvelope
@@ -30,5 +37,27 @@ final readonly class WithoutTags extends TextEnvelope
                 new FuncOf(strip_tags(...)),
             ),
         );
+    }
+
+    /**
+     * Strips HTML tags from a {@see Text}.
+     *
+     * @param Text $source The text to strip HTML tags from.
+     * @psalm-api
+     */
+    public static function ofText(Text $source): self
+    {
+        return new self($source);
+    }
+
+    /**
+     * Strips HTML tags from a native string.
+     *
+     * @param string $value The string to strip HTML tags from.
+     * @psalm-api
+     */
+    public static function ofString(string $value): self
+    {
+        return new self(TextOf::str($value));
     }
 }

--- a/tests/Text/AbbreviatedTest.php
+++ b/tests/Text/AbbreviatedTest.php
@@ -83,4 +83,35 @@ final class AbbreviatedTest extends TestCase
             'Abbreviated must return an empty string when the limit is zero'
         );
     }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str('Hello, world!');
+
+        self::assertSame(
+            (new Abbreviated($source, 8))->value(),
+            Abbreviated::ofText($source, 8)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofStringFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new Abbreviated(TextOf::str('Hello, world!'), 8))->value(),
+            Abbreviated::ofString('Hello, world!', 8)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructorForDefaultLimit(): void
+    {
+        $source = TextOf::str('short');
+
+        self::assertSame(
+            (new Abbreviated($source))->value(),
+            Abbreviated::ofText($source)->value(),
+        );
+    }
 }

--- a/tests/Text/HtmlEscapedTest.php
+++ b/tests/Text/HtmlEscapedTest.php
@@ -40,4 +40,24 @@ final class HtmlEscapedTest extends TestCase
             new HasTextValue('')
         );
     }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str('<b>A & B</b>');
+
+        self::assertSame(
+            (new HtmlEscaped($source))->value(),
+            HtmlEscaped::ofText($source)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofStringFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new HtmlEscaped(TextOf::str('<b>A & B</b>')))->value(),
+            HtmlEscaped::ofString('<b>A & B</b>')->value(),
+        );
+    }
 }

--- a/tests/Text/LeftPaddedTest.php
+++ b/tests/Text/LeftPaddedTest.php
@@ -49,4 +49,24 @@ final class LeftPaddedTest extends TestCase
             new HasTextValue('......')
         );
     }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str('foo');
+
+        self::assertSame(
+            (new LeftPadded($source, 6, '.'))->value(),
+            LeftPadded::ofText($source, 6, '.')->value(),
+        );
+    }
+
+    #[Test]
+    public function ofStringFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new LeftPadded(TextOf::str('foo'), 6, '.'))->value(),
+            LeftPadded::ofString('foo', 6, '.')->value(),
+        );
+    }
 }

--- a/tests/Text/NormalizedTest.php
+++ b/tests/Text/NormalizedTest.php
@@ -75,4 +75,24 @@ final class NormalizedTest extends TestCase
             'Normalized must throw an exception on malformed UTF-8 input'
         );
     }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str(" Hello \n\t world ");
+
+        self::assertSame(
+            (new Normalized($source))->value(),
+            Normalized::ofText($source)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofStringFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new Normalized(TextOf::str(" Hello \n\t world ")))->value(),
+            Normalized::ofString(" Hello \n\t world ")->value(),
+        );
+    }
 }

--- a/tests/Text/ReversedTest.php
+++ b/tests/Text/ReversedTest.php
@@ -56,4 +56,24 @@ final class ReversedTest extends TestCase
             new HasTextValue("\u{0301}efac")
         );
     }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str('café');
+
+        self::assertSame(
+            (new Reversed($source))->value(),
+            Reversed::ofText($source)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofStringFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new Reversed(TextOf::str('café')))->value(),
+            Reversed::ofString('café')->value(),
+        );
+    }
 }

--- a/tests/Text/RightPaddedTest.php
+++ b/tests/Text/RightPaddedTest.php
@@ -49,4 +49,24 @@ final class RightPaddedTest extends TestCase
             new HasTextValue('...')
         );
     }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str('foo');
+
+        self::assertSame(
+            (new RightPadded($source, 6, '.'))->value(),
+            RightPadded::ofText($source, 6, '.')->value(),
+        );
+    }
+
+    #[Test]
+    public function ofStringFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new RightPadded(TextOf::str('foo'), 6, '.'))->value(),
+            RightPadded::ofString('foo', 6, '.')->value(),
+        );
+    }
 }

--- a/tests/Text/TrimmedLeftTest.php
+++ b/tests/Text/TrimmedLeftTest.php
@@ -63,4 +63,24 @@ final class TrimmedLeftTest extends TestCase
             'TrimmedLeft must keep trailing spaces intact'
         );
     }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str(' hello ');
+
+        self::assertSame(
+            (new TrimmedLeft($source))->value(),
+            TrimmedLeft::ofText($source)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofStringFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new TrimmedLeft(TextOf::str(' hello ')))->value(),
+            TrimmedLeft::ofString(' hello ')->value(),
+        );
+    }
 }

--- a/tests/Text/TrimmedRightTest.php
+++ b/tests/Text/TrimmedRightTest.php
@@ -75,4 +75,24 @@ final class TrimmedRightTest extends TestCase
             'TrimmedRight must throw an exception on malformed UTF-8 input'
         );
     }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str(' hello ');
+
+        self::assertSame(
+            (new TrimmedRight($source))->value(),
+            TrimmedRight::ofText($source)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofStringFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new TrimmedRight(TextOf::str(' hello ')))->value(),
+            TrimmedRight::ofString(' hello ')->value(),
+        );
+    }
 }

--- a/tests/Text/TrimmedTest.php
+++ b/tests/Text/TrimmedTest.php
@@ -31,4 +31,24 @@ final class TrimmedTest extends TestCase
             new HasTextValue('')
         );
     }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str(' hello ');
+
+        self::assertSame(
+            (new Trimmed($source))->value(),
+            Trimmed::ofText($source)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofStringFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new Trimmed(TextOf::str(' hello ')))->value(),
+            Trimmed::ofString(' hello ')->value(),
+        );
+    }
 }

--- a/tests/Text/WithoutTagsTest.php
+++ b/tests/Text/WithoutTagsTest.php
@@ -31,4 +31,24 @@ final class WithoutTagsTest extends TestCase
             new HasTextValue('safe text 123')
         );
     }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str('<b>A & B</b>');
+
+        self::assertSame(
+            (new WithoutTags($source))->value(),
+            WithoutTags::ofText($source)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofStringFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new WithoutTags(TextOf::str('<b>A & B</b>')))->value(),
+            WithoutTags::ofString('<b>A & B</b>')->value(),
+        );
+    }
 }


### PR DESCRIPTION
- Added named factory mirrors to ten Text decorators (Trimmed, TrimmedLeft, TrimmedRight, LeftPadded, RightPadded, Normalized, HtmlEscaped, WithoutTags, Abbreviated, Reversed)
- Each decorator exposes both Text and native string factory variants
- Added equivalence tests covering primary, ofText and ofString forms

Part of #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added named factory methods to text processing classes, providing convenient alternatives to direct constructor calls. Users can now use `ofText()` and `ofString()` methods for more intuitive text object creation across abbreviation, HTML escaping, padding, normalization, reversal, trimming, and tag removal utilities.

* **Tests**
  * Added comprehensive test coverage verifying that new factory methods produce consistent results with primary constructors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->