### PR TITLE
Named Constructor Mirrors For Text Queries And Extracts

### DIFF
--- a/src/Text/Contains.php
+++ b/src/Text/Contains.php
@@ -14,8 +14,15 @@ use Primus\Scalar\ScalarOf;
  * UTF-8 because UTF-8 sequences cannot overlap byte boundaries of
  * other sequences.
  *
+ * Construction forms:
+ *
+ * - `new Contains(Text, Text)` — wrap haystack and needle as {@see Text}.
+ * - `Contains::ofTexts(Text, Text)` — named-constructor alias of the primary ctor.
+ * - `Contains::ofStrings(string, string)` — shortcut that wraps native strings
+ *   in {@see TextOf::str()} before searching.
+ *
  * Example:
- *     $has = new Contains(TextOf::str('hello world'), TextOf::str('lo wo'));
+ *     $has = Contains::ofStrings('hello world', 'lo wo');
  *     echo $has->value(); // true
  *
  * @extends ScalarEnvelope<bool>
@@ -35,5 +42,29 @@ final readonly class Contains extends ScalarEnvelope
                 static fn(): bool => str_contains($haystack->value(), $needle->value()),
             ),
         );
+    }
+
+    /**
+     * Tells whether the first {@see Text} contains the second.
+     *
+     * @param Text $haystack The text to search within.
+     * @param Text $needle The substring to look for.
+     * @psalm-api
+     */
+    public static function ofTexts(Text $haystack, Text $needle): self
+    {
+        return new self($haystack, $needle);
+    }
+
+    /**
+     * Tells whether the first native string contains the second.
+     *
+     * @param string $haystack The string to search within.
+     * @param string $needle The substring to look for.
+     * @psalm-api
+     */
+    public static function ofStrings(string $haystack, string $needle): self
+    {
+        return new self(TextOf::str($haystack), TextOf::str($needle));
     }
 }

--- a/src/Text/EndsWith.php
+++ b/src/Text/EndsWith.php
@@ -14,8 +14,15 @@ use Primus\Scalar\ScalarOf;
  * for UTF-8 because UTF-8 sequences cannot overlap byte boundaries of
  * other sequences.
  *
+ * Construction forms:
+ *
+ * - `new EndsWith(Text, Text)` — wrap haystack and suffix as {@see Text}.
+ * - `EndsWith::ofTexts(Text, Text)` — named-constructor alias of the primary ctor.
+ * - `EndsWith::ofStrings(string, string)` — shortcut that wraps native strings
+ *   in {@see TextOf::str()} before checking.
+ *
  * Example:
- *     $ends = new EndsWith(TextOf::str('hello world'), TextOf::str('world'));
+ *     $ends = EndsWith::ofStrings('hello world', 'world');
  *     echo $ends->value(); // true
  *
  * @extends ScalarEnvelope<bool>
@@ -35,5 +42,29 @@ final readonly class EndsWith extends ScalarEnvelope
                 static fn(): bool => str_ends_with($haystack->value(), $needle->value()),
             ),
         );
+    }
+
+    /**
+     * Tells whether a {@see Text} ends with a suffix.
+     *
+     * @param Text $haystack The text to inspect.
+     * @param Text $needle The suffix to look for.
+     * @psalm-api
+     */
+    public static function ofTexts(Text $haystack, Text $needle): self
+    {
+        return new self($haystack, $needle);
+    }
+
+    /**
+     * Tells whether a native string ends with a suffix.
+     *
+     * @param string $haystack The string to inspect.
+     * @param string $needle The suffix to look for.
+     * @psalm-api
+     */
+    public static function ofStrings(string $haystack, string $needle): self
+    {
+        return new self(TextOf::str($haystack), TextOf::str($needle));
     }
 }

--- a/src/Text/IsBlank.php
+++ b/src/Text/IsBlank.php
@@ -13,8 +13,15 @@ use Primus\Scalar\ScalarOf;
  * Treats both ASCII whitespace and Unicode whitespace (including
  * non-breaking spaces, line/paragraph separators, etc.) as blank.
  *
+ * Construction forms:
+ *
+ * - `new IsBlank(Text)` — wrap a {@see Text} to check.
+ * - `IsBlank::ofText(Text)` — named-constructor alias of the primary ctor.
+ * - `IsBlank::ofString(string)` — shortcut that wraps a native string in
+ *   {@see TextOf::str()} before checking.
+ *
  * Example:
- *     $blank = new IsBlank(TextOf::str(" \t\n"));
+ *     $blank = IsBlank::ofString(" \t\n");
  *     echo $blank->value(); // true
  *
  * @extends ScalarEnvelope<bool>
@@ -35,5 +42,27 @@ final readonly class IsBlank extends ScalarEnvelope
                 static fn(): bool => preg_match(self::BLANK_PATTERN, $text->value()) === 1,
             ),
         );
+    }
+
+    /**
+     * Tells whether a {@see Text} is empty or only whitespace.
+     *
+     * @param Text $source The text to check.
+     * @psalm-api
+     */
+    public static function ofText(Text $source): self
+    {
+        return new self($source);
+    }
+
+    /**
+     * Tells whether a native string is empty or only whitespace.
+     *
+     * @param string $value The string to check.
+     * @psalm-api
+     */
+    public static function ofString(string $value): self
+    {
+        return new self(TextOf::str($value));
     }
 }

--- a/src/Text/IsEmpty.php
+++ b/src/Text/IsEmpty.php
@@ -13,8 +13,15 @@ use Primus\Scalar\ScalarOf;
  * Returns true for the strings PHP treats as false in `if ($str)`,
  * namely '' and '0'. Any other string yields false.
  *
+ * Construction forms:
+ *
+ * - `new IsEmpty(Text)` — wrap a {@see Text} to check.
+ * - `IsEmpty::ofText(Text)` — named-constructor alias of the primary ctor.
+ * - `IsEmpty::ofString(string)` — shortcut that wraps a native string in
+ *   {@see TextOf::str()} before checking.
+ *
  * Example:
- *     $empty = new IsEmpty(TextOf::str('0'));
+ *     $empty = IsEmpty::ofString('0');
  *     echo $empty->value(); // true
  *
  * @extends ScalarEnvelope<bool>
@@ -33,5 +40,27 @@ final readonly class IsEmpty extends ScalarEnvelope
                 static fn(): bool => in_array($text->value(), ['', '0'], true),
             ),
         );
+    }
+
+    /**
+     * Tells whether a {@see Text} is falsy.
+     *
+     * @param Text $source The text to check.
+     * @psalm-api
+     */
+    public static function ofText(Text $source): self
+    {
+        return new self($source);
+    }
+
+    /**
+     * Tells whether a native string is falsy.
+     *
+     * @param string $value The string to check.
+     * @psalm-api
+     */
+    public static function ofString(string $value): self
+    {
+        return new self(TextOf::str($value));
     }
 }

--- a/src/Text/Mapped.php
+++ b/src/Text/Mapped.php
@@ -13,8 +13,13 @@ use Primus\Scalar\ScalarOf;
  * Stores no extra fields — the function is captured inside a lazy scalar
  * and the envelope delegates every projection to it.
  *
+ * Construction forms:
+ *
+ * - `new Mapped(Text, Func)` — wrap an existing {@see Text} value and mapper.
+ * - `Mapped::ofText(Text, Func)` — named-constructor alias of the primary ctor.
+ *
  * Example:
- *     $text = new Mapped(
+ *     $text = Mapped::ofText(
  *         TextOf::str('hello'),
  *         new FuncOf(strtoupper(...)),
  *     );
@@ -35,5 +40,17 @@ final readonly class Mapped extends TextEnvelope
                 new ScalarOf(static fn(): string => $func->apply($origin->value())),
             ),
         );
+    }
+
+    /**
+     * Transforms the value of a {@see Text} through a {@see Func}.
+     *
+     * @param Text $source The text whose value is transformed.
+     * @param Func<string, string> $mapper The transformation function.
+     * @psalm-api
+     */
+    public static function ofText(Text $source, Func $mapper): self
+    {
+        return new self($source, $mapper);
     }
 }

--- a/src/Text/PrefixOf.php
+++ b/src/Text/PrefixOf.php
@@ -14,11 +14,15 @@ use Primus\Func\FuncOf;
  * Position lookup and slicing use {@see mb_strpos()} and {@see mb_substr()},
  * so multibyte characters are preserved as whole units.
  *
+ * Construction forms:
+ *
+ * - `new PrefixOf(Text, Text)` — wrap origin and boundary as {@see Text}.
+ * - `PrefixOf::texts(Text, Text)` — named-constructor alias of the primary ctor.
+ * - `PrefixOf::strings(string, string)` — shortcut that wraps native strings
+ *   in {@see TextOf::str()} before slicing.
+ *
  * Example:
- *     $login = new PrefixOf(
- *         TextOf::str('user@example.com'),
- *         TextOf::str('@'),
- *     );
+ *     $login = PrefixOf::strings('user@example.com', '@');
  *     echo $login->value(); // 'user'
  */
 final readonly class PrefixOf extends TextEnvelope
@@ -47,5 +51,29 @@ final readonly class PrefixOf extends TextEnvelope
                 ),
             ),
         );
+    }
+
+    /**
+     * Extracts the prefix before a boundary in a {@see Text}.
+     *
+     * @param Text $source The text to split.
+     * @param Text $boundary The text that marks the split point.
+     * @psalm-api
+     */
+    public static function texts(Text $source, Text $boundary): self
+    {
+        return new self($source, $boundary);
+    }
+
+    /**
+     * Extracts the prefix before a boundary in a native string.
+     *
+     * @param string $value The string to split.
+     * @param string $boundary The string that marks the split point.
+     * @psalm-api
+     */
+    public static function strings(string $value, string $boundary): self
+    {
+        return new self(TextOf::str($value), TextOf::str($boundary));
     }
 }

--- a/src/Text/Replaced.php
+++ b/src/Text/Replaced.php
@@ -11,12 +11,18 @@ use Primus\Func\FuncOf;
  *
  * Replaces one or multiple search strings with replacements.
  *
+ * Construction forms:
+ *
+ * - `new Replaced(Text, string|list<string>, string|list<string>)` — wrap an
+ *   existing {@see Text} value.
+ * - `Replaced::ofText(Text, string|list<string>, string|list<string>)` —
+ *   named-constructor alias of the primary ctor.
+ * - `Replaced::ofString(string, string|list<string>, string|list<string>)` —
+ *   shortcut that wraps a native string in {@see TextOf::str()} before
+ *   replacing.
+ *
  * Example:
- *     $text = new Replaced(
- *         TextOf::str('<b>Hello & bye</b>'),
- *         ['<b>', '</b>', '&'],
- *         ['', '', 'and']
- *     );
+ *     $text = Replaced::ofString('<b>Hello & bye</b>', ['<b>', '</b>', '&'], ['', '', 'and']);
  *     echo $text->value(); // 'Hello and bye'
  */
 final readonly class Replaced extends TextEnvelope
@@ -36,5 +42,37 @@ final readonly class Replaced extends TextEnvelope
                 new FuncOf(static fn(string $s): string => str_replace($search, $replacement, $s)),
             ),
         );
+    }
+
+    /**
+     * Replaces substrings in a {@see Text}.
+     *
+     * @param Text $source The origin text.
+     * @param string|list<string> $search The substrings to search for.
+     * @param string|list<string> $replacement The replacements.
+     * @psalm-api
+     */
+    public static function ofText(
+        Text $source,
+        string|array $search,
+        string|array $replacement,
+    ): self {
+        return new self($source, $search, $replacement);
+    }
+
+    /**
+     * Replaces substrings in a native string.
+     *
+     * @param string $value The string to operate on.
+     * @param string|list<string> $search The substrings to search for.
+     * @param string|list<string> $replacement The replacements.
+     * @psalm-api
+     */
+    public static function ofString(
+        string $value,
+        string|array $search,
+        string|array $replacement,
+    ): self {
+        return new self(TextOf::str($value), $search, $replacement);
     }
 }

--- a/src/Text/Split.php
+++ b/src/Text/Split.php
@@ -12,8 +12,15 @@ use Primus\Scalar\Scalar;
  *
  * Produces an iterable of {@see Text} segments separated by the given delimiter.
  *
+ * Construction forms:
+ *
+ * - `new Split(string, Text)` — wrap a delimiter and a {@see Text} to split.
+ * - `Split::ofText(string, Text)` — named-constructor alias of the primary ctor.
+ * - `Split::ofString(string, string)` — shortcut that wraps a native string in
+ *   {@see TextOf::str()} before splitting.
+ *
  * Example:
- *     $parts = new Split(',', TextOf::str('a,b,c'));
+ *     $parts = Split::ofString(',', 'a,b,c');
  *     foreach ($parts->value() as $text) {
  *         echo $text->value(); // a, b, c
  *     }
@@ -29,6 +36,30 @@ final readonly class Split implements Scalar
      * @param Text $origin The text to split.
      */
     public function __construct(private string $delimiter, private Text $origin) {}
+
+    /**
+     * Splits a {@see Text} by a delimiter into parts.
+     *
+     * @param non-empty-string $glue The delimiter used to split the text.
+     * @param Text $source The text to split.
+     * @psalm-api
+     */
+    public static function ofText(string $glue, Text $source): self
+    {
+        return new self($glue, $source);
+    }
+
+    /**
+     * Splits a native string by a delimiter into parts.
+     *
+     * @param non-empty-string $glue The delimiter used to split the string.
+     * @param string $value The string to split.
+     * @psalm-api
+     */
+    public static function ofString(string $glue, string $value): self
+    {
+        return new self($glue, TextOf::str($value));
+    }
 
     #[Override]
     public function value(): iterable

--- a/src/Text/StartsWith.php
+++ b/src/Text/StartsWith.php
@@ -14,8 +14,15 @@ use Primus\Scalar\ScalarOf;
  * for UTF-8 because UTF-8 sequences cannot overlap byte boundaries of
  * other sequences.
  *
+ * Construction forms:
+ *
+ * - `new StartsWith(Text, Text)` — wrap haystack and prefix as {@see Text}.
+ * - `StartsWith::ofTexts(Text, Text)` — named-constructor alias of the primary ctor.
+ * - `StartsWith::ofStrings(string, string)` — shortcut that wraps native strings
+ *   in {@see TextOf::str()} before checking.
+ *
  * Example:
- *     $starts = new StartsWith(TextOf::str('hello world'), TextOf::str('hello'));
+ *     $starts = StartsWith::ofStrings('hello world', 'hello');
  *     echo $starts->value(); // true
  *
  * @extends ScalarEnvelope<bool>
@@ -35,5 +42,29 @@ final readonly class StartsWith extends ScalarEnvelope
                 static fn(): bool => str_starts_with($haystack->value(), $needle->value()),
             ),
         );
+    }
+
+    /**
+     * Tells whether a {@see Text} starts with a prefix.
+     *
+     * @param Text $haystack The text to inspect.
+     * @param Text $needle The prefix to look for.
+     * @psalm-api
+     */
+    public static function ofTexts(Text $haystack, Text $needle): self
+    {
+        return new self($haystack, $needle);
+    }
+
+    /**
+     * Tells whether a native string starts with a prefix.
+     *
+     * @param string $haystack The string to inspect.
+     * @param string $needle The prefix to look for.
+     * @psalm-api
+     */
+    public static function ofStrings(string $haystack, string $needle): self
+    {
+        return new self(TextOf::str($haystack), TextOf::str($needle));
     }
 }

--- a/src/Text/Sub.php
+++ b/src/Text/Sub.php
@@ -12,8 +12,15 @@ use Primus\Func\FuncOf;
  * Uses {@see mb_substr()} to return a portion of the text.
  * Equivalent to {@see mb_substr($text, $start, PHP_INT_MAX, 'UTF-8')}.
  *
+ * Construction forms:
+ *
+ * - `new Sub(Text, int, int = PHP_INT_MAX)` — wrap a {@see Text} with offsets.
+ * - `Sub::ofText(Text, int, int = PHP_INT_MAX)` — named-constructor alias of the primary ctor.
+ * - `Sub::ofString(string, int, int = PHP_INT_MAX)` — shortcut that wraps a
+ *   native string in {@see TextOf::str()} before slicing.
+ *
  * Example:
- *     $text = new Sub(TextOf::str('hello world'), 0, 5);
+ *     $text = Sub::ofString('hello world', 0, 5);
  *     echo $text->value(); // 'hello'
  */
 final readonly class Sub extends TextEnvelope
@@ -33,5 +40,31 @@ final readonly class Sub extends TextEnvelope
                 new FuncOf(static fn(string $s): string => mb_substr($s, $start, $length, 'UTF-8')),
             ),
         );
+    }
+
+    /**
+     * Extracts a substring from a {@see Text}.
+     *
+     * @param Text $source The text to extract from.
+     * @param int $start The start position in characters.
+     * @param int $length The maximum number of characters to extract.
+     * @psalm-api
+     */
+    public static function ofText(Text $source, int $start, int $length = PHP_INT_MAX): self
+    {
+        return new self($source, $start, $length);
+    }
+
+    /**
+     * Extracts a substring from a native string.
+     *
+     * @param string $value The string to extract from.
+     * @param int $start The start position in characters.
+     * @param int $length The maximum number of characters to extract.
+     * @psalm-api
+     */
+    public static function ofString(string $value, int $start, int $length = PHP_INT_MAX): self
+    {
+        return new self(TextOf::str($value), $start, $length);
     }
 }

--- a/src/Text/SuffixOf.php
+++ b/src/Text/SuffixOf.php
@@ -14,11 +14,15 @@ use Primus\Func\FuncOf;
  * use {@see mb_strpos()} and {@see mb_substr()}, so multibyte characters are
  * preserved as whole units.
  *
+ * Construction forms:
+ *
+ * - `new SuffixOf(Text, Text)` — wrap origin and boundary as {@see Text}.
+ * - `SuffixOf::texts(Text, Text)` — named-constructor alias of the primary ctor.
+ * - `SuffixOf::strings(string, string)` — shortcut that wraps native strings
+ *   in {@see TextOf::str()} before slicing.
+ *
  * Example:
- *     $domain = new SuffixOf(
- *         TextOf::str('user@example.com'),
- *         TextOf::str('@'),
- *     );
+ *     $domain = SuffixOf::strings('user@example.com', '@');
  *     echo $domain->value(); // 'example.com'
  */
 final readonly class SuffixOf extends TextEnvelope
@@ -56,5 +60,29 @@ final readonly class SuffixOf extends TextEnvelope
                 ),
             ),
         );
+    }
+
+    /**
+     * Extracts the suffix after a boundary in a {@see Text}.
+     *
+     * @param Text $source The text to split.
+     * @param Text $boundary The text that marks the split point.
+     * @psalm-api
+     */
+    public static function texts(Text $source, Text $boundary): self
+    {
+        return new self($source, $boundary);
+    }
+
+    /**
+     * Extracts the suffix after a boundary in a native string.
+     *
+     * @param string $value The string to split.
+     * @param string $boundary The string that marks the split point.
+     * @psalm-api
+     */
+    public static function strings(string $value, string $boundary): self
+    {
+        return new self(TextOf::str($value), TextOf::str($boundary));
     }
 }

--- a/tests/Text/ContainsTest.php
+++ b/tests/Text/ContainsTest.php
@@ -58,4 +58,25 @@ final class ContainsTest extends TestCase
             (new Contains(TextOf::str('привет мир'), TextOf::str('ет ми')))->value(),
         );
     }
+
+    #[Test]
+    public function ofTextsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $haystack = TextOf::str('hello world');
+        $needle = TextOf::str('lo wo');
+
+        self::assertSame(
+            (new Contains($haystack, $needle))->value(),
+            Contains::ofTexts($haystack, $needle)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofStringsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new Contains(TextOf::str('hello world'), TextOf::str('lo wo')))->value(),
+            Contains::ofStrings('hello world', 'lo wo')->value(),
+        );
+    }
 }

--- a/tests/Text/EndsWithTest.php
+++ b/tests/Text/EndsWithTest.php
@@ -58,4 +58,25 @@ final class EndsWithTest extends TestCase
             (new EndsWith(TextOf::str('привет мир'), TextOf::str('мир')))->value(),
         );
     }
+
+    #[Test]
+    public function ofTextsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $haystack = TextOf::str('hello world');
+        $needle = TextOf::str('world');
+
+        self::assertSame(
+            (new EndsWith($haystack, $needle))->value(),
+            EndsWith::ofTexts($haystack, $needle)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofStringsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new EndsWith(TextOf::str('hello world'), TextOf::str('world')))->value(),
+            EndsWith::ofStrings('hello world', 'world')->value(),
+        );
+    }
 }

--- a/tests/Text/IsBlankTest.php
+++ b/tests/Text/IsBlankTest.php
@@ -58,4 +58,24 @@ final class IsBlankTest extends TestCase
     {
         self::assertFalse((new IsBlank(TextOf::str('привет')))->value());
     }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str(" \t\n");
+
+        self::assertSame(
+            (new IsBlank($source))->value(),
+            IsBlank::ofText($source)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofStringFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new IsBlank(TextOf::str(" \t\n")))->value(),
+            IsBlank::ofString(" \t\n")->value(),
+        );
+    }
 }

--- a/tests/Text/IsEmptyTest.php
+++ b/tests/Text/IsEmptyTest.php
@@ -52,4 +52,24 @@ final class IsEmptyTest extends TestCase
             'double zero' => ['00'],
         ];
     }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str('');
+
+        self::assertSame(
+            (new IsEmpty($source))->value(),
+            IsEmpty::ofText($source)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofStringFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new IsEmpty(TextOf::str('0')))->value(),
+            IsEmpty::ofString('0')->value(),
+        );
+    }
 }

--- a/tests/Text/MappedTest.php
+++ b/tests/Text/MappedTest.php
@@ -56,4 +56,16 @@ final class MappedTest extends TestCase
 
         self::assertSame(1, $calls);
     }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str('hello');
+        $mapper = new FuncOf(strtoupper(...));
+
+        self::assertSame(
+            (new Mapped($source, $mapper))->value(),
+            Mapped::ofText($source, $mapper)->value(),
+        );
+    }
 }

--- a/tests/Text/PrefixOfTest.php
+++ b/tests/Text/PrefixOfTest.php
@@ -95,4 +95,25 @@ final class PrefixOfTest extends TestCase
             new HasTextValue('')
         );
     }
+
+    #[Test]
+    public function textsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str('user@example.com');
+        $boundary = TextOf::str('@');
+
+        self::assertSame(
+            (new PrefixOf($source, $boundary))->value(),
+            PrefixOf::texts($source, $boundary)->value(),
+        );
+    }
+
+    #[Test]
+    public function stringsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new PrefixOf(TextOf::str('user@example.com'), TextOf::str('@')))->value(),
+            PrefixOf::strings('user@example.com', '@')->value(),
+        );
+    }
 }

--- a/tests/Text/ReplacedTest.php
+++ b/tests/Text/ReplacedTest.php
@@ -53,4 +53,24 @@ final class ReplacedTest extends TestCase
             new HasTextValue('')
         );
     }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str('hello world');
+
+        self::assertSame(
+            (new Replaced($source, 'world', 'PHP'))->value(),
+            Replaced::ofText($source, 'world', 'PHP')->value(),
+        );
+    }
+
+    #[Test]
+    public function ofStringFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new Replaced(TextOf::str('hello world'), 'world', 'PHP'))->value(),
+            Replaced::ofString('hello world', 'world', 'PHP')->value(),
+        );
+    }
 }

--- a/tests/Text/SplitTest.php
+++ b/tests/Text/SplitTest.php
@@ -58,4 +58,39 @@ final class SplitTest extends TestCase
             new HasTextValues(['a', '', 'b', ''])
         );
     }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str('a,b,c');
+
+        self::assertSame(
+            self::collect((new Split(',', $source))->value()),
+            self::collect(Split::ofText(',', $source)->value()),
+        );
+    }
+
+    #[Test]
+    public function ofStringFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            self::collect((new Split(',', TextOf::str('a,b,c')))->value()),
+            self::collect(Split::ofString(',', 'a,b,c')->value()),
+        );
+    }
+
+    /**
+     * @param iterable<\Primus\Text\Text> $parts
+     * @return list<string>
+     */
+    private static function collect(iterable $parts): array
+    {
+        $result = [];
+
+        foreach ($parts as $part) {
+            $result[] = $part->value();
+        }
+
+        return $result;
+    }
 }

--- a/tests/Text/SplitTest.php
+++ b/tests/Text/SplitTest.php
@@ -63,34 +63,36 @@ final class SplitTest extends TestCase
     public function ofTextFactoryAgreesWithPrimaryConstructor(): void
     {
         $source = TextOf::str('a,b,c');
+        $primary = [];
 
-        self::assertSame(
-            self::collect((new Split(',', $source))->value()),
-            self::collect(Split::ofText(',', $source)->value()),
-        );
+        foreach ((new Split(',', $source))->value() as $part) {
+            $primary[] = $part->value();
+        }
+
+        $factory = [];
+
+        foreach (Split::ofText(',', $source)->value() as $part) {
+            $factory[] = $part->value();
+        }
+
+        self::assertSame($primary, $factory);
     }
 
     #[Test]
     public function ofStringFactoryAgreesWithPrimaryConstructor(): void
     {
-        self::assertSame(
-            self::collect((new Split(',', TextOf::str('a,b,c')))->value()),
-            self::collect(Split::ofString(',', 'a,b,c')->value()),
-        );
-    }
+        $primary = [];
 
-    /**
-     * @param iterable<\Primus\Text\Text> $parts
-     * @return list<string>
-     */
-    private static function collect(iterable $parts): array
-    {
-        $result = [];
-
-        foreach ($parts as $part) {
-            $result[] = $part->value();
+        foreach ((new Split(',', TextOf::str('a,b,c')))->value() as $part) {
+            $primary[] = $part->value();
         }
 
-        return $result;
+        $factory = [];
+
+        foreach (Split::ofString(',', 'a,b,c')->value() as $part) {
+            $factory[] = $part->value();
+        }
+
+        self::assertSame($primary, $factory);
     }
 }

--- a/tests/Text/StartsWithTest.php
+++ b/tests/Text/StartsWithTest.php
@@ -58,4 +58,25 @@ final class StartsWithTest extends TestCase
             (new StartsWith(TextOf::str('привет мир'), TextOf::str('привет')))->value(),
         );
     }
+
+    #[Test]
+    public function ofTextsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $haystack = TextOf::str('hello world');
+        $needle = TextOf::str('hello');
+
+        self::assertSame(
+            (new StartsWith($haystack, $needle))->value(),
+            StartsWith::ofTexts($haystack, $needle)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofStringsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new StartsWith(TextOf::str('hello world'), TextOf::str('hello')))->value(),
+            StartsWith::ofStrings('hello world', 'hello')->value(),
+        );
+    }
 }

--- a/tests/Text/SubTest.php
+++ b/tests/Text/SubTest.php
@@ -40,4 +40,24 @@ final class SubTest extends TestCase
             new HasTextValue('😀b')
         );
     }
+
+    #[Test]
+    public function ofTextFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str('hello world');
+
+        self::assertSame(
+            (new Sub($source, 0, 5))->value(),
+            Sub::ofText($source, 0, 5)->value(),
+        );
+    }
+
+    #[Test]
+    public function ofStringFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new Sub(TextOf::str('hello world'), 0, 5))->value(),
+            Sub::ofString('hello world', 0, 5)->value(),
+        );
+    }
 }

--- a/tests/Text/SuffixOfTest.php
+++ b/tests/Text/SuffixOfTest.php
@@ -95,4 +95,25 @@ final class SuffixOfTest extends TestCase
             new HasTextValue('')
         );
     }
+
+    #[Test]
+    public function textsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        $source = TextOf::str('user@example.com');
+        $boundary = TextOf::str('@');
+
+        self::assertSame(
+            (new SuffixOf($source, $boundary))->value(),
+            SuffixOf::texts($source, $boundary)->value(),
+        );
+    }
+
+    #[Test]
+    public function stringsFactoryAgreesWithPrimaryConstructor(): void
+    {
+        self::assertSame(
+            (new SuffixOf(TextOf::str('user@example.com'), TextOf::str('@')))->value(),
+            SuffixOf::strings('user@example.com', '@')->value(),
+        );
+    }
 }


### PR DESCRIPTION
- Added named factory mirrors to eleven Text classes (Contains, EndsWith, StartsWith, IsBlank, IsEmpty, PrefixOf, SuffixOf, Sub, Split, Replaced, Mapped)
- Used texts/strings naming for Of-suffix classes (PrefixOf, SuffixOf) and ofText/ofString for the rest
- Added equivalence tests verifying each factory produces the same result as the primary constructor

Closes #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added named-constructor factory methods across text utilities to construct from either Text objects or native strings (e.g., Class::ofText(...) and Class::ofString(...)), and updated examples to use these factories.

* **Tests**
  * Added tests ensuring each new factory method yields the same results as the original constructors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->